### PR TITLE
Update debug library

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,4 @@
-version: 0.1.47-pre{build}
-
-# temporary fix for nuget connectivity issues
-hosts:
-  api.nuget.org: 93.184.221.200
+version: 0.1.48-pre{build}
 
 pull_requests:
   do_not_increment_build_number: true

--- a/source/VisualStudio.Extension/Properties/AssemblyInfo.cs
+++ b/source/VisualStudio.Extension/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.47.0")]
-[assembly: AssemblyFileVersion("0.1.47.0")]
+[assembly: AssemblyVersion("0.1.48.0")]
+[assembly: AssemblyFileVersion("0.1.48.0")]

--- a/source/VisualStudio.Extension/ToolWindow.DeviceExplorer/ViewModel/DeviceExplorerViewModel.cs
+++ b/source/VisualStudio.Extension/ToolWindow.DeviceExplorer/ViewModel/DeviceExplorerViewModel.cs
@@ -244,7 +244,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension.ToolWindow.ViewModel
 
                 ThreadHelper.JoinableTaskFactory.Run(async delegate {
 
-                    bool connectOk = await SelectedDevice.DebugEngine.ConnectAsync(3, 1000);
+                    bool connectOk = await SelectedDevice.DebugEngine.ConnectAsync(3, 1000, true);
 
                     ConnectionStateResult = connectOk ? ConnectionState.Connected : ConnectionState.Disconnected;
                 });

--- a/source/VisualStudio.Extension/VisualStudio.Extension.csproj
+++ b/source/VisualStudio.Extension/VisualStudio.Extension.csproj
@@ -270,8 +270,8 @@
     <Reference Include="Microsoft.VisualStudio.Validation, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.VisualStudio.Validation.15.3.15\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Tools.Debugger, Version=0.5.6390.20522, Culture=neutral, PublicKeyToken=e520bb6b53f04733, processorArchitecture=MSIL">
-      <HintPath>..\packages\nanoFramework.Tools.Debugger.Net.0.4.0-preview018\lib\net46\nanoFramework.Tools.Debugger.dll</HintPath>
+    <Reference Include="nanoFramework.Tools.Debugger, Version=0.5.6409.21222, Culture=neutral, PublicKeyToken=e520bb6b53f04733, processorArchitecture=MSIL">
+      <HintPath>..\packages\nanoFramework.Tools.Debugger.Net.0.4.0-preview019\lib\net46\nanoFramework.Tools.Debugger.dll</HintPath>
     </Reference>
     <Reference Include="Polly, Version=5.2.0.0, Culture=neutral, PublicKeyToken=c8a3ffc3f8f825cc, processorArchitecture=MSIL">
       <HintPath>..\packages\Polly-Signed.5.2.0\lib\net45\Polly.dll</HintPath>
@@ -279,8 +279,8 @@
     <!-- reference this assembly when Configuration is Release (on Debug reference the project directly instead) -->
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="PropertyChanged, Version=2.1.2.0, Culture=neutral, PublicKeyToken=ee3ee20bcf148ddd, processorArchitecture=MSIL">
-      <HintPath>..\packages\PropertyChanged.Fody.2.1.2\lib\netstandard1.0\PropertyChanged.dll</HintPath>
+    <Reference Include="PropertyChanged, Version=2.1.3.0, Culture=neutral, PublicKeyToken=ee3ee20bcf148ddd, processorArchitecture=MSIL">
+      <HintPath>..\packages\PropertyChanged.Fody.2.1.3\lib\netstandard1.0\PropertyChanged.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="PropertyChanging, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/source/VisualStudio.Extension/packages.config
+++ b/source/VisualStudio.Extension/packages.config
@@ -31,9 +31,9 @@
   <package id="Microsoft.VSSDK.BuildTools" version="15.1.192" targetFramework="net46" developmentDependency="true" />
   <package id="MvvmLightLibs" version="5.3.0.0" targetFramework="net462" />
   <package id="nanoFramework.CoreLibrary" version="1.0.0-preview022" targetFramework="net46" developmentDependency="true" />
-  <package id="nanoFramework.Tools.Debugger.Net" version="0.4.0-preview018" targetFramework="net46" />
+  <package id="nanoFramework.Tools.Debugger.Net" version="0.4.0-preview019" targetFramework="net46" />
   <package id="Polly-Signed" version="5.2.0" targetFramework="net46" />
-  <package id="PropertyChanged.Fody" version="2.1.2" targetFramework="net46" developmentDependency="true" />
+  <package id="PropertyChanged.Fody" version="2.1.3" targetFramework="net46" developmentDependency="true" />
   <package id="PropertyChanging.Fody" version="1.28.0" targetFramework="net462" developmentDependency="true" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net46" />
   <package id="System.Composition" version="1.0.31" targetFramework="net46" />

--- a/source/VisualStudio.Extension/source.extension.vsixmanifest
+++ b/source/VisualStudio.Extension/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="47973986-ed3c-4b64-ba40-a9da73b44ef7" Version="0.1.47" Language="en-US" Publisher="nanoFramework" />
+    <Identity Id="47973986-ed3c-4b64-ba40-a9da73b44ef7" Version="0.1.48" Language="en-US" Publisher="nanoFramework" />
     <DisplayName>nanoFramework VS2017 Extension</DisplayName>
     <Description xml:space="preserve">Visual Studio 2017 extension for nanoFramework. Enables creating C# Solutions and provides debugging tools.</Description>
     <MoreInfo>http://www.nanoframework.net</MoreInfo>


### PR DESCRIPTION
- add "force" option to ConnectAsync call to allow it to force refreshing the device capabilities
- remove temporary workaround for AppVeyor access to Nuget
- bump VS extension to v0.1.48

Signed-off-by: José Simões <jose.simoes@eclo.solutions>