### PR TITLE
Remove wrong code in MetaDataProcessor

### DIFF
--- a/source/CSharp.BlankApplication/CSharp.BlankApplication.vstemplate
+++ b/source/CSharp.BlankApplication/CSharp.BlankApplication.vstemplate
@@ -25,7 +25,7 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="47973986-ed3c-4b64-ba40-a9da73b44ef7">
-      <package id="nanoFramework.Tools.MSBuildSystem" version="1.0.0-preview0032" />
+      <package id="nanoFramework.Tools.MSBuildSystem" version="1.0.0-preview0033" />
     </packages>
     <packages repository="extension" repositoryId="47973986-ed3c-4b64-ba40-a9da73b44ef7">
       <package id="nanoFramework.CoreLibrary" version="1.0.0-preview012" />

--- a/source/CSharp.ClassLibrary/CSharp.ClassLibrary.vstemplate
+++ b/source/CSharp.ClassLibrary/CSharp.ClassLibrary.vstemplate
@@ -24,7 +24,7 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="47973986-ed3c-4b64-ba40-a9da73b44ef7">
-      <package id="nanoFramework.Tools.MSBuildSystem" version="1.0.0-preview0032" />
+      <package id="nanoFramework.Tools.MSBuildSystem" version="1.0.0-preview0033" />
     </packages>
     <packages repository="extension" repositoryId="47973986-ed3c-4b64-ba40-a9da73b44ef7">
       <package id="nanoFramework.CoreLibrary" version="1.0.0-preview012" />

--- a/source/Tools.BuildTasks/Nuget.MSBuildSystem/Nuget.MSBuildSystem.nuproj
+++ b/source/Tools.BuildTasks/Nuget.MSBuildSystem/Nuget.MSBuildSystem.nuproj
@@ -36,7 +36,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Tools.MSBuildSystem</Id>
-    <Version>1.0.0-preview0032</Version>
+    <Version>1.0.0-preview0033</Version>
     <Title>nanoFramework.Tools.MSBuildSystem</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/source/Tools.MetaDataProcessor/MetaDataProcessor.cpp
+++ b/source/Tools.MetaDataProcessor/MetaDataProcessor.cpp
@@ -575,7 +575,6 @@ struct Settings : CLR_RT_ParseOptions
 		LPCWSTR     szFile = PARAM_EXTRACT_STRING(params, 0);
 		LPCWSTR     szName = PARAM_EXTRACT_STRING(params, 1);
 		LPCWSTR     szProj = PARAM_EXTRACT_STRING(params, 2);
-		LPCWSTR     szLeg = PARAM_EXTRACT_STRING(params, 3);
 
 		std::string name;
 
@@ -972,7 +971,7 @@ int _tmain(int argc, _TCHAR* argv[])
 
 	::CoInitialize(0);
 
-	wprintf(L"nanoFramework MetaDataProcessor v1.0.12\r\n");
+	wprintf(L"nanoFramework MetaDataProcessor v1.0.13\r\n");
 
 	NANOCLR_CHECK_HRESULT(HAL_Windows::Memory_Resize(64 * 1024 * 1024));
 	// TODO check if we are still using this.....

--- a/source/VisualStudio.Extension/VisualStudio.Extension.csproj
+++ b/source/VisualStudio.Extension/VisualStudio.Extension.csproj
@@ -57,8 +57,8 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="..\Tools.BuildTasks\Nuget.MSBuildSystem\bin\$(Configuration)\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0032.nupkg">
-      <Link>Packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0032.nupkg</Link>
+    <Content Include="..\Tools.BuildTasks\Nuget.MSBuildSystem\bin\$(Configuration)\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0033.nupkg">
+      <Link>Packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0033.nupkg</Link>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>

--- a/source/VisualStudio.Extension/source.extension.vsixmanifest
+++ b/source/VisualStudio.Extension/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="47973986-ed3c-4b64-ba40-a9da73b44ef7" Version="0.1.15.0" Language="en-US" Publisher="nanoFramework" />
+    <Identity Id="47973986-ed3c-4b64-ba40-a9da73b44ef7" Version="0.1.16" Language="en-US" Publisher="nanoFramework" />
     <DisplayName>nanoFramework VS2017 Extension</DisplayName>
     <Description xml:space="preserve">Visual Studio 2017 extension for nanoFramework. Enables creating C# Solutions and provides debugging tools.</Description>
     <MoreInfo>http://www.nanoframework.net</MoreInfo>
@@ -20,7 +20,7 @@
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
     <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="CSharp.BlankApplication" d:TargetPath="|CSharp.BlankApplication;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
     <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="CSharp.AssemblyInfoTemplate" d:TargetPath="|CSharp.AssemblyInfoTemplate;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
-    <Asset Type="nanoFramework.Tools.MSBuildSystem.1.0.0-preview0032.nupkg" d:Source="File" Path="Packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0021.nupkg" d:VsixSubPath="Packages" />
+    <Asset Type="nanoFramework.Tools.MSBuildSystem.1.0.0-preview0033.nupkg" d:Source="File" Path="Packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0021.nupkg" d:VsixSubPath="Packages" />
     <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="CSharp.ClassLibrary" d:TargetPath="|CSharp.ClassLibrary;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
     <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="CSharp.ClassTemplate" d:TargetPath="|CSharp.ClassTemplate;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
     <Asset Type="nanoFramework.Core.Library.1.0.0-preview012.nupkg" d:Source="File" Path="Packages\nanoFramework.Core.Library.1.0.0-preview012.nupkg" d:VsixSubPath="Packages" />


### PR DESCRIPTION
- fix #62
- bumped MSBuild system Nuget version to preview0033
- bumped VS extension to 0.1.16

Signed-off-by: José Simões <jose.simoes@eclo.solutions>