### PR TITLE
Improvements in deployment and debug start/stop

### DIFF
--- a/source/VisualStudio.Extension/CorDebug/DebugPortSupplier.cs
+++ b/source/VisualStudio.Extension/CorDebug/DebugPortSupplier.cs
@@ -26,22 +26,12 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
         private class DebugPortSupplierPrivate : DebugPortSupplier
         {                        
-            //private DebugPort[] _ports;
             private IDebugCoreServer2 _server;
             List<DebugPort> _ports = new List<DebugPort>();
 
             public DebugPortSupplierPrivate() : base(true)
             {
-
-                NanoDeviceBase device = NanoFrameworkPackage.NanoDeviceCommService.DebugClient.NanoFrameworkDevices[0];
-
-                _ports.Add(new DebugPort(device, this));
             }
-
-
-            //public DebugPortSupplierPrivate() : base(true)
-            //{
-            //}
 
             public override DebugPort FindPort(string name)
             {
@@ -70,10 +60,12 @@ namespace nanoFramework.Tools.VisualStudio.Extension
             new public int EnumPorts(out IEnumDebugPorts2 ppEnum)
             {
                 List<IDebugPort2> ports = new List<IDebugPort2>();
+                _ports.Clear();
 
-                foreach(NanoDeviceBase device in NanoFrameworkPackage.NanoDeviceCommService.DebugClient.NanoFrameworkDevices)
+                foreach (NanoDeviceBase device in NanoFrameworkPackage.NanoDeviceCommService.DebugClient.NanoFrameworkDevices)
                 {
                     ports.Add(new DebugPort(device, this));
+                    _ports.Add(new DebugPort(device, this));
                 }
 
                 ppEnum = new CorDebugEnum(ports, typeof(IDebugPort2), typeof(IEnumDebugPorts2));
@@ -82,6 +74,8 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
             new public int AddPort(IDebugPortRequest2 pRequest, out IDebugPort2 ppPort)
             {
+                IEnumDebugPorts2 portList;
+                EnumPorts(out portList);
 
                 string name;
                 pRequest.GetPortName(out name);
@@ -174,7 +168,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
         public int CanAddPort()
         {
-            return COM_HResults.S_FALSE;
+            return COM_HResults.S_OK;
         }
 
         public int GetPortSupplierName(out string name)

--- a/source/VisualStudio.Extension/NanoFrameworkPackage.cs
+++ b/source/VisualStudio.Extension/NanoFrameworkPackage.cs
@@ -84,6 +84,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
         private const string SHOW_INTERNAL_ERRORS_KEY = "ShowInternalErrors";
 
+        private static bool? s_OptionShowInternalErrors;
         /// <summary>
         /// User option for outputting internal extension errors to the extension output pane.
         /// The value is persisted per user.
@@ -93,13 +94,20 @@ namespace nanoFramework.Tools.VisualStudio.Extension
         {
             get
             {
-                return bool.Parse((string)s_instance.UserRegistryRoot.OpenSubKey(EXTENSION_SUBKEY).GetValue(SHOW_INTERNAL_ERRORS_KEY, "False"));
+                if (!s_OptionShowInternalErrors.HasValue)
+                {
+                    s_OptionShowInternalErrors = bool.Parse((string)s_instance.UserRegistryRoot.OpenSubKey(EXTENSION_SUBKEY).GetValue(SHOW_INTERNAL_ERRORS_KEY, "False"));
+                }
+
+                return s_OptionShowInternalErrors.Value;
             }
 
             set
             {
                 s_instance.UserRegistryRoot.OpenSubKey(EXTENSION_SUBKEY, true).SetValue(SHOW_INTERNAL_ERRORS_KEY, value);
                 s_instance.UserRegistryRoot.OpenSubKey(EXTENSION_SUBKEY, true).Flush();
+
+                s_OptionShowInternalErrors = value;
             }
         }
 

--- a/source/VisualStudio.Extension/ToolWindow.DeviceExplorer/DeviceExplorerCommand.cs
+++ b/source/VisualStudio.Extension/ToolWindow.DeviceExplorer/DeviceExplorerCommand.cs
@@ -221,7 +221,10 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 (sender as MenuCommand).Enabled = false;
 
                 // make sure this device is showing as selected in Device Explorer tree view
-                ViewModelLocator.DeviceExplorer.ForceNanoDeviceSelection().FireAndForget();
+                await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                {
+                    ViewModelLocator.DeviceExplorer.ForceNanoDeviceSelection();
+                });
 
                 // connect to the device
                 if (await NanoDeviceCommService.Device.DebugEngine.ConnectAsync(5000))
@@ -280,7 +283,10 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 (sender as MenuCommand).Enabled = false;
 
                 // make sure this device is showing as selected in Device Explorer tree view
-                ViewModelLocator.DeviceExplorer.ForceNanoDeviceSelection().FireAndForget();
+                await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                {
+                    ViewModelLocator.DeviceExplorer.ForceNanoDeviceSelection();
+                });
 
                 // only query device if it's different 
                 if (ViewModelLocator.DeviceExplorer.SelectedDevice.Description.GetHashCode() != ViewModelLocator.DeviceExplorer.LastDeviceConnectedHash)
@@ -406,7 +412,10 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 (sender as MenuCommand).Enabled = false;
 
                 // make sure this device is showing as selected in Device Explorer tree view
-                ViewModelLocator.DeviceExplorer.ForceNanoDeviceSelection().FireAndForget();
+                await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                {
+                    ViewModelLocator.DeviceExplorer.ForceNanoDeviceSelection();
+                });
 
                 // connect to the device
                 if (await NanoDeviceCommService.Device.DebugEngine.ConnectAsync(5000))
@@ -483,7 +492,10 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 (sender as MenuCommand).Enabled = false;
 
                 // make sure this device is showing as selected in Device Explorer tree view
-                ViewModelLocator.DeviceExplorer.ForceNanoDeviceSelection().FireAndForget();
+                await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                {
+                    ViewModelLocator.DeviceExplorer.ForceNanoDeviceSelection();
+                });
 
                 // connect to the device
                 if (await NanoDeviceCommService.Device.DebugEngine.ConnectAsync(5000))
