### PR TITLE
Fix user options management and persistence

### DIFF
--- a/source/VisualStudio.Extension/MessageCentre/MessageCentre.cs
+++ b/source/VisualStudio.Extension/MessageCentre/MessageCentre.cs
@@ -9,7 +9,6 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using System;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 
 namespace nanoFramework.Tools.VisualStudio.Extension
 {
@@ -22,9 +21,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
         private static IVsOutputWindowPane _debugPane;
         private static IVsOutputWindowPane _nanoFrameworkMessagesPane;
         private static IVsStatusbar _statusBar;
-        private static bool _showInternalErrors;
         private static string _paneName;
-
 
         public static async System.Threading.Tasks.Task InitializeAsync(AsyncPackage package, string name)
         {
@@ -49,10 +46,6 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 _outputWindow.CreatePane(ref tempId, _paneName, 0, 1);
                 _outputWindow.GetPane(ref tempId, out _nanoFrameworkMessagesPane);
             });
-
-            // this one is true for now
-            // TODO expose setting
-            _showInternalErrors = true;
         }
 
         public static void DebugMessage(string message)
@@ -86,7 +79,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
         public static void InternalErrorMessage(bool assertion, string message, int skipFrames)
         {
-            if (!assertion && _showInternalErrors)
+            if (!assertion && NanoFrameworkPackage.OptionShowInternalErrors)
             {
                 message = String.IsNullOrEmpty(message) ? "Unknown Error" : message;
 

--- a/source/VisualStudio.Extension/ToolWindow.DeviceExplorer/DeviceExplorerControl.xaml.cs
+++ b/source/VisualStudio.Extension/ToolWindow.DeviceExplorer/DeviceExplorerControl.xaml.cs
@@ -28,8 +28,16 @@ namespace nanoFramework.Tools.VisualStudio.Extension
         {
             InitializeComponent();
 
+            Loaded += DeviceExplorerControl_Loaded;
+
             deviceTreeView.SelectedItemChanged += DevicesTreeView_SelectedItemChanged;
             Messenger.Default.Register<NotificationMessage>(this, DeviceExplorerViewModel.MessagingTokens.ForceSelectionOfNanoDevice, (message) => ForceSelectionOfNanoDeviceHandler());
+        }
+
+        private void DeviceExplorerControl_Loaded(object sender, System.Windows.RoutedEventArgs e)
+        {
+            // update the status of the control button
+            DeviceExplorerCommand.UpdateShowInternalErrorsButton(NanoFrameworkPackage.OptionShowInternalErrors);
         }
 
         private void Hyperlink_RequestNavigate(object sender, System.Windows.Navigation.RequestNavigateEventArgs e)


### PR DESCRIPTION
## Description
- User options are now persisted using the registry instead of the solution suo file
- Preference for OptionShowInternalErrors is not output to welcome message anymore
- Definitive fix for ShowInternalErrors button in Device Explorer

## Motivation and Context

## How Has This Been Tested?<!-- (if applicable) -->
_ VS experimental instance

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>