### PR TITLE
Add VS2015 solution for MSBuild tasks

### DIFF
--- a/source/VisualStudio.BuildTask/Extensions/CommandLineBuilderExtensions.cs
+++ b/source/VisualStudio.BuildTask/Extensions/CommandLineBuilderExtensions.cs
@@ -1,0 +1,73 @@
+﻿//
+// Copyright (c) 2017 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace nanoFramework.Tools.VisualStudio
+{
+    public static class CommandLineBuilderExtensions
+    {
+        public static void AppendSwitchIfTrue(this CommandLineBuilder commandLinedBuilder, string switchValue, bool value)
+        {
+            if(value)
+            {
+                commandLinedBuilder.AppendSwitch("-minimize");
+            }
+        }
+
+        public static void AppendSwitchAndFiles(this CommandLineBuilder commandLinedBuilder, string switchName, ITaskItem[] fileList)
+        {
+            // paranoid check if property has any data 
+            if (fileList?.Length > 0)
+            {
+                commandLinedBuilder.AppendSwitch(switchName);
+
+                foreach(ITaskItem file in fileList)
+                {
+                    commandLinedBuilder.AppendFileNameIfNotNull(file);
+                };
+            }
+        }
+
+        public static void AppendSwitchForEachFile(this CommandLineBuilder commandLinedBuilder, string switchName, ITaskItem[] fileList)
+        {
+            if (fileList?.Length > 0)
+            {
+
+                foreach (ITaskItem file in fileList)
+                {
+                    commandLinedBuilder.AppendSwitch(switchName);
+                    commandLinedBuilder.AppendFileNameIfNotNull(file.ItemSpec);
+                };
+            }
+        }
+
+        public static void AppendSwitchForFile(this CommandLineBuilder commandLinedBuilder, string switchName, string fileName)
+        {
+            if (!string.IsNullOrEmpty(fileName))
+            {
+                commandLinedBuilder.AppendSwitch(switchName);
+                commandLinedBuilder.AppendFileNameIfNotNull(fileName);
+            }
+        }
+
+        //public static void AppendSwitchToFileAndExtraSwitches(this CommandLineBuilder commandLinedBuilder, string switchValue, string file, )
+        //{
+        //    // paranoid check if property has any data 
+        //    if (fileList?[0]?.MetadataCount > 0)
+        //    {
+        //        commandLinedBuilder.AppendSwitch(switchValue);
+
+        //        fileList.Select(stringFile => {
+
+        //            commandLinedBuilder.AppendFileNameIfNotNull(stringFile);
+
+        //            return new object();
+        //        }).ToList();
+        //    }
+        //}
+    }
+}

