### PR TITLE
Fixed deployment

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.1.40-pre{build}
+version: 0.1.41-pre{build}
 pull_requests:
   do_not_increment_build_number: true
 branches:
@@ -15,15 +15,9 @@ build_script:
 
     msbuild source\nanoFramework.Tools.VisualStudio.sln /p:Configuration=Release  /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 artifacts:
-- path: '**\bin\Release\*MSBuildSystem*.nupkg'
-  name: MSBuild_System_Nuget_Package
 - path: '**\*.vsix'
   name: VS_extension
 deploy:
-- provider: NuGet
-  api_key:
-    secure: NSRDXbS8tmzOy4wStGuO3yQMKI8Sk10vF8iQtz9ZDXEnHfwnuDdnXbr/Kno3MMvY
-  skip_symbols: true
 - provider: GitHub
   tag: v$(appveyor_build_version)
   release: nanoFramework VS2017 Extension v$(appveyor_build_version)

--- a/source/VisualStudio.Extension/Deployment/DeployProvider.cs
+++ b/source/VisualStudio.Extension/Deployment/DeployProvider.cs
@@ -39,6 +39,8 @@ namespace nanoFramework.Tools.VisualStudio.Extension
         private const int _timeoutMiliseconds = 200;
 
         private ViewModelLocator _viewModelLocator;
