### PR TITLE
Fix duplicate import of user proj file

### DIFF
--- a/source/VisualStudio.Extension/Targets/NFProjectSystem.CSharp.targets
+++ b/source/VisualStudio.Extension/Targets/NFProjectSystem.CSharp.targets
@@ -80,6 +80,4 @@
   <!-- Import MetaDataProcessor targets **AFTER** everything else-->
   <Import Project="$(MSBuildThisFileDirectory)\NFProjectSystem.MDP.targets" />
 
-  <Import Project="$(MSBuildProjectFullPath).user" Condition="Exists('$(MSBuildProjectFullPath).user')" />
-
 </Project>


### PR DESCRIPTION
## Description
Remove inclusion of user proj file in targets file

## Motivation and Context
- Fixes warning from MSBuild about duplicate inclusion of file.
- Fixes/Closes/Resolves nanoFramework/Home#225

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>