--- a/source/VisualStudio.BuildTask/MetaDataProcessorTask.cs
+++ b/source/VisualStudio.BuildTask/MetaDataProcessorTask.cs
@@ -1,0 +1,230 @@
+﻿//
+// Copyright (c) 2017 The nanoFramework project contributors
+// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
+// See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System.ComponentModel;
+using System;
+using System.Reflection;
+using System.IO;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace nanoFramework.Tools.VisualStudio
+{
+    [Description("MetaDataProcessorTaskEntry")]
+    public class MetaDataProcessorTask : ToolTask  // TODO this will be replace with a simple Task when we have MetaDataProcessor in C#
+    {
+        private string tempDataBaseFile = null;
+
+
+        #region public properties for the task
+
+        /// <summary>
+        /// Array of nanoFramework assemblies to be passed to MetaDataProcessor in -loadHints switch 
+        /// </summary>
+        public ITaskItem[] LoadHints { get; set; }
+
+        public ITaskItem[] Load { get; set; }
+
+        public ITaskItem[] LoadDatabase { get; set; }
+
+        public ITaskItem[] LoadStrings { get; set; }
+
+        public ITaskItem[] ExcludeClassByName { get; set; }
+
+        public ITaskItem[] Parse { get; set; }
+
+        public bool Minimize { get; set; }
+
+        public string Compile { get; set; }
+
+        public ITaskItem[] ImportResources { get; set; }
+
+        [Output]
+        public ITaskItem[] FilesWritten { get { return _FilesWritten.ToArray(); } private set { } }
+        private List<ITaskItem> _FilesWritten = new List<ITaskItem>();
+
+        #endregion
+
+
+        public override bool Execute()
+        {
+            // report to VS output window what step the build is 
+            Log.LogCommandLine(MessageImportance.Normal, "Starting nanoFramework MetaDataProcessor...");
+
+            try
+            {
+                // execute the ToolTask base method which is running the command line to call MetaDataProcessor will the appropriate parameters
+                base.Execute();
+
+                RecordFilesWritten();
+            }
+            catch (Exception ex)
+            {
+                Log.LogError("nanoFramework build error: " + ex.Message);
+            }
+            finally
+            {
+                Cleanup();
+            }
+
+            // if we've logged any errors that's because there were errors (WOW!)
+            return !Log.HasLoggedErrors;
+        }
+
+        private void RecordFileWritten(string file)
+        {
+            if (!string.IsNullOrEmpty(file))
+            {
+                if (File.Exists(file))
+                {
+                    _FilesWritten.Add(new TaskItem(file));
+                }
+            }
+        }
+
+        private void RecordFilesWritten()
+        {
+            //RecordFileWritten(SaveStrings);
+            //RecordFileWritten(GenerateStringsTable);
+            //RecordFileWritten(DumpAll);
+            //RecordFileWritten(DumpExports);
+            RecordFileWritten(Compile);
+            RecordFileWritten(Path.ChangeExtension(Compile, "pdbx"));
+            //RecordFileWritten(RefreshAssemblyOutput);
+            //RecordFileWritten(CreateDatabaseFile);
+            //RecordFileWritten(GenerateDependency);
+        }
+
+        private void Cleanup()
+        {
+            if (tempDataBaseFile != null)
+                File.Delete(tempDataBaseFile);
+        }
+
+        protected override string ToolName
+        {
+            get
+            {
+                return "nF.Tools.MetaDataProcessor.exe";
+            }
+        }
+
+        protected override string GenerateFullPathToTool()
+        {
+            return Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "nF.Tools.MetaDataProcessor.exe");
+        }
+
+        protected override string GenerateCommandLineCommands()
+        {
+            Log.LogWarning("exe: " + GenerateFullPathToTool());
+
+            // build command line to execute MetaDataProcessor
+            CommandLineBuilder commandLinedBuilder = new CommandLineBuilder();
+
+            // going through all possible options for MetaDataProcessor now...
+
+            // -loadHints
+            AppendLoadHints(commandLinedBuilder);
+
+            // -load
+            commandLinedBuilder.AppendSwitchForEachFile("-load", Load);
+
+            // -loadDatabase
+            commandLinedBuilder.AppendSwitchForEachFile("-loadDatabase", LoadDatabase);
+
+            // -loadStrings
+            commandLinedBuilder.AppendSwitchAndFiles("-loadStrings", LoadStrings);
+
+            // -excludeClassByName
+            commandLinedBuilder.AppendSwitchForEachFile("-excludeClassByName", ExcludeClassByName);
+
+            // -parse
+            commandLinedBuilder.AppendSwitchAndFiles("-parse", Parse);
+
+            // -minimize
+            commandLinedBuilder.AppendSwitchIfTrue("-minimize", Minimize);
+
+            //AppendSwitchIfTrue(commandLine, "-resolve", this.Resolve);
+
+            //AppendSwitchFiles(commandLine, "-dump_exports", this.DumpExports);
+
+            //AppendSwitchFiles(commandLine, "-dump_all", this.DumpAll);
+
+            //AppendSwitch(commandLine, "-importResource", this.ImportResources);
+
+            // -compile
+            commandLinedBuilder.AppendSwitchForFile("-compile", Compile);
+
+            //AppendSwitchFiles(commandLine, "-savestrings", this.SaveStrings);
+
+            //AppendSwitchIfTrue(commandLine, "-verbose", this.Verbose);
+
+            //AppendSwitchIfTrue(commandLine, "-verboseMinimize", this.VerboseMinimize);
+
+            //AppendSwitchIfTrue(commandLine, "-noByteCode", this.NoByteCode);
+
+            //AppendSwitchIfTrue(commandLine, "-noAttributes", this.NoAttributes);
+
+            //AppendSwitch(commandLine, "-ignoreAssembly", this.IgnoreAssembly);
+
+            //AppendSwitchFiles(commandLine, "-generateStringsTable", this.GenerateStringsTable);
+
+            //AppendSwitchFiles(commandLine, "-generate_dependency", this.GenerateDependency);
+
+            //AppendCreateDatabase(commandLine);
+
+            //AppendSwitchFileStrings(commandLine, "-generate_skeleton", this.GenerateSkeletonFile, this.GenerateSkeletonName, this.GenerateSkeletonProject, this.LegacySkeletonInterop ? "TRUE" : "FALSE");
+
+            //AppendRefreshAssemblyCommand(commandLine);
+
+
+
+            //commandLinedBuilder.AppendSwitch("-parse");
+            //commandLinedBuilder.AppendFileNameIfNotNull(@"C:\Users\jassimoes\Documents\Visual Studio 2017\Projects\NFApp111\NFApp111\bin\Debug\NFApp111.exe");
+
+
+            Log.LogWarning("cmd: " + commandLinedBuilder.ToString());
+
+            return commandLinedBuilder.ToString();
+
+            //return "";
+        }
+
+        #region command line helper methods
+
+        private void AppendLoadHints(CommandLineBuilder commandLinedBuilder)
+        {
+            LoadHints?.Select(hint => {
+
+                commandLinedBuilder.AppendSwitch("-loadHints");
+                commandLinedBuilder.AppendSwitch(Path.GetFileNameWithoutExtension(hint.GetMetadata("FullPath")));
+                commandLinedBuilder.AppendFileNameIfNotNull(hint);
+
+                return new object();
+            }).ToList();
+        }
+        
+
+        private void AppendCreateDatabase(CommandLineBuilder commandLine)
+        {
+            //if (this.CreateDatabase == null || this.CreateDatabase.Length == 0)
+            //    return;
+
+            //tempDataBaseFile = Path.GetTempFileName();
+            //using (StreamWriter sw = new StreamWriter(m_tempFile))
+            //{
+            //    foreach (ITaskItem item in this.CreateDatabase)
+            //        sw.WriteLine(GetProperBuildFlavor(item.ItemSpec));
+            //}
+
+            //AppendSwitchFiles(commandLine, "-create_database", tempDataBaseFile, this.CreateDatabaseFile);
+        }
+
+        #endregion
+    }
+}