+        private int assemblyList;
+
         ViewModelLocator ViewModelLocator
         {
             get
@@ -61,9 +63,12 @@ namespace nanoFramework.Tools.VisualStudio.Extension
         [Import]
         private ProjectProperties Properties { get; set; }
 
+        [Import]
+        IProjectService ProjectService { get; set; }
+
         public async Task DeployAsync(CancellationToken cancellationToken, TextWriter outputPaneWriter)
         {
-            // make sure we’re on the UI thread
+            // make sure we're on the UI thread
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             // just in case....
@@ -81,23 +86,16 @@ namespace nanoFramework.Tools.VisualStudio.Extension
             await outputPaneWriter.WriteLineAsync($"Getting things ready to deploy assemblies to nanoFramework device: {device.Description}.");
 
             List<byte[]> assemblies = new List<byte[]>();
-            HybridDictionary systemAssemblies = new HybridDictionary();
-
-            // ensure that assemblies are loaded
 
             // build policy to check for device initialized
             // on false result
             // set retry count
             // set wait time between retries
-            // on each retry send comand to ResumeExecution
-            var deviceInInitStatePolicy = Policy.HandleResult(false).WaitAndRetryAsync(
+            var deviceInInitStatePolicy = Policy.HandleResult<bool>(r => r == false).WaitAndRetryAsync(
                 _numberOfRetries,
                 retryAttempt => TimeSpan.FromMilliseconds(_timeoutMiliseconds),
-                async (exception, timeSpan, retryCount, context) =>
+                async (result, timeSpan, retryCount, context) =>
                 {
-                    // send command to resune execution
-                    await device.DebugEngine.ResumeExecutionAsync();
-
                     // provide feedback to user on the 1st pass
                     if (retryCount == 0)
                     {
@@ -105,130 +103,61 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                     }
                 });
 
-
-            //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-            // DEBUG warning: setting breakpoints on the code block bellow causes unhandled exception from the debug library becasue the async/await calls
-
-            // check if device is initialized
-
-            //Ensure Assemblies are loaded
-            if (await IsDeviceInInitializeStateAsync(device.DebugEngine))
+            // check if device is still in initialized state
+            if (await device.DebugEngine.IsDeviceInInitializeStateAsync())
             {
+                // device is still in initialization state, try resume execution
                 await device.DebugEngine.ResumeExecutionAsync();
-
-                while (await IsDeviceInInitializeStateAsync(device.DebugEngine))
-                {
-                    await outputPaneWriter.WriteLineAsync(ResourceStrings.WaitingDeviceInitialization);
-
-                    //need to break out of this or timeout or something?
-                    // TODO 
-                    await System.Threading.Tasks.Task.Delay(200);
-                }
             }
 
-            //Debug.WriteLine($"currentExecutionMode is {result.currentExecutionMode }");
-            //Debug.WriteLine($"currentExecutionMode masked is {result.currentExecutionMode & Debugger.WireProtocol.Commands.Debugging_Execution_ChangeConditions.c_State_Mask }");
+            if (!await deviceInInitStatePolicy.ExecuteAsync(async () => { return await device.DebugEngine.IsDeviceInInitializeStateAsync(); }))
+            { 
+                // device is NOT in initialization state, meaning is running or stopped
+                await outputPaneWriter.WriteLineAsync(ResourceStrings.DeviceInitialized);
 
-            //if (((result.currentExecutionMode & Debugger.WireProtocol.Commands.Debugging_Execution_ChangeConditions.c_State_Mask) == Debugger.WireProtocol.Commands.Debugging_Execution_ChangeConditions.c_State_Initialize))
-            //{
-            // device is in initialized state
-            await outputPaneWriter.WriteLineAsync(ResourceStrings.DeviceInitialized);
+                // get the list of assemblies referenced by the project
+                var referencedAssemblies = await Properties.ConfiguredProject.Services.AssemblyReferences.GetResolvedReferencesAsync();
 
-            // try to resolve assemblies
+                // get the target path to reach the PE for the executable
 
-            // Create cancelation token source
-            CancellationTokenSource cts = new CancellationTokenSource();
+                // this is not currently working so...
+                //var props = Properties.GetConfigurationGeneralPropertiesAsync();
 
-            // resolve assemblies on device
-            List<Debugger.WireProtocol.Commands.DebuggingResolveAssembly> assembliesOnDevice = await device.DebugEngine.ResolveAllAssembliesAsync(cts.Token);
+                //... we need to access the target path using reflexion (step by step)
+                // get type for ConfiguredProject
+                var projSystemType = Properties.ConfiguredProject.GetType();
 
-            // find out which are the system assemblies
-            // we will insert each system assembly in a dictionary where the key will be the assembly version
-            foreach (Debugger.WireProtocol.Commands.DebuggingResolveAssembly assembly in assembliesOnDevice)
-            {
-                // provide feedback to the user
-                await outputPaneWriter.WriteLineAsync($"Found Assembly {assembly.Result.Name} {assembly.Result.Version}.");
+                // get private property MSBuildProject
+                var buildProject = projSystemType.GetTypeInfo().GetDeclaredProperty("MSBuildProject");
 
-                // only add assemblies that are deployed
-                if (assembly.Result.Status.HasFlag(Debugger.WireProtocol.Commands.DebuggingResolveAssembly.ResolvedStatus.Deployed))
+                // get value of MSBuildProject property from ConfiguredProject object
+                // this result is of type Microsoft.Build.Evaluation.Project
+                var projectResult = ((System.Threading.Tasks.Task<Microsoft.Build.Evaluation.Project>)buildProject.GetValue(Properties.ConfiguredProject));
+
+                // we want the target path property
+                var targetPath = projectResult.Result.Properties.First(p => p.Name == "TargetPath").EvaluatedValue;
+
+                // build a list with the full path for each DLL and EXE
+                List<string> assemblyList = new List<string>();
+
+                foreach (IAssemblyReference reference in referencedAssemblies)
                 {
-                    systemAssemblies.Add(assembly.Result.Name.ToLower(), assembly.Result.Version);
-                }
-            }
-
-            // get the list of assemblies referenced by the project
-            var referencedAssemblies = await Properties.ConfiguredProject.Services.AssemblyReferences.GetResolvedReferencesAsync();
-
-            // build a list with the full path for each DLL and name
-            List<(string path, string name)> dlls = new List<(string path, string name)>();
-            foreach (IAssemblyReference reference in referencedAssemblies)
-            {
-                dlls.Add((await reference.GetFullPathAsync(), (await reference.GetAssemblyNameAsync()).Name));
-            }
-
-            // build a list with the PE files corresponding to each DLL
-            List<(string path, string name)> pes = dlls.Select(a => (a.path.Replace(".dll", ".pe"), a.name)).ToList();
-
-            // now we will re-deploy all system assemblies
-            for (int i = 0; i < pes.Count; ++i)
-            {
-                string assemblyPath = pes[i].path;
-                string dllPath = dlls[i].path;
-
-                ////is this a system assembly?
-                //string fileName = Path.ChangeExtension(Path.GetFileName(assemblyPath), null).ToLower();
-                bool deployNewVersion = true;
-
-                if (systemAssemblies.Contains(pes[i].name))
-                {
-                    // get the version of the assembly on the device 
-                    Debugger.WireProtocol.Commands.DebuggingResolveAssembly.Version versionOnDevice = (Debugger.WireProtocol.Commands.DebuggingResolveAssembly.Version)systemAssemblies[pes[i].name];
-
-                    // get the version of the assembly of the project
-                    // We need to load the bytes for the assembly because other Load methods can override the path
-                    // with gac or recently used paths.  This is the only way we control the exact assembly that is loaded.
-                    byte[] assemblyData = null;
-
-                    using (FileStream sr = new FileStream(dllPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
-                    {
-                        assemblyData = new byte[sr.Length];
-                        sr.Read(assemblyData, 0, (int)sr.Length);
-                    }
-
-                    Assembly assm = Assembly.Load(assemblyData);
-                    Version versionToDeploy = assm.GetName().Version;
-
-                    // get project properties
-                    var projectConfiguration = Properties.ConfiguredProject.ProjectConfiguration;
-
-                    // compare versions strictly, and deploy whatever assembly does not match the version on the device
-                    if (versionOnDevice.Equals(versionToDeploy))
-                    {
-                        deployNewVersion = false;
-                    }
-                    else
-                    {
-                        //////////////////////////////////////////////// 
-                        //            !!! SPECIAL CASE !!!            //
-                        //                                            //
-                        // MSCORLIB cannot be deployed more than once //
-                        ////////////////////////////////////////////////
-
-                        if (assm.GetName().Name.ToLower().Contains("mscorlib"))
-                        {
-                            await outputPaneWriter.WriteLineAsync($"Cannot deploy the base assembly '{assm.GetName().Name}', or any of his satellite assemblies, to device - {device.Description} twice. Assembly '{9}' on the device has version {versionOnDevice.MajorVersion}.{versionOnDevice.MinorVersion}.{ versionOnDevice.BuildNumber}.{ versionOnDevice.RevisionNumber}, while the program is trying to deploy version {versionToDeploy.Major}.{ versionToDeploy.Minor}.{ versionToDeploy.Build}.{ versionToDeploy.Revision} ");
-                            //SetDeployFailure(message);
-                            return;
-                        }
-                    }
+                    assemblyList.Add(await reference.GetFullPathAsync());
                 }
 
-                // append to the deploy blob the assembly whose version does not match, or that still is not on the device
-                if (deployNewVersion)
+                // now add the executable to this list
+                assemblyList.Add(targetPath);
+
+                // build a list with the PE files corresponding to each DLL and EXE
+                List<string> peCollection = assemblyList.Select(a => a.Replace(".dll", ".pe").Replace(".exe", ".pe")).ToList();
+
+                // now we will re-deploy all system assemblies
+                foreach(string pePath in peCollection)
                 {
-                    using (FileStream fs = File.Open(assemblyPath, FileMode.Open, FileAccess.Read))
+                    // append to the deploy blob the assembly
+                    using (FileStream fs = File.Open(pePath, FileMode.Open, FileAccess.Read))
                     {
-                        await outputPaneWriter.WriteLineAsync($"Adding pe file {Path.GetFileName(assemblyPath)} to deployment bundle");
+                        await outputPaneWriter.WriteLineAsync($"Adding pe file {Path.GetFileNameWithoutExtension(pePath)} to deployment bundle");
                         long length = (fs.Length + 3) / 4 * 4;
                         byte[] buffer = new byte[length];
 
@@ -236,27 +165,24 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                         assemblies.Add(buffer);
                     }
                 }
+
+                await outputPaneWriter.WriteLineAsync("Deploying assemblies to device...");
+
+                if (!await device.DebugEngine.DeploymentExecuteAsync(assemblies, false))
+                {
+                    await outputPaneWriter.WriteLineAsync("Deploy failed.");
+                    return;
+                }
+
+                //
+                await outputPaneWriter.WriteLineAsync("Deployment successful.");
+
             }
-
-            await outputPaneWriter.WriteLineAsync("Deploying assemblies to device...");
-
-            if (!await device.DebugEngine.DeploymentExecuteAsync(assemblies, false))
+            else
             {
-                await outputPaneWriter.WriteLineAsync("Deploy failed.");
-                return;
+                // after retry policy applied seems that we couldn't set the device in initizaled state...
+                await outputPaneWriter.WriteLineAsync(ResourceStrings.DeviceInitializationTimeout);
             }
-
-            //
-            await outputPaneWriter.WriteLineAsync("Deployment successful.");
-
-            //}
-            //else
-            //{
-            //    // after retry policy applied seems that we couldn't set the device in initizaled state...
-            //    await outputPaneWriter.WriteLineAsync(ResourceStrings.DeviceInitializationTimeout);
-            //}
-        
-   
         }
 
         public bool IsDeploySupported
@@ -273,29 +199,6 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
         public void Rollback()
         {
-        }
-
-        //public string[] GetDependencies(bool fIncludeStartProgram, bool fPE)
-        //{
-        //    string frameworkVersion = GetTargetFrameworkProperty();
-
-        //    BuildHost buildHost
-
-        //    IVsProjectBuildSystem innerIVsProjectBuildSystem = n
-        //}
-
-        public async Task<bool> IsDeviceInInitializeStateAsync(Engine debugEngine)
-        {
-            var result = await debugEngine.SetExecutionModeAsync(0, 0);
-
-            if (result.success)
-            {
-                return ((result.currentExecutionMode & Debugger.WireProtocol.Commands.Debugging_Execution_ChangeConditions.c_State_Mask) == Debugger.WireProtocol.Commands.Debugging_Execution_ChangeConditions.c_State_Initialize);
-            }
-            else
-            {
-                return false;
-            }
         }
     }
 }

--- a/source/VisualStudio.Extension/ProjectSystem/ProjectProperties.cs
+++ b/source/VisualStudio.Extension/ProjectSystem/ProjectProperties.cs
@@ -51,5 +51,6 @@ namespace nanoFramework.Tools.VisualStudio.Extension
         {
             get { return base.ConfiguredProject; }
         }
+
     }
 }

--- a/source/VisualStudio.Extension/Properties/AssemblyInfo.cs
+++ b/source/VisualStudio.Extension/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.40.0")]
-[assembly: AssemblyFileVersion("0.1.40.0")]
+[assembly: AssemblyVersion("0.1.41.0")]
+[assembly: AssemblyFileVersion("0.1.41.0")]

--- a/source/VisualStudio.Extension/Resources/ResourceStrings.Designer.cs
+++ b/source/VisualStudio.Extension/Resources/ResourceStrings.Designer.cs
@@ -61,7 +61,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ERROR: Timeout waiting for device to initialize. Try reset the device and reconnect in Device Explorer tool window..
+        ///   Looks up a localized string similar to ERROR: Timeout waiting for device to leave initialization state. Try reset the device and reconnect in Device Explorer tool window..
         /// </summary>
         internal static string DeviceInitializationTimeout {
             get {

--- a/source/VisualStudio.Extension/Resources/ResourceStrings.resx
+++ b/source/VisualStudio.Extension/Resources/ResourceStrings.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="DeviceInitializationTimeout" xml:space="preserve">
-    <value>ERROR: Timeout waiting for device to initialize. Try reset the device and reconnect in Device Explorer tool window.</value>
+    <value>ERROR: Timeout waiting for device to leave initialization state. Try reset the device and reconnect in Device Explorer tool window.</value>
   </data>
   <data name="DeviceInitialized" xml:space="preserve">
     <value>Device is initialized</value>

--- a/source/VisualStudio.Extension/VisualStudio.Extension.csproj
+++ b/source/VisualStudio.Extension/VisualStudio.Extension.csproj
@@ -271,6 +271,7 @@
       <HintPath>..\packages\Microsoft.VisualStudio.Validation.15.3.15\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.Tools.Debugger, Version=0.4.6383.23861, Culture=neutral, PublicKeyToken=e520bb6b53f04733, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\nanoFramework.Tools.Debugger.Net.0.4.0-preview016\lib\net46\nanoFramework.Tools.Debugger.dll</HintPath>
     </Reference>
     <Reference Include="Polly, Version=5.1.0.0, Culture=neutral, PublicKeyToken=c8a3ffc3f8f825cc, processorArchitecture=MSIL">

--- a/source/VisualStudio.Extension/VisualStudio.Extension.previous.nugetreferenceswitcher
+++ b/source/VisualStudio.Extension/VisualStudio.Extension.previous.nugetreferenceswitcher
@@ -1,1 +1,1 @@
-nanoFramework.Tools.DebugLibrary.Net	../../nf-debugger/source/nanoFramework.Tools.DebugLibrary.Net/nanoFramework.Tools.DebugLibrary.Net.csproj	../packages/nanoFramework.Tools.Debugger.Net.0.4.0-preview013/lib/net46/nanoFramework.Tools.Debugger.dll
+nanoFramework.Tools.DebugLibrary.Net	../../nf-debugger/source/nanoFramework.Tools.DebugLibrary.Net/nanoFramework.Tools.DebugLibrary.Net.csproj	../packages/nanoFramework.Tools.Debugger.Net.0.4.0-preview016/lib/net46/nanoFramework.Tools.Debugger.dll

--- a/source/VisualStudio.Extension/source.extension.vsixmanifest
+++ b/source/VisualStudio.Extension/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="47973986-ed3c-4b64-ba40-a9da73b44ef7" Version="0.1.40" Language="en-US" Publisher="nanoFramework" />
+    <Identity Id="47973986-ed3c-4b64-ba40-a9da73b44ef7" Version="0.1.41" Language="en-US" Publisher="nanoFramework" />
     <DisplayName>nanoFramework VS2017 Extension</DisplayName>
     <Description xml:space="preserve">Visual Studio 2017 extension for nanoFramework. Enables creating C# Solutions and provides debugging tools.</Description>
     <MoreInfo>http://www.nanoframework.net</MoreInfo>


### PR DESCRIPTION
- wasn't including the target to the deployment list
- correct retry policy declaration (and use) for checking if device is in initialization state
- remove everything related with checking deployed assemblies because we are always deploying everything
- update Debug library Nuget package
- update AppVeyor removing the Nuget artifacts and deployment
- bump VS extension version to 0.1.41

Signed-off-by: José Simões <jose.simoes@eclo.solutions>