### PR TITLE
Add function to generate skeleton code without Interop

### DIFF
--- a/source/CSharp.BlankApplication/CSharp.BlankApplication.vstemplate
+++ b/source/CSharp.BlankApplication/CSharp.BlankApplication.vstemplate
@@ -25,7 +25,7 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="47973986-ed3c-4b64-ba40-a9da73b44ef7">
-      <package id="nanoFramework.Tools.MSBuildSystem" version="1.0.0-preview0036" />
+      <package id="nanoFramework.Tools.MSBuildSystem" version="1.0.0-preview0037" />
     </packages>
     <packages repository="extension" repositoryId="47973986-ed3c-4b64-ba40-a9da73b44ef7">
       <package id="nanoFramework.CoreLibrary" version="1.0.0-preview012" />

--- a/source/CSharp.ClassLibrary/CSharp.ClassLibrary.vstemplate
+++ b/source/CSharp.ClassLibrary/CSharp.ClassLibrary.vstemplate
@@ -24,7 +24,7 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="47973986-ed3c-4b64-ba40-a9da73b44ef7">
-      <package id="nanoFramework.Tools.MSBuildSystem" version="1.0.0-preview0036" />
+      <package id="nanoFramework.Tools.MSBuildSystem" version="1.0.0-preview0037" />
     </packages>
     <packages repository="extension" repositoryId="47973986-ed3c-4b64-ba40-a9da73b44ef7">
       <package id="nanoFramework.CoreLibrary" version="1.0.0-preview012" />

--- a/source/Tools.BuildTasks/MetaDataProcessorTask.cs
+++ b/source/Tools.BuildTasks/MetaDataProcessorTask.cs
@@ -68,6 +68,13 @@ namespace nanoFramework.Tools
 
         public string CreateDatabaseFile { get; set; }
 
+        /// <summary>
+        /// Option to generate skeleton project without Interop support.
+        /// This is required to generate Core Libraries.
+        /// Default is false, meaning that Interop support will be used.
+        /// </summary>
+        public bool SkeletonWithoutInterop { get; set; } = true;
+
         public bool Resolve { get; set; }
 
         public string RefreshAssemblyName { get; set; }
@@ -234,7 +241,7 @@ namespace nanoFramework.Tools
             AppendCreateDatabase(commandLinedBuilder);
 
             // -generate_skeleton
-            commandLinedBuilder.AppendSwitchToFileAndExtraSwitches("-generate_skeleton", GenerateSkeletonFile, GenerateSkeletonName, GenerateSkeletonProject);
+            commandLinedBuilder.AppendSwitchToFileAndExtraSwitches("-generate_skeleton", GenerateSkeletonFile, GenerateSkeletonName, GenerateSkeletonProject, SkeletonWithoutInterop ? "TRUE" : "FALSE");
 
             // -refresh_assembly
             AppendRefreshAssemblyCommand(commandLinedBuilder);

--- a/source/Tools.BuildTasks/Nuget.MSBuildSystem/Nuget.MSBuildSystem.nuproj
+++ b/source/Tools.BuildTasks/Nuget.MSBuildSystem/Nuget.MSBuildSystem.nuproj
@@ -36,7 +36,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>nanoFramework.Tools.MSBuildSystem</Id>
-    <Version>1.0.0-preview0036</Version>
+    <Version>1.0.0-preview0037</Version>
     <Title>nanoFramework.Tools.MSBuildSystem</Title>
     <Authors>nanoFramework project contributors</Authors>
     <Owners>nanoFramework project contributors</Owners>

--- a/source/Tools.MetaDataProcessor/MetaDataProcessor.cpp
+++ b/source/Tools.MetaDataProcessor/MetaDataProcessor.cpp
@@ -575,6 +575,9 @@ struct Settings : CLR_RT_ParseOptions
 		LPCWSTR     szFile = PARAM_EXTRACT_STRING(params, 0);
 		LPCWSTR     szName = PARAM_EXTRACT_STRING(params, 1);
 		LPCWSTR     szProj = PARAM_EXTRACT_STRING(params, 2);
+		LPCWSTR     szNoInterop = PARAM_EXTRACT_STRING(params, 3);
+
+		BOOL codeGeneratorNoInterop = _wcsicmp(L"TRUE", szNoInterop) == 0;
 
 		std::string name;
 
@@ -587,7 +590,14 @@ struct Settings : CLR_RT_ParseOptions
 		currentAssembly = g_CLR_RT_TypeSystem.FindAssembly(name.c_str(), NULL, false);
 		if (currentAssembly)
 		{
-			currentAssembly->GenerateSkeleton(szFile, szProj);
+			if (codeGeneratorNoInterop)
+			{
+				currentAssembly->GenerateSkeleton_NoInterop(szFile, szProj);
+			}
+			else
+			{
+				currentAssembly->GenerateSkeleton(szFile, szProj);
+			}
 		}
 
 		NANOCLR_NOCLEANUP();