--- a/source/VisualStudio.BuildTask/Properties/AssemblyInfo.cs
+++ b/source/VisualStudio.BuildTask/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("VisualStudio.BuildTask")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("VisualStudio.BuildTask")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("ce0631f2-731d-4a48-b927-f13f6b2fb055")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/source/VisualStudio.BuildTask/ResolveRuntimeDependenciesTask.cs
+++ b/source/VisualStudio.BuildTask/ResolveRuntimeDependenciesTask.cs
@@ -1,0 +1,66 @@
+﻿//
+// Copyright (c) 2017 The nanoFramework project contributors
+// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
+// See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.ComponentModel;
+using System.Linq;
+
+namespace nanoFramework.Tools.VisualStudio
+{
+    [Description("ResolveRuntimeDependenciesTaskEntry")]
+    public class ResolveRuntimeDependenciesTask : Task
+    {
+        #region public properties for the task
+
+        public string Assembly { get; set; }
+
+        public string StartProgram { get; set; }
+
+        public ITaskItem[] AssemblyReferences { get; set; }
+
+        public ITaskItem[] StartProgramReferences { get; set; }
+
+        #endregion
+
+
+        public override bool Execute()
+        {
+            // report to VS output window what step the build is 
+            Log.LogMessage(MessageImportance.Normal, "Resolving Runtime Dependencies for nanoFramework assembly...");
+
+            try
+            {
+                object host = HostObject;
+
+                if (host != null)
+                {
+                    Type typ = host.GetType();
+
+                    typ.GetProperty("Assembly").SetValue(host, Assembly, null);
+                    typ.GetProperty("StartProgram").SetValue(host, StartProgram, null);
+                    typ.GetProperty("AssemblyReferences").SetValue(host, GetFullPathFromItems(AssemblyReferences), null);
+                    typ.GetProperty("StartProgramReferences").SetValue(host, GetFullPathFromItems(StartProgramReferences), null);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.LogError("nanoFramework ResolveRuntimeDependenciesTask error: " + ex.Message);
+            }
+
+            // if we've logged any errors that's because there were errors (WOW!)
+            return !Log.HasLoggedErrors;
+        }
+
+        protected string[] GetFullPathFromItems(ITaskItem[] items)
+        {
+            return items?.Select((item) => {
+                return item.GetMetadata("FullPath");
+            }).ToArray();
+        }
+    }
+}

--- a/source/VisualStudio.BuildTask/VisualStudio.BuildTask.csproj
+++ b/source/VisualStudio.BuildTask/VisualStudio.BuildTask.csproj
@@ -1,0 +1,61 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CE0631F2-731D-4A48-B927-F13F6B2FB055}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>nanoFramework.Tools.VisualStudio</RootNamespace>
+    <AssemblyName>nanoFramework.Tools.VisualStudio.BuildTask</AssemblyName>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Build.Framework" />
+    <Reference Include="Microsoft.Build.Utilities.v4.0" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MetaDataProcessorTask.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Extensions\CommandLineBuilderExtensions.cs" />
+    <Compile Include="ResolveRuntimeDependenciesTask.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="nanoFrameworkBuild.targets" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/source/VisualStudio.BuildTask/nanoFrameworkBuild.targets
+++ b/source/VisualStudio.BuildTask/nanoFrameworkBuild.targets
@@ -1,0 +1,6 @@
+﻿
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+ 
+  <UsingTask TaskName="GenerateNanoAssemblyTask" AssemblyFile="$(MSBuildThisFileDirectory)nanoFramework.Tools.VisualStudio.BuildTask.dll" />
+
+</Project>

