### PR TITLE
Update NuGet packages

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.1.59-pre{build}
+version: 0.1.60-pre{build}
 
 pull_requests:
   do_not_increment_build_number: true

--- a/source/VisualStudio.Extension/Properties/AssemblyInfo.cs
+++ b/source/VisualStudio.Extension/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.59.0")]
-[assembly: AssemblyFileVersion("0.1.59.0")]
+[assembly: AssemblyVersion("0.1.60.0")]
+[assembly: AssemblyFileVersion("0.1.60.0")]

--- a/source/VisualStudio.Extension/VisualStudio.Extension.csproj
+++ b/source/VisualStudio.Extension/VisualStudio.Extension.csproj
@@ -180,11 +180,8 @@
     <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Composition, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Composition.15.0.71\lib\net45\Microsoft.VisualStudio.Composition.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Composition.Configuration, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Composition.15.0.71\lib\net45\Microsoft.VisualStudio.Composition.Configuration.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.Composition, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Composition.15.3.38\lib\net45\Microsoft.VisualStudio.Composition.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.VisualStudio.CoreUtility.15.0.26606\lib\net45\Microsoft.VisualStudio.CoreUtility.dll</HintPath>
@@ -203,14 +200,14 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.ProjectSystem, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.ProjectSystem.15.0.751\lib\net46\Microsoft.VisualStudio.ProjectSystem.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.ProjectSystem.15.3.224\lib\net46\Microsoft.VisualStudio.ProjectSystem.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.ProjectSystem.Interop, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.ProjectSystem.15.0.751\lib\net46\Microsoft.VisualStudio.ProjectSystem.Interop.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.ProjectSystem.15.3.224\lib\net46\Microsoft.VisualStudio.ProjectSystem.Interop.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.ProjectSystem.VS, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.ProjectSystem.15.0.751\lib\net46\Microsoft.VisualStudio.ProjectSystem.VS.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.ProjectSystem.15.3.224\lib\net46\Microsoft.VisualStudio.ProjectSystem.VS.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.15.0, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.VisualStudio.Shell.15.0.15.0.26606\lib\Microsoft.VisualStudio.Shell.15.0.dll</HintPath>
@@ -260,7 +257,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Threading, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Threading.15.3.23\lib\net45\Microsoft.VisualStudio.Threading.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.Threading.15.4.4\lib\net45\Microsoft.VisualStudio.Threading.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Utilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -268,7 +265,11 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Validation, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Validation.15.3.15\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.Validation.15.3.32\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Win32.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Win32.Primitives.4.3.0\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.Tools.Debugger, Version=0.5.6414.13818, Culture=neutral, PublicKeyToken=e520bb6b53f04733, processorArchitecture=MSIL">
       <HintPath>..\packages\nanoFramework.Tools.Debugger.Net.0.4.0-preview020\lib\net46\nanoFramework.Tools.Debugger.dll</HintPath>
@@ -288,6 +289,9 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.AppContext.4.3.0\lib\net46\System.AppContext.dll</HintPath>
+    </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
@@ -308,11 +312,57 @@
     <Reference Include="System.Composition.TypedParts, Version=1.0.31.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Composition.TypedParts.1.0.31\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
     </Reference>
+    <Reference Include="System.Console, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Console.4.3.0\lib\net46\System.Console.dll</HintPath>
+    </Reference>
     <Reference Include="System.Data" />
     <Reference Include="System.Design" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.3.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Globalization.Calendars, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Globalization.Calendars.4.3.0\lib\net46\System.Globalization.Calendars.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.Compression, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Compression.4.3.0\lib\net46\System.IO.Compression.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.IO.Compression.ZipFile, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Compression.ZipFile.4.3.0\lib\net46\System.IO.Compression.ZipFile.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.FileSystem, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.FileSystem.4.3.0\lib\net46\System.IO.FileSystem.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.Http.4.3.0\lib\net46\System.Net.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Sockets, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.Sockets.4.3.0\lib\net46\System.Net.Sockets.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net46\System.Security.Cryptography.Algorithms.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net46\System.Security.Cryptography.X509Certificates.dll</HintPath>