@@ -928,6 +938,7 @@ struct Settings : CLR_RT_ParseOptions
 		PARAM_GENERIC(L"<file>", L"Prefix name for the files");
 		PARAM_GENERIC(L"<name>", L"Name of the assembly");
 		PARAM_GENERIC(L"<project>", L"Identifier for the library");
+		PARAM_GENERIC(L"<true|false>", L"Generate code without Interop support");
 
 		OPTION_CALL(Cmd_RefreshAssembly, L"-refresh_assembly", L"Recomputes CRCs for an assembly");
 		PARAM_GENERIC(L"<name>", L"Name of the assembly");
@@ -971,7 +982,7 @@ int _tmain(int argc, _TCHAR* argv[])
 
 	::CoInitialize(0);
 
-	wprintf(L"nanoFramework MetaDataProcessor v1.0.16\r\n");
+	wprintf(L"nanoFramework MetaDataProcessor v1.0.17\r\n");
 
 	NANOCLR_CHECK_HRESULT(HAL_Windows::Memory_Resize(64 * 1024 * 1024));
 	// TODO check if we are still using this.....

--- a/source/VisualStudio.Extension/BuildSystem/DeployedBuildSystem/nanoFramework.Tools.MSBuildSystem.targets
+++ b/source/VisualStudio.Extension/BuildSystem/DeployedBuildSystem/nanoFramework.Tools.MSBuildSystem.targets
@@ -428,6 +428,7 @@
       GenerateSkeletonFile="$(NFMDP_STUB_GenerateSkeletonFile)"
       GenerateSkeletonName="$(NFMDP_STUB_GenerateSkeletonName)"
       GenerateSkeletonProject="$(NFMDP_STUB_GenerateSkeletonProject)"
+      SkeletonWithoutInterop="$(NFMDP_STUB_SkeletonWithoutInterop)"
       GenerateDependency="$(NFMDP_STUB_GenerateDependency)"
       CreateDatabase="@(NFMDP_STUB_CreateDatabase)"
       RefreshAssemblyName="$(NFMDP_STUB_RefreshAssemblyName)"

--- a/source/VisualStudio.Extension/VisualStudio.Extension.csproj
+++ b/source/VisualStudio.Extension/VisualStudio.Extension.csproj
@@ -57,8 +57,8 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="..\Tools.BuildTasks\Nuget.MSBuildSystem\bin\$(Configuration)\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0036.nupkg">
-      <Link>Packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0036.nupkg</Link>
+    <Content Include="..\Tools.BuildTasks\Nuget.MSBuildSystem\bin\$(Configuration)\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0037.nupkg">
+      <Link>Packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0037.nupkg</Link>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>

--- a/source/VisualStudio.Extension/source.extension.vsixmanifest
+++ b/source/VisualStudio.Extension/source.extension.vsixmanifest
@@ -20,7 +20,7 @@
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
     <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="CSharp.BlankApplication" d:TargetPath="|CSharp.BlankApplication;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
     <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="CSharp.AssemblyInfoTemplate" d:TargetPath="|CSharp.AssemblyInfoTemplate;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
-    <Asset Type="nanoFramework.Tools.MSBuildSystem.1.0.0-preview0036.nupkg" d:Source="File" Path="Packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0021.nupkg" d:VsixSubPath="Packages" />
+    <Asset Type="nanoFramework.Tools.MSBuildSystem.1.0.0-preview0037.nupkg" d:Source="File" Path="Packages\nanoFramework.Tools.MSBuildSystem.1.0.0-preview0021.nupkg" d:VsixSubPath="Packages" />
     <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="CSharp.ClassLibrary" d:TargetPath="|CSharp.ClassLibrary;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
     <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="CSharp.ClassTemplate" d:TargetPath="|CSharp.ClassTemplate;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
     <Asset Type="nanoFramework.Core.Library.1.0.0-preview012.nupkg" d:Source="File" Path="Packages\nanoFramework.Core.Library.1.0.0-preview012.nupkg" d:VsixSubPath="Packages" />


### PR DESCRIPTION
- Add code to generate skeleton code without requiring Interop support
- Add support options to MetaDataProcessor, Task and targets
- Bumped MSBuild System version to preview0037
- fixes #70
- update nf-interpreter submodule

Signed-off-by: José Simões <jose.simoes@eclo.solutions>