### PR TITLE
Revert NuGet for System.Threading.Tasks.Dataflow to 4.5.25.0

### DIFF
--- a/source/VisualStudio.Extension/VisualStudio.Extension.csproj
+++ b/source/VisualStudio.Extension/VisualStudio.Extension.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Microsoft.VSSDK.BuildTools.15.1.192\build\Microsoft.VSSDK.BuildTools.props" Condition="Exists('..\packages\Microsoft.VSSDK.BuildTools.15.1.192\build\Microsoft.VSSDK.BuildTools.props')" />
   <PropertyGroup>
@@ -363,8 +363,8 @@
     <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net46\System.Security.Cryptography.X509Certificates.dll</HintPath>
     </Reference>
-    <Reference Include="System.Threading.Tasks.Dataflow, Version=4.6.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Threading.Tasks.Dataflow.4.8.0\lib\portable-net45+win8+wpa81\System.Threading.Tasks.Dataflow.dll</HintPath>
+    <Reference Include="System.Threading.Tasks.Dataflow, Version=4.5.25.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Dataflow.4.5.25\lib\dotnet\System.Threading.Tasks.Dataflow.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.1.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.4.0\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/source/VisualStudio.Extension/app.config
+++ b/source/VisualStudio.Extension/app.config
@@ -16,7 +16,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks.Dataflow" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.6.1.0" newVersion="4.6.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.5.25.0" newVersion="4.5.25.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Build.Utilities.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/source/VisualStudio.Extension/packages.config
+++ b/source/VisualStudio.Extension/packages.config
@@ -86,7 +86,7 @@
   <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net46" />
-  <package id="System.Threading.Tasks.Dataflow" version="4.8.0" targetFramework="net46" />
+  <package id="System.Threading.Tasks.Dataflow" version="4.5.25" targetFramework="net46" />
   <package id="System.Threading.Tasks.Extensions" version="4.4.0" targetFramework="net46" />
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="net46" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net46" />


### PR DESCRIPTION
## Description
Revert NuGet package to a version that works with VS extension.

## Motivation and Context
This DLL is on the list of the DLLs which are automatically excluded from a VSIX package.
The reason for that is because it's supposed to exist as part of the VS regular install.
Why is this relevant? If we compile the VS extension against a version higher then the one that exists on the target system it will fail when the VS extension is launched.
The alternative would be to manually add it to the vsix manifest.
As we are not taking any particular advantage from using the latest and greatest version, the safest approach is to use a version that is in the requirement list of another NuGet package. That would be Microsoft.VisualStudio.Composition.

## How Has This Been Tested?
- Deployed to VS experimental instance and confirmed to wrok.

## Types of changes
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