--- a/source/VisualStudio.Extension/BuildSystem/DeployedBuildSystem/nanoFramework.Tools.MSBuildTargets.props
+++ b/source/VisualStudio.Extension/BuildSystem/DeployedBuildSystem/nanoFramework.Tools.MSBuildTargets.props
@@ -1,18 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
   <PropertyGroup>
     <ProjectSystemBase>$(MSBuildThisFileDirectory)</ProjectSystemBase>
 
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-
-    <!--<DebuggerFlavor>ScriptDebugger</DebuggerFlavor>-->
-    <!--<RunCommand>$(WinDir)\System32\cscript.exe</RunCommand>-->
-    <!--<RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>-->
-    <!--<StartItem>Start.js</StartItem>-->
-    <PropertyGroup>
-      <LanguageTargets>$(MSBuildToolsPath)\Microsoft.CSharp.targets</LanguageTargets>
-    </PropertyGroup>
-    
   </PropertyGroup>
+
 </Project>

--- a/source/VisualStudio.Extension/BuildSystem/DeployedBuildSystem/nanoFramework.Tools.MSBuildTargets.targets
+++ b/source/VisualStudio.Extension/BuildSystem/DeployedBuildSystem/nanoFramework.Tools.MSBuildTargets.targets
@@ -1,6 +1,298 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <!-- Declares the MSBuild tasks that are provided by nanoFramework tools.
+    The path is the current directory because we are using the Nuget package build directory to place all these.
+  -->
+  <UsingTask TaskName="MetaDataProcessorTask"             AssemblyFile="$(MSBuildThisFileDirectory)nanoFramework.Tools.VisualStudio.BuildTask.dll" />
+  <UsingTask TaskName="ResolveRuntimeDependenciesTask"    AssemblyFile="$(MSBuildThisFileDirectory)nanoFramework.Tools.VisualStudio.BuildTask.dll" />
 