@@ -558,7 +570,10 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 (sender as MenuCommand).Enabled = false;
 
                 // make sure this device is showing as selected in Device Explorer tree view
-                ViewModelLocator.DeviceExplorer.ForceNanoDeviceSelection().FireAndForget();
+                await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                {
+                    ViewModelLocator.DeviceExplorer.ForceNanoDeviceSelection();
+                });
 
                 // connect to the device
                 if (await NanoDeviceCommService.Device.DebugEngine.ConnectAsync(5000))

--- a/source/VisualStudio.Extension/ToolWindow.DeviceExplorer/ViewModel/DeviceExplorerViewModel.cs
+++ b/source/VisualStudio.Extension/ToolWindow.DeviceExplorer/ViewModel/DeviceExplorerViewModel.cs
@@ -127,29 +127,20 @@ namespace nanoFramework.Tools.VisualStudio.Extension.ToolWindow.ViewModel
             switch (SelectedTransportType)
             {
                 case Debugger.WireProtocol.TransportType.Serial:
-                    //BusySrv.ShowBusy(Res.GetString("HC_Searching"));
                     AvailableDevices = new ObservableCollection<NanoDeviceBase>(NanoDeviceCommService.DebugClient.NanoFrameworkDevices);
                     NanoDeviceCommService.DebugClient.NanoFrameworkDevices.CollectionChanged += NanoFrameworkDevices_CollectionChanged;
-                    //NanoDeviceCommService.SerialDebugClient.NanoFrameworkDevicesCollectionChanged += NanoDeviceCommService_NanoFrameworkDevicesCollectionChanged;
-                    //BusySrv.HideBusy();
                     break;
 
                 case Debugger.WireProtocol.TransportType.Usb:
-                    //BusySrv.ShowBusy(Res.GetString("HC_Searching"));
                     //AvailableDevices = new ObservableCollection<NanoDeviceBase>(UsbDebugService.NanoFrameworkDevices);
                     //NanoDeviceCommService.NanoFrameworkDevicesCollectionChanged += NanoDeviceCommService_NanoFrameworkDevicesCollectionChanged;
-                    // if there's just one, select it
-                    //SelectedDevice = (AvailableDevices.Count == 1) ? AvailableDevices.First() : null;
-                    //BusySrv.HideBusy();
                     break;
 
                 case Debugger.WireProtocol.TransportType.TcpIp:
                     // TODO
-                    //BusySrv.ShowBusy("Not implemented yet! Why not give it a try??");
                     //await Task.Delay(2500);
                     //    AvailableDevices = new ObservableCollection<NanoDeviceBase>();
                     //    SelectedDevice = null;
-                    //BusySrv.HideBusy();
                     break;
             }
 
@@ -162,7 +153,10 @@ namespace nanoFramework.Tools.VisualStudio.Extension.ToolWindow.ViewModel
                     // is there a single device
                     if (AvailableDevices.Count == 1)
                     {
-                        ForceNanoDeviceSelection(AvailableDevices[0]).FireAndForget();
+                        ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                        {
+                            ForceNanoDeviceSelection(AvailableDevices[0]);
+                        });
                     }
                 }
             }
@@ -198,7 +192,10 @@ namespace nanoFramework.Tools.VisualStudio.Extension.ToolWindow.ViewModel
                     if (deviceToReSelect != null)
                     {
                         // device seems to be back online, select it
-                        ForceNanoDeviceSelection(deviceToReSelect).FireAndForget();
+                        ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                        {
+                            ForceNanoDeviceSelection(deviceToReSelect);
+                        });
 
                         // clear device to reselect
                         DeviceToReSelect = null;
