### PR TITLE
Correct name in targets file

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.1.58-pre{build}
+version: 0.1.59-pre{build}
 
 pull_requests:
   do_not_increment_build_number: true

--- a/source/VisualStudio.Extension/Targets/NFProjectSystem.MDP.targets
+++ b/source/VisualStudio.Extension/Targets/NFProjectSystem.MDP.targets
@@ -203,7 +203,7 @@
       <NanoFramework_DebugReferencesStateFile>$(IntermediateOutputPath)nanoFramework_DebugReferences.cache</NanoFramework_DebugReferencesStateFile>
     </PropertyGroup>
 
-    <ResolveAssemblyReference
+    <ResolveAssemblyReferences
         Assemblies="@(Reference)"
         AssemblyFiles="$(NanoFramework_StartProgram);@(_ResolvedProjectReferencePaths)"
         InstalledAssemblyTables="@(InstalledAssemblyTables)"
@@ -232,7 +232,7 @@
       <Output TaskParameter="SuggestedRedirects" ItemName="NanoFramework_SuggestedBindingRedirects"/>
       <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
 
-    </ResolveAssemblyReference>
+    </ResolveAssemblyReferences>
 
     <ResolveRuntimeDependenciesTask
         Assembly="$(NanoFramework_Assembly)$(TargetExt)"


### PR DESCRIPTION
- bump AppVeyor to 0.1.59

Signed-off-by: José Simões <jose.simoes@eclo.solutions>