+  <!-- Overrides the "DependsOn" Properties for MSBuild. This is the recommended way of dealing with this because MSBuild 
+  evaluates the definition of targets sequentially. So there is no way to prevent another project that imports nanoFramework projects
+  from overriding the targets we need to override.
+  See https://msdn.microsoft.com/en-us/library/ms366724.aspx.
+  -->
+  <PropertyGroup>
+    <CoreBuildDependsOn>
+      BuildOnlySettings;
+      PrepareForBuild;
+      PreBuildEvent;
+      ResolveReferences;
+      PrepareResources;
+      ResolveKeySource;
+      Compile;
+      GenerateSerializationAssemblies;
+      CreateSatelliteAssemblies;
+      GetTargetPath;
+      PrepareForRun;
+      IncrementalClean;
+      MetaDataProcessor;
+      PostBuildEvent
+    </CoreBuildDependsOn>
+
+    <CleanDependsOn>
+      BeforeClean;
+      CleanReferencedProjects;
+      CoreClean;
+      AfterClean
+    </CleanDependsOn>
+
+    <CoreCleanDependsOn>
+      NanoFrameworkClean
+    </CoreCleanDependsOn>
+
+    <PrepareForRunDependsOn>
+      MetaDataProcessor;
+      CopyFilesToOutputDirectory;
+      CopyNanoFrameworkFiles
+    </PrepareForRunDependsOn>
+
+    <PrepareResourcesDependsOn>
+      PrepareResourceNames;
+      ResGen;
+      CompileLicxFiles;
+      <!--NanoResourceGenerator-->
+    </PrepareResourcesDependsOn>
+
+    <ResolveReferencesDependsOn>
+      BeforeResolveReferences;
+      ResolveProjectReferences;
+      ResolveAssemblyReferences;
+      ResolveRuntimeDependencies;
+      AfterResolveReferences
+    </ResolveReferencesDependsOn>
+
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <NanoFramework_StartProgram Condition=" '$(StartAction)'== 'Program' ">$(StartProgram)</NanoFramework_StartProgram>
+    <NanoFramework_IntermediateAssembly>$(ProjectDir)$(IntermediateOutputPath)$(TargetName)</NanoFramework_IntermediateAssembly>
+    <NanoFramework_Assembly>$(ProjectDir)$(OutDir)$(TargetName)</NanoFramework_Assembly>
+    <!--<nanoFramework_PdbxExt>.pdbx</nanoFramework_PdbxExt>
+    <nanoFramework_ExeExt>.exe</nanoFramework_ExeExt>
+    <nanoFramework_DllExt>.dll</nanoFramework_DllExt>
+    <nanoFramework_PdbExt>.pdb</nanoFramework_PdbExt>-->
+
+    <!-- Prevents the import of mscorlib.dll because we are using nanoFramework System namespace and objects.
+      See https://msdn.microsoft.com/en-us/library/fa13yay7.aspx
+    -->
+    <NoStdLib>true</NoStdLib>
+    
+    <!-- TODO add documentation about this
+    See https://msdn.microsoft.com/en-us/library/ms242202.aspx
+    See https://msdn.microsoft.com/en-us/library/ms171262.aspx
+    -->
+    <EnableUnmanagedDebugging>false</EnableUnmanagedDebugging>
+        
+  </PropertyGroup>
   
