### PR TITLE
Remove Nuget project from VS extension solution

### DIFF
--- a/source/VisualStudio.Extension/VisualStudio.Extension.csproj
+++ b/source/VisualStudio.Extension/VisualStudio.Extension.csproj
@@ -52,12 +52,14 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
+    <None Include="BuildSystem\DeployedBuildSystem\nanoFramework.Tools.MSBuildTargets.props">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="BuildSystem\DeployedBuildSystem\nanoFramework.Tools.MSBuildTargets.targets" />
-    <None Include="BuildSystem\DeployedBuildSystem\nanoFramework.Tools.MSBuildTargets.props" />
     <None Include="packages.config" />
     <Content Include="Packages\nanoFramework.Tools.MSBuildTargets.1.0.0-preview0012.nupkg">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>

--- a/source/VisualStudio.MSBuildTargets/Readme.txt
+++ b/source/VisualStudio.MSBuildTargets/Readme.txt
@@ -1,3 +1,0 @@
-﻿# VisualStudio.MSBuildTargets Readme
-
-Nothing of interest here...

--- a/source/VisualStudio.MSBuildTargets/VisualStudio.MSBuildTargets.nuproj
+++ b/source/VisualStudio.MSBuildTargets/VisualStudio.MSBuildTargets.nuproj
@@ -1,7 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <Import Project="$(NuGetAuthoringPath)\NuGet.Packaging.Authoring.props" Condition="Exists('$(NuGetAuthoringPath)\NuGet.Packaging.Authoring.props')" />
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|AnyCPU">
       <Configuration>Debug</Configuration>
@@ -12,45 +10,47 @@
       <Platform>AnyCPU</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="build\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\Debug\nF.Tools.MetaDataProcessor.exe">
+      <Link>build\nF.Tools.MetaDataProcessor.exe</Link>
+    </Content>
+    <Content Include="..\VisualStudio.BuildTask\bin\Release\nanoFramework.Tools.VisualStudio.BuildTask.dll">
+      <Link>build\nanoFramework.Tools.VisualStudio.BuildTask.dll</Link>
+    </Content>
+    <Content Include="..\VisualStudio.Extension\BuildSystem\DeployedBuildSystem\nanoFramework.Tools.MSBuildTargets.props">
+      <Link>build\nanoFramework.Tools.MSBuildTargets.props</Link>
+    </Content>
+    <Content Include="..\VisualStudio.Extension\BuildSystem\DeployedBuildSystem\nanoFramework.Tools.MSBuildTargets.targets">
+      <Link>build\nanoFramework.Tools.MSBuildTargets.targets</Link>
+    </Content>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>1d406978-d747-4ba7-a315-155c0ffdfdbe</ProjectGuid>
+  </PropertyGroup>
+  <PropertyGroup>
+    <NuProjPath Condition=" '$(NuProjPath)' == '' ">$(MSBuildExtensionsPath)\NuProj\</NuProjPath>
+  </PropertyGroup>
+  <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
-    <PackageId>nanoFramework.Tools.MSBuildTargets</PackageId>
-    <PackageVersion Condition="'$(PackageVersion)' == ''">1.0.0-preview0012</PackageVersion>
+    <Id>nanoFramework.Tools.MSBuildTargets</Id>
+    <Version>1.0.0-preview0012</Version>
     <Title>MSBuild targets for nanoFramework projects</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>
     <Summary>MSBuild targets and properties for nanoFramework project type.</Summary>
     <Description>This package installs the required MSBuild targets and properties to support nanoFramework project type building.</Description>
-    <PackageReleaseNotes>
-    </PackageReleaseNotes>
-    <PackageProjectUrl>https://github.com/nanoframework/nf-Visual-Studio-extension</PackageProjectUrl>
-    <PackageLicenseUrl>http://opensource.org/licenses/Apache-2.0</PackageLicenseUrl>
+    <ReleaseNotes>
+    </ReleaseNotes>
+    <ProjectUrl>https://github.com/nanoframework/nf-Visual-Studio-extension</ProjectUrl>
+    <LicenseUrl>
+    </LicenseUrl>
     <Copyright>Copyright (c) 2017 The nanoFramework project contributors</Copyright>
-    <PackageTags>VisualStudio.MSBuildTargets</PackageTags>
-    <PackageIconUrl>https://secure.gravatar.com/avatar/97d0e092247f0716db6d4b47b7d1d1ad</PackageIconUrl>
+    <Tags>VisualStudio.MSBuildTargets</Tags>
+    <IconUrl>https://secure.gravatar.com/avatar/97d0e092247f0716db6d4b47b7d1d1ad</IconUrl>
+    <OutputPath>..\VisualStudio.Extension\Packages</OutputPath>
   </PropertyGroup>
