### PR TITLE
Fix early breakpoint set

### DIFF
--- a/source/CSharp.BlankApplication/Program.cs
+++ b/source/CSharp.BlankApplication/Program.cs
@@ -8,8 +8,6 @@ namespace $safeprojectname$
     {
         public static void Main()
         {
-            Thread.Sleep(1000);  // Give some time to debugger to attach
-
             try
             {
                 // User code goes here

--- a/source/VisualStudio.Extension/CorDebug/CorDebug.cs
+++ b/source/VisualStudio.Extension/CorDebug/CorDebug.cs
@@ -130,7 +130,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 CorDebugProcess process = CorDebugProcess.CreateProcessEx(pPort, lpApplicationName, lpCommandLine, lpProcessAttributes, lpThreadAttributes, bInheritHandles, dwCreationFlags, lpEnvironment, lpCurrentDirectory, ref lpStartupInfo, ref lpProcessInformation, debuggingFlags);
 
                 // StartDebugging() will either get a connected device into a debuggable state and start the dispatch thread, or throw.
-                process.StartDebugging(this, false);
+                process.StartDebugging(this, true);
                 ppProcess = process;
 
                 return COM_HResults.S_OK;

--- a/source/VisualStudio.Extension/VisualStudio.Extension.csproj
+++ b/source/VisualStudio.Extension/VisualStudio.Extension.csproj
@@ -358,7 +358,7 @@
       <HintPath>..\packages\Microsoft.Win32.Primitives.4.3.0\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.Tools.Debugger, Version=0.5.0.0, Culture=neutral, PublicKeyToken=e520bb6b53f04733, processorArchitecture=MSIL">
-      <HintPath>..\packages\nanoFramework.Tools.Debugger.Net.0.5.0-preview066\lib\net46\nanoFramework.Tools.Debugger.dll</HintPath>
+      <HintPath>..\packages\nanoFramework.Tools.Debugger.Net.0.5.0-preview067\lib\net46\nanoFramework.Tools.Debugger.dll</HintPath>
     </Reference>
     <!-- reference this assembly when Configuration is Release (on Debug reference the project directly instead) -->
     <Reference Include="PresentationCore" />

--- a/source/VisualStudio.Extension/packages.config
+++ b/source/VisualStudio.Extension/packages.config
@@ -38,7 +38,7 @@
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net46" />
   <package id="MvvmLightLibs" version="5.3.0.0" targetFramework="net462" />
   <package id="nanoFramework.CoreLibrary" version="1.0.0-preview043" targetFramework="net46" developmentDependency="true" />
-  <package id="nanoFramework.Tools.Debugger.Net" version="0.5.0-preview066" targetFramework="net46" />
+  <package id="nanoFramework.Tools.Debugger.Net" version="0.5.0-preview067" targetFramework="net46" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net46" />
   <package id="PropertyChanged.Fody" version="2.1.4" targetFramework="net46" developmentDependency="true" />
   <package id="PropertyChanging.Fody" version="1.28.0" targetFramework="net462" developmentDependency="true" />


### PR DESCRIPTION
## Description
- Correct parameter in StartDebugging
- Rework AttachEngine to force connection only if required
- Assemblies are now loaded after device is in initialized state
- Update debugger library
- Update debugger submodule @acb29129
- Remove Thread.Sleep() workaround from application template

## Motivation and Context
- Fixe issue with breakpoints set in initial lines of code never being hit

## How Has This Been Tested?<!-- (if applicable) -->
- Performing debug on VS experimental instance

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>