+  
+  <!-- Clean pe/pdbx files -->
+  <Target Name="NanoFrameworkClean">
+    <Delete Condition="EXISTS('$(ProjectDir)$(OutDir)$(TargetName).pe')"   Files="$(ProjectDir)$(OutDir)$(TargetName).pe" />
+    <Delete Condition="EXISTS('$(ProjectDir)$(OutDir)$(TargetName).pdbx')" Files="$(ProjectDir)$(OutDir)$(TargetName).pdbx" />
+  </Target>
+
+  <Target Name="CopyToOutDir" >
+    <Copy
+        Condition="Exists('$(ProjectDir)$(IntermediateOutputPath)$(TargetName).pdbx')"
+        SourceFiles="$(ProjectDir)$(IntermediateOutputPath)$(TargetName).pdbx"
+        DestinationFolder="$(ProjectDir)$(OutDir)" >
+      <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
+    </Copy>
+  </Target>
+
+  <PropertyGroup>
+    <MetaDataProcessorDependsOn>Compile;CopyToOutDir</MetaDataProcessorDependsOn>
+    <NF_GenerateStubsDirectory Condition="'$(NF_GenerateStubsDirectory)'==''">$(ProjectDir)Stubs\</NF_GenerateStubsDirectory>
+    <NF_GenerateStubsRootName Condition="'$(NF_GenerateStubsRootName)'==''">$(TargetName)</NF_GenerateStubsRootName>
+    <NF_GenerateSkeletonProjectName Condition="'$(NF_GenerateSkeletonProjectName)'==''">$(TargetName)</NF_GenerateSkeletonProjectName>
+    <NF_GenerateSkeletonFile>$(NF_GenerateStubsDirectory)$(NF_GenerateStubsRootName)</NF_GenerateSkeletonFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <NF_GeneratedStubFile Include="$(NF_GenerateStubsDirectory)$(NF_GenerateStubsRootName).h" />
+    <NF_GeneratedStubFile Include="$(NF_GenerateStubsDirectory)$(NF_GenerateStubsRootName).cpp" />
+    <NF_GenerateStubsFeatureProj Include="$(NF_GenerateStubsDirectory)$(NF_GenerateStubsRootName).featureproj" Condition="'$(NF_GenerateStubs)'=='true'" />
+  </ItemGroup>
+
+  <Target
+    Name="GetReferenceAssemblyPaths"
+    DependsOnTargets="$(GetReferenceAssemblyPathsDependsOn)">
+  </Target>
+  
+  <!-- after the .NET regular build generate nanoFramework assembly -->
+  <!--<Target Name="AfterBuild" >
+    <GenerateNanoAssemblyTask
+      
+        LoadHints="@(ReferencePath);@(ReferenceDependencyPaths);@(ReferenceSatellitePaths)"
+        Parse="$(NanoFramework_Assembly)$(TargetExt)"
+        Compile="$(NanoFramework_IntermediateAssembly).pe"
+        ImportResources="@(nanoFramework_Resources)"
+        Minimize="true">
+      
+    </GenerateNanoAssemblyTask>
+    
+  </Target>-->
+
+  <Target Name="MetaDataProcessor"
+      Inputs="$(NanoFramework_Assembly)$(TargetExt);
+        @(ReferencePath);
+        @(ReferenceDependencyPaths);
+        @(ReferenceSatellitePaths);
+        @(NanoFramework_Resources)"
+      Outputs="$(NanoFramework_IntermediateAssembly).pe;@(NF_GenerateStubsFeatureProj)"
+      DependsOnTargets="$(MetaDataProcessorDependsOn)"
+        >
+    <!-- Should we also use ReferenceCopyLocalPaths, dlls that got copied to output directory?? -->
+    <MetaDataProcessorTask
+        LoadHints="@(ReferencePath);@(ReferenceDependencyPaths);@(ReferenceSatellitePaths)"
+        Parse="$(NanoFramework_Assembly)$(TargetExt)"
+        Compile="$(NanoFramework_IntermediateAssembly).pe"
+        ImportResources="@(nanoFramework_Resources)"
+        Minimize="true">
+
+      <Output TaskParameter="FilesWritten" ItemName="FileWrites" />
+    </MetaDataProcessorTask>
+
+    <!--CallTarget is less than ideal... NF_GeneratedStubFile isn't a complete list...-->
+    <CallTarget Targets="GenerateStubs" Condition="'$(NF_GenerateStubs)'=='true'" />
+  </Target>
+
+  <!-- Generate stubs for assemblies containing methods to be implemented in native code -->
+  <Target Name="GenerateStubs"
+    Inputs="$(NanoFramework_IntermediateAssembly).pe"
+    Outputs="@(NF_GeneratedStubFile)"
+    DependsOnTargets="ReferencedAssemblyDllsToPeFiles"
+    >
+    <MakeDir Condition="!Exists('$(NF_GenerateStubsDirectory)')" Directories="$(NF_GenerateStubsDirectory)" />
+
+    <MetaDataProcessorTask
+      Verbose="true"
+      Load="$(NanoFramework_IntermediateAssembly).pe;@(ReferencedPeFile)"
+
+      GenerateSkeletonName="$(TargetName)"
+      GenerateSkeletonFile="$(NF_GenerateSkeletonFile)"
+      GenerateSkeletonProject="$(NF_GenerateSkeletonProjectName)"
+      RefreshAssemblyName="$(AssemblyName)"
+      RefreshAssemblyOutput="$(NanoFramework_IntermediateAssembly).pe"
+      Resolve="true"
+      >
+      <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
+      <!--TODO... output here is incomplete? -->
+    </MetaDataProcessorTask>
+
+    <CreateInteropFeatureProj
+        StubsPath="$(NF_GenerateStubsDirectory)"
+        Name="$(TargetName)"
+        AssemblyName="$(NanoFramework_IntermediateAssembly).pe"
+        ManagedProjectFile="$(MSBuildProjectFullPath)"
+        NativeProjectFile="$(NF_GenerateStubsDirectory)$(TargetName)_stubs.proj"
+          />
+    <!--TODO FileWrites for FeatureProj -->
+  </Target>
+
+  <Target Name="ReferencedAssemblyDllsToPeFiles" DependsOnTargets="ResolveRuntimeDependencies">
+    <ItemGroup>
+      <_ReferencedAssemblyDll Include="@(NanoFramework_StartProgram_ResolvedFiles);@(NanoFramework_StartProgram_ResolvedDependencyFiles)" />
+      <_ReferencedPeFile Include="@(_ReferencedAssemblyDll->'%(RootDir)%(Directory)%(filename).pe')" />
+
+      <ReferencedPeFile Include="%(_ReferencedPeFile.identity)" Condition="EXISTS(%(_ReferencedPeFile.identity))" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="CopyNanoFrameworkFiles" >
+    <Copy
+        SourceFiles="$(NanoFramework_IntermediateAssembly).pe"
+        DestinationFiles="$(NanoFramework_Assembly).pe"
+        SkipUnchangedFiles="true">
+      <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
+    </Copy>
+
+    <Copy
+        Condition="Exists('$(NanoFramework_IntermediateAssembly).pdbx')"
+        SourceFiles="$(NanoFramework_Assembly).pdbx"
+        DestinationFiles="$(NanoFramework_Assembly).pdbx"
+        SkipUnchangedFiles="true">
+      <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
+    </Copy>
+
+    <!--
+        These two tasks will also copy the .pe and .pdbx files for references
+        that are marked as CopyLocal. A couple of notes.  @(ReferenceCopyLocalPaths) can contain the
+        .dll and .pdb files, so there is likely duplicate copying going on here: the copy command
+        is a little smart, but we are still doing a bit more work than necessary.
+        Also, if the pdbx files are in a separate directory from the .dll, then this may fail.
+        I haven't tried yet.
+        -->
+
+    <Copy
+        SourceFiles="@(ReferenceCopyLocalPaths->'%(RootDir)%(Directory)%(Filename).pe')"
+        DestinationFiles="@(ReferenceCopyLocalPaths->'$(OutDir)%(DestinationSubDirectory)%(Filename).pe')"
+        SkipUnchangedFiles="true" >
+      <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
+    </Copy>
+    
+    <Copy
+        SourceFiles="@(ReferenceCopyLocalPaths->'%(RootDir)%(Directory)%(Filename).pdbx')"
+        DestinationFiles="@(ReferenceCopyLocalPaths->'$(OutDir)%(DestinationSubDirectory)%(Filename).pdbx')"
+        SkipUnchangedFiles="true">
+      <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
+    </Copy>
+    
+  </Target>
+
+  <Target Name="ResolveRuntimeDependencies" >
+
+    <ItemGroup>
+      <NanoFramework_StartProgramItem Include="$(NanoFramework_StartProgram)" Condition=" '$(NanoFramework_StartProgram)' != '' " />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <NanoFramework_DebugReferencesStateFile>$(IntermediateOutputPath)NanoFramework_DebugReferences.cache</NanoFramework_DebugReferencesStateFile>
+    </PropertyGroup>
+
+    <ResolveAssemblyReference
+        Assemblies="@(Reference)"
+        AssemblyFiles="$(NanoFramework_StartProgram);@(_ResolvedProjectReferencePaths)"
+        InstalledAssemblyTables="@(InstalledAssemblyTables)"
+        CandidateAssemblyFiles="@(Content);@(None)"
+        SearchPaths="{CandidateAssemblyFiles};
+                         $(ReferencePath);
+                         {HintPathFromItem};
+                         $(TargetFrameworkDirectoryLE);
+                         {Registry:$(FrameworkRegistryBase),$(TargetFrameworkVersion),$(AssemblyFoldersSuffix)$(AssemblyFoldersExConditions)};
+                         {RawFileName};
+                         $(OutputPath);
+                         @(NanoFramework_StartProgramItem->'%(RootDir)%(Directory)')"
+        AppConfigFile="@(_ResolveAssemblyReferencesApplicationConfigFileForExes)"
+        AutoUnify="$(AutoUnifyAssemblyReferences)"
+        FindDependencies="true"
+        FindSatellites="true"
+        FindRelatedFiles="true"
+        Silent="!$(BuildingProject)"
+        StateFile="$(NanoFramework_DebugReferencesStateFile)">
+      
+      <Output TaskParameter="ResolvedFiles" ItemName="NanoFramework_StartProgram_ResolvedFiles"/>
+      <Output TaskParameter="ResolvedDependencyFiles" ItemName="NanoFramework_StartProgram_ResolvedDependencyFiles"/>
+      <Output TaskParameter="RelatedFiles" ItemName="NanoFramework_ReferenceRelatedPaths"/>
+      <Output TaskParameter="SatelliteFiles" ItemName="NanoFramework_ReferenceSatellitePaths"/>
+      <Output TaskParameter="CopyLocalFiles" ItemName="NanoFramework_ReferenceCopyLocalPaths"/>
+      <Output TaskParameter="SuggestedRedirects" ItemName="NanoFramework_SuggestedBindingRedirects"/>
+      <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
+    
+    </ResolveAssemblyReference>
+
+    <ResolveRuntimeDependenciesTask
+        Assembly="$(NanoFramework_Assembly)$(TargetExt)"
+        AssemblyReferences="@(ReferencePath);@(ReferenceDependencyPaths);@(ReferenceSatellitePaths)"
+        StartProgram="$(NanoFramework_StartProgram)"
+        StartProgramReferences="@(NanoFramework_StartProgram_ResolvedFiles);@(NanoFramework_StartProgram_ResolvedDependencyFiles)"/>
+  
+  </Target>
+  
+  <!-- Overriding common targets.  Application and Deployment manifests are not supported -->
+  <Target Name="_CopyManifestFiles" />
+  <Target Name="_CopyApplicationConfigFiles" />
+
 </Project>

