### PR TITLE
Fix reboot condition evaluation in DeployProvider

### DIFF
--- a/source/VisualStudio.Extension/DeployProvider/DeployProvider.cs
+++ b/source/VisualStudio.Extension/DeployProvider/DeployProvider.cs
@@ -72,7 +72,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
             await outputPaneWriter.WriteLineAsync($"Getting things ready to deploy assemblies to nanoFramework device: {device.Description}.");
 
             // flag to signal if device has any assemblies deployed
-            bool hasAssembliesDeployed = device.DeviceInfo.Assemblies.Count() > 0 ? true : false;
+            bool hasAssembliesDeployed = device.DeviceInfo.Assemblies.Length > 0 ? true : false;
 
             List<byte[]> assemblies = new List<byte[]>();
 

--- a/source/VisualStudio.Extension/Properties/AssemblyInfo.cs
+++ b/source/VisualStudio.Extension/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.64.0")]
-[assembly: AssemblyFileVersion("0.1.64.0")]
+[assembly: AssemblyVersion("0.1.65.0")]
+[assembly: AssemblyFileVersion("0.1.65.0")]

--- a/source/VisualStudio.Extension/source.extension.vsixmanifest
+++ b/source/VisualStudio.Extension/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="47973986-ed3c-4b64-ba40-a9da73b44ef7" Version="0.1.64" Language="en-US" Publisher="nanoFramework" />
+    <Identity Id="47973986-ed3c-4b64-ba40-a9da73b44ef7" Version="0.1.65" Language="en-US" Publisher="nanoFramework" />
     <DisplayName>nanoFramework VS2017 Extension</DisplayName>
     <Description xml:space="preserve">Visual Studio 2017 extension for nanoFramework. Enables creating C# Solutions and provides debugging tools.</Description>
     <MoreInfo>http://www.nanoframework.net</MoreInfo>


### PR DESCRIPTION
## Description
- Reboot flag was using a Linq which was being evaluated too late providing wrong information
- Bump VS extension to V0.1.65.


## Motivation and Context
- Fixes wrong evaluation of boot option in deployment provider.

## How Has This Been Tested?<!-- (if applicable) -->
- Deployment of managed app in VS experimental instance.


## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
