### PR TITLE
Correct error output for MetaDataProcessor

### DIFF
--- a/source/Tools.Parser/Support.cpp
+++ b/source/Tools.Parser/Support.cpp
@@ -281,11 +281,11 @@ void ErrorReporting::Print( LPCWSTR szOrigin, LPCWSTR szSubCategory, BOOL fError
 
     va_start( arg, szTextFormat );
 
-                       wprintf( L"%s: ", szOrigin ? szOrigin : L"nanoFramework MetaDataProcessor:"  );
-    if(szSubCategory)  wprintf( L"%s " , szSubCategory												);
-    /***************/  wprintf( L"%s NFMDP%04d: ", fError ? L"error" : L"warning", code				);
-    if(szTextFormat )  vwprintf( szTextFormat, arg													);
-    /***************/  wprintf( L"\n"																);
+                       wprintf( L"%s: ", szOrigin ? szOrigin : L"NFMDP"					);
+    if(szSubCategory)  wprintf( L"%s " , szSubCategory									);
+    /***************/  wprintf( L"%s NFMDP%04d: ", fError ? L"error" : L"warning", code	);
+    if(szTextFormat )  vwprintf( szTextFormat, arg										);
+    /***************/  wprintf( L"\n"													);
 
     va_end( arg );
 


### PR DESCRIPTION
- origin string must be a single word otherwise VS isn't able to process the output

Signed-off-by: José Simões <jose.simoes@eclo.solutions>