### PR TITLE
Improvements in debug start and  deploy provider

### DIFF
--- a/source/VisualStudio.Extension/DeployProvider/DeployProvider.cs
+++ b/source/VisualStudio.Extension/DeployProvider/DeployProvider.cs
@@ -33,7 +33,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
         private const int _numberOfRetries = 5;
 
         // timeout when performing a deploy operation
-        private const int _timeoutMiliseconds = 200;
+        private const int _timeoutMiliseconds = 500;
 
         private static ViewModelLocator _viewModelLocator;
 
@@ -102,7 +102,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
                     // handle the workflow required to try resuming the execution on the device
                     // only required if device is not already there
-                    // retry 5 times with a 200ms interval between retries
+                    // retry 5 times with a 500ms interval between retries
                     while (retryCount++ < _numberOfRetries && deviceIsInInitializeState)
                     {
                         if (!device.DebugEngine.IsDeviceInInitializeState())

--- a/source/VisualStudio.Extension/VisualStudio.Extension.csproj
+++ b/source/VisualStudio.Extension/VisualStudio.Extension.csproj
@@ -364,7 +364,7 @@
       <HintPath>..\packages\Microsoft.Win32.Primitives.4.3.0\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.Tools.Debugger, Version=0.5.0.0, Culture=neutral, PublicKeyToken=e520bb6b53f04733, processorArchitecture=MSIL">
-      <HintPath>..\packages\nanoFramework.Tools.Debugger.Net.0.5.0-preview095\lib\net46\nanoFramework.Tools.Debugger.dll</HintPath>
+      <HintPath>..\packages\nanoFramework.Tools.Debugger.Net.0.5.0-preview098\lib\net46\nanoFramework.Tools.Debugger.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/source/VisualStudio.Extension/VisualStudio.Extension.previous.nugetreferenceswitcher
+++ b/source/VisualStudio.Extension/VisualStudio.Extension.previous.nugetreferenceswitcher
@@ -1,1 +1,1 @@
-nanoFramework.Tools.DebugLibrary.Net	../../nf-debugger/source/nanoFramework.Tools.DebugLibrary.Net/nanoFramework.Tools.DebugLibrary.Net.csproj	../packages/nanoFramework.Tools.Debugger.Net.0.5.0-preview093/lib/net46/nanoFramework.Tools.Debugger.dll
+nanoFramework.Tools.DebugLibrary.Net	../../nf-debugger/source/nanoFramework.Tools.DebugLibrary.Net/nanoFramework.Tools.DebugLibrary.Net.csproj	../packages/nanoFramework.Tools.Debugger.Net.0.5.0-preview096/lib/net46/nanoFramework.Tools.Debugger.dll

--- a/source/VisualStudio.Extension/packages.config
+++ b/source/VisualStudio.Extension/packages.config
@@ -45,7 +45,7 @@
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net46" />
   <package id="MvvmLightLibs" version="5.4.1" targetFramework="net46" />
   <package id="nanoFramework.CoreLibrary" version="1.0.0-preview050" targetFramework="net46" developmentDependency="true" />
-  <package id="nanoFramework.Tools.Debugger.Net" version="0.5.0-preview095" targetFramework="net46" />
+  <package id="nanoFramework.Tools.Debugger.Net" version="0.5.0-preview098" targetFramework="net46" />
   <package id="NETStandard.Library" version="2.0.3" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net46" />
   <package id="PropertyChanged.Fody" version="2.5.6" targetFramework="net46" developmentDependency="true" />

--- a/source/VisualStudio.Extension/source.extension.vsixmanifest
+++ b/source/VisualStudio.Extension/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="47973986-ed3c-4b64-ba40-a9da73b44ef7" Version="0.3.9.1" Language="en-US" Publisher="nanoFramework" />
+    <Identity Id="47973986-ed3c-4b64-ba40-a9da73b44ef7" Version="0.5.0.0" Language="en-US" Publisher="nanoFramework" />
     <DisplayName>nanoFramework VS2017 Extension</DisplayName>
     <Description xml:space="preserve">Visual Studio 2017 extension for nanoFramework. Enables creating C# Solutions and provides debugging tools.</Description>
     <MoreInfo>http://www.nanoframework.net</MoreInfo>


### PR DESCRIPTION
## Description
- Increase retry timeout for deploy provider and AttachToEngine
- Remove forced detach from engine in AttachToEngine
- DetachFromEngine doesn't call engine stop anymore
- Update debugger Nuget to 0.5.0-preview098
- Update debugger sub-moldule @ 8c2dee3ad
- Increase extension version in manifest


## Motivation and Context


## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>