-  <PropertyGroup Label="Globals">
-    <OutputPath>bin\$(Configuration)\</OutputPath>
-    <ProjectGuid>6bfec204-f554-4b10-a22d-25c7b3f94e8f</ProjectGuid>
-  </PropertyGroup>
-  <ItemGroup>
-    <Content Include="..\VisualStudio.Extension\BuildSystem\DeployedBuildSystem\nanoFramework.Tools.MSBuildTargets.props">
-      <Link>build\nanoFramework.Tools.MSBuildTargets.props</Link>
-      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-    </Content>
-    <None Include="Readme.txt">
-      <IncludeInPackage>true</IncludeInPackage>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="NuGet.Build.Packaging">
-      <Version>0.1.248-pr110</Version>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="build\" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
-  <Import Project="$(NuGetAuthoringPath)\NuGet.Packaging.Authoring.targets" Condition="Exists('$(NuGetAuthoringPath)\NuGet.Packaging.Authoring.targets')" />
+  <Import Project="$(NuProjPath)\NuProj.targets" />
 </Project>

--- a/source/nanoFramework.Tools.VisualStudio.sln
+++ b/source/nanoFramework.Tools.VisualStudio.sln
@@ -13,8 +13,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSharp.ClassTemplate", "CSh
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSharp.AssemblyInfoTemplate", "CSharp.AssemblyInfoTemplate\CSharp.AssemblyInfoTemplate.csproj", "{EF2FEEDF-2D22-49F7-A51C-F6D4155A7932}"
 EndProject
-Project("{5DD5E4FA-CB73-4610-85AB-557B54E96AA9}") = "VisualStudio.MSBuildTargets", "VisualStudio.MSBuildTargets\VisualStudio.MSBuildTargets.nuproj", "{6BFEC204-F554-4B10-A22D-25C7B3F94E8F}"
-EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Core", "..\nf-interpreter\src\CLR\Core\Core.vcxproj", "{89CF8BDB-9C8A-4D18-BC3E-4312C5BD34B1}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CorLib", "..\nf-interpreter\src\CLR\CorLib\CorLib.vcxproj", "{58E950CC-2FF6-423C-B006-A70A19272F20}"
@@ -115,17 +113,6 @@ Global
 		{EF2FEEDF-2D22-49F7-A51C-F6D4155A7932}.Release|x64.Build.0 = Release|Any CPU
 		{EF2FEEDF-2D22-49F7-A51C-F6D4155A7932}.Release|x86.ActiveCfg = Release|Any CPU
 		{EF2FEEDF-2D22-49F7-A51C-F6D4155A7932}.Release|x86.Build.0 = Release|Any CPU
-		{6BFEC204-F554-4B10-A22D-25C7B3F94E8F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6BFEC204-F554-4B10-A22D-25C7B3F94E8F}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{6BFEC204-F554-4B10-A22D-25C7B3F94E8F}.Debug|x64.Build.0 = Debug|Any CPU
-		{6BFEC204-F554-4B10-A22D-25C7B3F94E8F}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{6BFEC204-F554-4B10-A22D-25C7B3F94E8F}.Debug|x86.Build.0 = Debug|Any CPU
-		{6BFEC204-F554-4B10-A22D-25C7B3F94E8F}.Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{6BFEC204-F554-4B10-A22D-25C7B3F94E8F}.Release|Any CPU.Build.0 = Debug|Any CPU
-		{6BFEC204-F554-4B10-A22D-25C7B3F94E8F}.Release|x64.ActiveCfg = Debug|Any CPU
-		{6BFEC204-F554-4B10-A22D-25C7B3F94E8F}.Release|x64.Build.0 = Debug|Any CPU
-		{6BFEC204-F554-4B10-A22D-25C7B3F94E8F}.Release|x86.ActiveCfg = Debug|Any CPU
-		{6BFEC204-F554-4B10-A22D-25C7B3F94E8F}.Release|x86.Build.0 = Debug|Any CPU
 		{89CF8BDB-9C8A-4D18-BC3E-4312C5BD34B1}.Debug|Any CPU.ActiveCfg = Debug|Win32
 		{89CF8BDB-9C8A-4D18-BC3E-4312C5BD34B1}.Debug|Any CPU.Build.0 = Debug|Win32
 		{89CF8BDB-9C8A-4D18-BC3E-4312C5BD34B1}.Debug|x64.ActiveCfg = Debug|x64


### PR DESCRIPTION
- the current version of Nugeter can't handle our requirements (distributing stuff in build directory)
- reverting to a VS2015 project with Nugeter

Signed-off-by: José Simões <jose.simoes@eclo.solutions>