--- a/source/VisualStudio.MSBuildTargets/VisualStudio.MSBuildTargets.nuproj
+++ b/source/VisualStudio.MSBuildTargets/VisualStudio.MSBuildTargets.nuproj
@@ -36,7 +36,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Tools.MSBuildTargets</Id>
-    <Version>1.0.0-preview0012</Version>
+    <Version>1.0.0-preview0014</Version>
     <Title>MSBuild targets for nanoFramework projects</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/source/VisualStudio.MSBuildTargets/VisualStudio.MSBuildTargets.sln
+++ b/source/VisualStudio.MSBuildTargets/VisualStudio.MSBuildTargets.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FF286327-C783-4F7A-AB73-9BCBAD0D4460}") = "VisualStudio.MSBuildTargets", "VisualStudio.MSBuildTargets.nuproj", "{1D406978-D747-4BA7-A315-155C0FFDFDBE}"
+	ProjectSection(ProjectDependencies) = postProject
+		{CE0631F2-731D-4A48-B927-F13F6B2FB055} = {CE0631F2-731D-4A48-B927-F13F6B2FB055}
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisualStudio.BuildTask", "..\VisualStudio.BuildTask\VisualStudio.BuildTask.csproj", "{CE0631F2-731D-4A48-B927-F13F6B2FB055}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1D406978-D747-4BA7-A315-155C0FFDFDBE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1D406978-D747-4BA7-A315-155C0FFDFDBE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1D406978-D747-4BA7-A315-155C0FFDFDBE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1D406978-D747-4BA7-A315-155C0FFDFDBE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CE0631F2-731D-4A48-B927-F13F6B2FB055}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CE0631F2-731D-4A48-B927-F13F6B2FB055}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CE0631F2-731D-4A48-B927-F13F6B2FB055}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CE0631F2-731D-4A48-B927-F13F6B2FB055}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
- had to implement these in VS2015 solution to make it easier to build the Nuget package (in the future, all this should be moved to VS 2017)
- update Nuget package to include the supporting MSBuild tasks, project targets and suport tools

Signed-off-by: José Simões <jose.simoes@eclo.solutions>