+    </Reference>
     <Reference Include="System.Threading.Tasks.Dataflow, Version=4.6.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Dataflow.4.7.0\lib\portable-net45+win8+wpa81\System.Threading.Tasks.Dataflow.dll</HintPath>
     </Reference>
@@ -329,6 +379,10 @@
     </Reference>
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Xml.ReaderWriter, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Xml.ReaderWriter.4.3.0\lib\net46\System.Xml.ReaderWriter.dll</HintPath>
+    </Reference>
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
@@ -530,7 +584,7 @@
     </XamlPropertyRule>
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\Microsoft.VisualStudio.ProjectSystem.Analyzers.15.0.751\analyzers\Microsoft.VisualStudio.ProjectSystem.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.VisualStudio.ProjectSystem.Analyzers.15.3.224\analyzers\Microsoft.VisualStudio.ProjectSystem.Analyzers.dll" />
     <Analyzer Include="..\packages\UwpDesktop.10.0.14393.3\analyzers\dotnet\UwpDesktopAnalyzer.dll" />
   </ItemGroup>
   <ItemGroup>
@@ -551,17 +605,17 @@
     <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.SDK.VsixSuppression.14.1.33\build\Microsoft.VisualStudio.SDK.VsixSuppression.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VisualStudio.SDK.VsixSuppression.14.1.33\build\Microsoft.VisualStudio.SDK.VsixSuppression.targets'))" />
     <Error Condition="!Exists('..\packages\UwpDesktop.10.0.14393.3\build\portable-net45+uap\UwpDesktop.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\UwpDesktop.10.0.14393.3\build\portable-net45+uap\UwpDesktop.targets'))" />
     <Error Condition="!Exists('..\packages\Fody.2.1.2\build\netstandard1.0\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.2.1.0\build\netstandard1.0\Fody.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.ProjectSystem.SDK.Tools.15.0.751\build\Microsoft.VisualStudio.ProjectSystem.Sdk.Tools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VisualStudio.ProjectSystem.SDK.Tools.15.0.751\build\Microsoft.VisualStudio.ProjectSystem.Sdk.Tools.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.10\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.9\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.15.1.192\build\Microsoft.VSSDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.15.1.192\build\Microsoft.VSSDK.BuildTools.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.15.1.192\build\Microsoft.VSSDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.15.1.192\build\Microsoft.VSSDK.BuildTools.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.ProjectSystem.SDK.Tools.15.3.224\build\Microsoft.VisualStudio.ProjectSystem.Sdk.Tools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VisualStudio.ProjectSystem.SDK.Tools.15.3.224\build\Microsoft.VisualStudio.ProjectSystem.Sdk.Tools.targets'))" />
   </Target>
   <Import Project="..\packages\Microsoft.VisualStudio.SDK.VsixSuppression.14.1.33\build\Microsoft.VisualStudio.SDK.VsixSuppression.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.SDK.VsixSuppression.14.1.33\build\Microsoft.VisualStudio.SDK.VsixSuppression.targets')" />
   <Import Project="..\packages\UwpDesktop.10.0.14393.3\build\portable-net45+uap\UwpDesktop.targets" Condition="Exists('..\packages\UwpDesktop.10.0.14393.3\build\portable-net45+uap\UwpDesktop.targets')" />
   <Import Project="..\packages\Microsoft.VSSDK.BuildTools.15.1.192\build\Microsoft.VSSDK.BuildTools.targets" Condition="Exists('..\packages\Microsoft.VSSDK.BuildTools.15.1.192\build\Microsoft.VSSDK.BuildTools.targets')" />
   <Import Project="..\packages\Fody.2.1.2\build\netstandard1.0\Fody.targets" Condition="Exists('..\packages\Fody.2.1.2\build\netstandard1.0\Fody.targets')" />
