### PR TITLE
Improvements in MetaDataProcessor

### DIFF
--- a/source/Tools.MetaDataProcessor/Info_Win32.cpp
+++ b/source/Tools.MetaDataProcessor/Info_Win32.cpp
@@ -406,14 +406,15 @@ static const CHAR c_WARNING_FILE_OVERWRITE_Header[] =
 "//-----------------------------------------------------------------------------\n"
 "\n\n";
 
+// the include name bellow has to be in LOWER case
 static const CHAR c_Include_Header_Begin[] =
 "\n"
-"#include \"%S_native.h\"\n"
+"#include \"%s_native.h\"\n"
 "\n"
 "\n";
 
 static const CHAR c_Include_Interop_h[] =
-"#include <NANOCLR_Interop.h>\n";
+"#include <nanoCLR_Interop.h>\n";
 
 //--//
 

--- a/source/Tools.MetaDataProcessor/MetaDataProcessor.cpp
+++ b/source/Tools.MetaDataProcessor/MetaDataProcessor.cpp
@@ -983,7 +983,7 @@ int _tmain(int argc, _TCHAR* argv[])
 
 	::CoInitialize(0);
 
-	wprintf(L"nanoFramework MetaDataProcessor v1.0.9\r\n");
+	wprintf(L"nanoFramework MetaDataProcessor v1.0.10\r\n");
 
 	NANOCLR_CHECK_HRESULT(HAL_Windows::Memory_Resize(64 * 1024 * 1024));
 	// TODO check if we are still using this.....


### PR DESCRIPTION
- include headers now has correct case in file name (relevant for systems where file name case matters)
- bumped version to 1.0.10

Signed-off-by: José Simões <jose.simoes@eclo.solutions>