@@ -210,7 +207,10 @@ namespace nanoFramework.Tools.VisualStudio.Extension.ToolWindow.ViewModel
                     // is there a single device
                     if (AvailableDevices.Count == 1)
                     {
-                        ForceNanoDeviceSelection(AvailableDevices[0]).FireAndForget();
+                        ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                        {
+                            ForceNanoDeviceSelection(AvailableDevices[0]);
+                        });
                     }
                     else
                     {
@@ -218,17 +218,18 @@ namespace nanoFramework.Tools.VisualStudio.Extension.ToolWindow.ViewModel
                         if (SelectedDevice != null)
                         {
                             // maintain selection
-                            ForceNanoDeviceSelection(AvailableDevices.FirstOrDefault(d => d.Description == SelectedDevice.Description)).FireAndForget();
+                            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                            {
+                                ForceNanoDeviceSelection(AvailableDevices.FirstOrDefault(d => d.Description == SelectedDevice.Description));
+                            });
                         }
                     }
                 }
             }
         }
 
-        private async Task ForceNanoDeviceSelection(NanoDeviceBase nanoDevice)
+        private void ForceNanoDeviceSelection(NanoDeviceBase nanoDevice)
         {
-            await Task.Delay(100);
-
             // select the device
             SelectedDevice = nanoDevice;
 
@@ -236,10 +237,8 @@ namespace nanoFramework.Tools.VisualStudio.Extension.ToolWindow.ViewModel
             MessengerInstance.Send(new NotificationMessage(""), MessagingTokens.ForceSelectionOfNanoDevice);
         }
 
-        public async Task ForceNanoDeviceSelection()
+        public void  ForceNanoDeviceSelection()
         {
-            await Task.Delay(100);
-
             // request forced selection of device in UI
             MessengerInstance.Send(new NotificationMessage(""), MessagingTokens.ForceSelectionOfNanoDevice);
         }

--- a/source/VisualStudio.Extension/VisualStudio.Extension.csproj
+++ b/source/VisualStudio.Extension/VisualStudio.Extension.csproj
@@ -364,7 +364,7 @@
       <HintPath>..\packages\Microsoft.Win32.Primitives.4.3.0\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.Tools.Debugger, Version=0.5.0.0, Culture=neutral, PublicKeyToken=e520bb6b53f04733, processorArchitecture=MSIL">
-      <HintPath>..\packages\nanoFramework.Tools.Debugger.Net.0.5.0-preview098\lib\net46\nanoFramework.Tools.Debugger.dll</HintPath>
+      <HintPath>..\packages\nanoFramework.Tools.Debugger.Net.0.5.0-preview102\lib\net46\nanoFramework.Tools.Debugger.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/source/VisualStudio.Extension/VisualStudio.Extension.previous.nugetreferenceswitcher
+++ b/source/VisualStudio.Extension/VisualStudio.Extension.previous.nugetreferenceswitcher
@@ -1,1 +1,1 @@
-nanoFramework.Tools.DebugLibrary.Net	../../nf-debugger/source/nanoFramework.Tools.DebugLibrary.Net/nanoFramework.Tools.DebugLibrary.Net.csproj	../packages/nanoFramework.Tools.Debugger.Net.0.5.0-preview096/lib/net46/nanoFramework.Tools.Debugger.dll
+nanoFramework.Tools.DebugLibrary.Net	../../nf-debugger/source/nanoFramework.Tools.DebugLibrary.Net/nanoFramework.Tools.DebugLibrary.Net.csproj	../packages/nanoFramework.Tools.Debugger.Net.0.5.0-preview101/lib/net46/nanoFramework.Tools.Debugger.dll

--- a/source/VisualStudio.Extension/packages.config
+++ b/source/VisualStudio.Extension/packages.config
@@ -45,7 +45,7 @@
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net46" />
   <package id="MvvmLightLibs" version="5.4.1" targetFramework="net46" />
   <package id="nanoFramework.CoreLibrary" version="1.0.0-preview050" targetFramework="net46" developmentDependency="true" />
-  <package id="nanoFramework.Tools.Debugger.Net" version="0.5.0-preview098" targetFramework="net46" />
+  <package id="nanoFramework.Tools.Debugger.Net" version="0.5.0-preview102" targetFramework="net46" />
   <package id="NETStandard.Library" version="2.0.3" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net46" />
   <package id="PropertyChanged.Fody" version="2.5.6" targetFramework="net46" developmentDependency="true" />


### PR DESCRIPTION
## Description
- Improve sanity check of native assemblies in DeployProvider (doesn't require call to GetDeviceInfo() anymore)
- Clean-up CorDebugProcess from unused methods and fields
- Remove repeated calls to connect and attach methods in debug start sequence
- Improve OnProcessExit code
- StopDebugging on CorDebugProcess now forces reboot of target (required to solve memory leaks caused by forced execution end)
- Package OptionShowInternalErrors is now getting the value from a nullable backing field (getting it from the registry was throwing exception on VS shutdown)
- Improve code in DeviceExplorer view model with non async messaging tasks
- Rework DebugPortSuplier to update availale ports on debug launch (was locked to the first device available when the constructor was called)
- Clean up code in DeviceExplorer view model
- Remove duplicate v char in executable version output on deployment provider
- Update debugger Nuget to 0.5.0-preview102
- Update debugger sub-moldule @ 955c5f0a


## Motivation and Context
- Fixes infamous VS error 0x8004005 on deployment
- Resolves nanoFramework/Home#342

## How Has This Been Tested?<!-- (if applicable) -->
- VS experimental instance


## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