-  <Import Project="..\packages\Microsoft.VisualStudio.ProjectSystem.SDK.Tools.15.0.751\build\Microsoft.VisualStudio.ProjectSystem.Sdk.Tools.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.ProjectSystem.SDK.Tools.15.0.751\build\Microsoft.VisualStudio.ProjectSystem.Sdk.Tools.targets')" />
   <Import Project="..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.9\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.9\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets')" />
+  <Import Project="..\packages\Microsoft.VisualStudio.ProjectSystem.SDK.Tools.15.3.224\build\Microsoft.VisualStudio.ProjectSystem.Sdk.Tools.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.ProjectSystem.SDK.Tools.15.3.224\build\Microsoft.VisualStudio.ProjectSystem.Sdk.Tools.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/source/VisualStudio.Extension/packages.config
+++ b/source/VisualStudio.Extension/packages.config
@@ -3,15 +3,16 @@
   <package id="CommonServiceLocator" version="1.3" targetFramework="net462" />
   <package id="Fody" version="2.1.2" targetFramework="net46" developmentDependency="true" />
   <package id="Microsoft.Composition" version="1.0.31" targetFramework="net46" />
+  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net46" />
   <package id="Microsoft.Tpl.Dataflow" version="4.5.24" targetFramework="net462" />
-  <package id="Microsoft.VisualStudio.Composition" version="15.0.71" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Composition" version="15.3.38" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.CoreUtility" version="15.0.26606" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Imaging" version="15.0.26606" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.OLE.Interop" version="7.10.6070" targetFramework="net462" />
-  <package id="Microsoft.VisualStudio.ProjectSystem" version="15.0.751" targetFramework="net46" />
-  <package id="Microsoft.VisualStudio.ProjectSystem.Analyzers" version="15.0.751" targetFramework="net46" developmentDependency="true" />
-  <package id="Microsoft.VisualStudio.ProjectSystem.SDK" version="15.0.751" targetFramework="net46" />
-  <package id="Microsoft.VisualStudio.ProjectSystem.SDK.Tools" version="15.0.751" targetFramework="net46" developmentDependency="true" />
+  <package id="Microsoft.VisualStudio.ProjectSystem" version="15.3.224" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.ProjectSystem.Analyzers" version="15.3.224" targetFramework="net46" developmentDependency="true" />
+  <package id="Microsoft.VisualStudio.ProjectSystem.SDK" version="15.3.224" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.ProjectSystem.SDK.Tools" version="15.3.224" targetFramework="net46" developmentDependency="true" />
   <package id="Microsoft.VisualStudio.SDK.EmbedInteropTypes" version="15.0.10" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.SDK.VsixSuppression" version="14.1.33" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Shell.15.0" version="15.0.26606" targetFramework="net46" />
@@ -25,16 +26,21 @@
   <package id="Microsoft.VisualStudio.Shell.Interop.9.0" version="9.0.30729" targetFramework="net462" />
   <package id="Microsoft.VisualStudio.TextManager.Interop" version="7.10.6070" targetFramework="net462" />
   <package id="Microsoft.VisualStudio.TextManager.Interop.8.0" version="8.0.50727" targetFramework="net462" />
-  <package id="Microsoft.VisualStudio.Threading" version="15.3.23" targetFramework="net46" />
-  <package id="Microsoft.VisualStudio.Utilities" version="15.0.26606" targetFramework="net46" />
-  <package id="Microsoft.VisualStudio.Validation" version="15.3.15" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Threading" version="15.4.4" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Utilities" version="15.0.26607" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Validation" version="15.3.32" targetFramework="net46" />
   <package id="Microsoft.VSSDK.BuildTools" version="15.1.192" targetFramework="net46" developmentDependency="true" />
