### PR TITLE
Fixes issues with typed array generation

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.1.44-pre{build}
+version: 0.1.47-pre{build}
 pull_requests:
   do_not_increment_build_number: true
 branches:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,9 @@
 version: 0.1.47-pre{build}
+
+# temporary fix for nuget connectivity issues
+hosts:
+  api.nuget.org: 93.184.221.200
+
 pull_requests:
   do_not_increment_build_number: true
 branches:

--- a/source/Tools.MetaDataProcessor/ManagedElementTypes_Win32.h
+++ b/source/Tools.MetaDataProcessor/ManagedElementTypes_Win32.h
@@ -56,6 +56,9 @@ public:
 	// Declaration of variable in marshaling code.
 	virtual string GetVariableDecl() { return GetStandardTypeName(); }
 
+	// Declaration of variable for use in typed array in marshaling code.
+	virtual string GetVariableDeclForTypedArray() { return GetNativeType(); }
+
 	// For value type there is no prefix. Return empty string
 	virtual string GetTypeNamePrefix() { return "\0"; }
 
@@ -102,7 +105,7 @@ public:
 	virtual ~CLR_RT_ManagedElementTypeArray() {}
 
 	// Varialble declaration - "CLR_RT_TypedArray_" of specified type;
-	virtual string GetVariableDecl() { return "CLR_RT_TypedArray_" + CLR_RT_ManagedElementType::GetVariableDecl(); }
+	virtual string GetVariableDecl() { return "CLR_RT_TypedArray_" + CLR_RT_ManagedElementType::GetVariableDeclForTypedArray(); }
 
 	// Reference types are prefixed by BYREF_ in function names.
 	virtual string GetTypeNamePrefix() { return "SZARRAY_"; }

--- a/source/Tools.MetaDataProcessor/MetaDataProcessor.cpp
+++ b/source/Tools.MetaDataProcessor/MetaDataProcessor.cpp
@@ -982,7 +982,7 @@ int _tmain(int argc, _TCHAR* argv[])
 
 	::CoInitialize(0);
 
-	wprintf(L"nanoFramework MetaDataProcessor v1.0.18\r\n");
+	wprintf(L"nanoFramework MetaDataProcessor v1.0.19\r\n");
 
 	NANOCLR_CHECK_HRESULT(HAL_Windows::Memory_Resize(64 * 1024 * 1024));
 	// TODO check if we are still using this.....

--- a/source/VisualStudio.Extension/Properties/AssemblyInfo.cs
+++ b/source/VisualStudio.Extension/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.46.0")]
-[assembly: AssemblyFileVersion("0.1.46.0")]
+[assembly: AssemblyVersion("0.1.47.0")]
+[assembly: AssemblyFileVersion("0.1.47.0")]

--- a/source/VisualStudio.Extension/source.extension.vsixmanifest
+++ b/source/VisualStudio.Extension/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="47973986-ed3c-4b64-ba40-a9da73b44ef7" Version="0.1.46" Language="en-US" Publisher="nanoFramework" />
+    <Identity Id="47973986-ed3c-4b64-ba40-a9da73b44ef7" Version="0.1.47" Language="en-US" Publisher="nanoFramework" />
     <DisplayName>nanoFramework VS2017 Extension</DisplayName>
     <Description xml:space="preserve">Visual Studio 2017 extension for nanoFramework. Enables creating C# Solutions and provides debugging tools.</Description>
     <MoreInfo>http://www.nanoframework.net</MoreInfo>


### PR DESCRIPTION
- was wrongly using the C native types instead of the "mapped" ones from the CLR
- fixes #115
- bump MDP to v1.0.19
- bump VS extension to 0.1.47

Signed-off-by: José Simões <jose.simoes@eclo.solutions>