+  <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net46" />
   <package id="MvvmLightLibs" version="5.3.0.0" targetFramework="net462" />
   <package id="nanoFramework.CoreLibrary" version="1.0.0-preview028" targetFramework="net46" developmentDependency="true" />
   <package id="nanoFramework.Tools.Debugger.Net" version="0.4.0-preview020" targetFramework="net46" />
+  <package id="NETStandard.Library" version="1.6.1" targetFramework="net46" />
   <package id="Polly-Signed" version="5.3.1" targetFramework="net46" />
   <package id="PropertyChanged.Fody" version="2.1.4" targetFramework="net46" developmentDependency="true" />
   <package id="PropertyChanging.Fody" version="1.28.0" targetFramework="net462" developmentDependency="true" />
+  <package id="System.AppContext" version="4.3.0" targetFramework="net46" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net46" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections.Immutable" version="1.4.0" targetFramework="net46" />
   <package id="System.Composition" version="1.0.31" targetFramework="net46" />
   <package id="System.Composition.AttributedModel" version="1.0.31" targetFramework="net46" />
@@ -42,8 +48,49 @@
   <package id="System.Composition.Hosting" version="1.0.31" targetFramework="net46" />
   <package id="System.Composition.Runtime" version="1.0.31" targetFramework="net46" />
   <package id="System.Composition.TypedParts" version="1.0.31" targetFramework="net46" />
+  <package id="System.Console" version="4.3.0" targetFramework="net46" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net46" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.3.0" targetFramework="net46" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net46" />
+  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net46" />
+  <package id="System.Dynamic.Runtime" version="4.3.0" targetFramework="net46" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net46" />
+  <package id="System.Globalization.Calendars" version="4.3.0" targetFramework="net46" />
+  <package id="System.IO" version="4.3.0" targetFramework="net46" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net46" />
+  <package id="System.IO.Compression.ZipFile" version="4.3.0" targetFramework="net46" />
+  <package id="System.IO.FileSystem" version="4.3.0" targetFramework="net46" />
+  <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net46" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net46" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net46" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net46" />
+  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net46" />
+  <package id="System.Net.Sockets" version="4.3.0" targetFramework="net46" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="net46" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net46" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net46" />
+  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net46" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net46" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net46" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net46" />
+  <package id="System.Runtime.Handles" version="4.3.0" targetFramework="net46" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net46" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net46" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net46" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net46" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net46" />
+  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net46" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net46" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading.Tasks.Dataflow" version="4.8.0" targetFramework="net46" />
   <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net46" />
+  <package id="System.Threading.Timer" version="4.3.0" targetFramework="net46" />
   <package id="System.ValueTuple" version="4.3.1" targetFramework="net46" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net46" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net46" />
   <package id="UwpDesktop" version="10.0.14393.3" targetFramework="net462" />
 </packages>

--- a/source/VisualStudio.Extension/source.extension.vsixmanifest
+++ b/source/VisualStudio.Extension/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="47973986-ed3c-4b64-ba40-a9da73b44ef7" Version="0.1.59" Language="en-US" Publisher="nanoFramework" />
+    <Identity Id="47973986-ed3c-4b64-ba40-a9da73b44ef7" Version="0.1.60" Language="en-US" Publisher="nanoFramework" />
     <DisplayName>nanoFramework VS2017 Extension</DisplayName>
     <Description xml:space="preserve">Visual Studio 2017 extension for nanoFramework. Enables creating C# Solutions and provides debugging tools.</Description>
     <MoreInfo>http://www.nanoframework.net</MoreInfo>


### PR DESCRIPTION
## Description
Update NuGet packages of VSProjectSystem to 15.3.
Bump VS extension to 0.1.60.

## Motivation and Context
Previous attempt failed because the System.Composition package was updated to 1.1.0. Remaining at 1.0.31 doesn't break the Deploy feature.

## How Has This Been Tested?
Deploy option shows as expected in project node. All the remaining features as working too.

## Types of changes
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
