### PR TITLE
Rework stub generation handling

### DIFF
--- a/source/VisualStudio.Extension/Rules/NanoFrameworkPropertyPage.xaml
+++ b/source/VisualStudio.Extension/Rules/NanoFrameworkPropertyPage.xaml
@@ -6,7 +6,7 @@
 	Description="nanoFramework specific properties"
 	xmlns="http://schemas.microsoft.com/build/2009/properties">
     <Rule.DataSource>
-        <DataSource Persistence="ProjectFile" Label="NanoFramework" SourceOfDefaultValue="AfterContext"/>
+        <DataSource Persistence="ProjectFile" Label="nanoFramework" SourceOfDefaultValue="AfterContext"/>
     </Rule.DataSource>
 
     <Rule.Categories>
@@ -17,36 +17,41 @@
     </Rule.Categories>
 
     <!-- General category properties -->
-    <BoolProperty Category="General" Name="NFMDP_STUB_SKIP" DisplayName="Generate stub files" Visible="True" ReverseSwitch="True" Default="true" Description="Enable this to generate stub files during build.">
+    <BoolProperty Category="General" Name="NF_GenerateStubs" DisplayName="Generate stub files" Visible="True" Default="false" Description="Enable this to generate stub files during build.">
         <BoolProperty.DataSource>
-            <DataSource Persistence="ProjectFile" Label="NanoFramework" PersistedName="NFMDP_STUB_SKIP" HasConfigurationCondition="False" />
+            <DataSource Persistence="ProjectFile" Label="nanoFramework" PersistedName="NF_GenerateStubs" HasConfigurationCondition="False" />
         </BoolProperty.DataSource>
     </BoolProperty>
-    <StringProperty Category="General" Name="NFMDP_STUB_DESTINATION" Subtype="Folder" DisplayName="Destination of stub files" Visible="True" Default="$(ProjectDir)$(IntermediateOutputPath)" Description="Destination folder for the stub.">
+    <StringProperty Category="General" Name="NF_GenerateStubsRootName" Subtype="Folder" DisplayName="Root name for stub files" Visible="True" Default="$(TargetName)" Description="Root name for stub files.">
         <StringProperty.DataSource>
-            <DataSource Persistence="ProjectFile" Label="NanoFramework" PersistedName="NFMDP_STUB_DESTINATION" HasConfigurationCondition="False" />
+            <DataSource Persistence="ProjectFile" Label="nanoFramework" PersistedName="NF_GenerateStubsRootName" HasConfigurationCondition="False" />
+        </StringProperty.DataSource>
+    </StringProperty>    
+    <StringProperty Category="General" Name="NF_GenerateStubsDirectory" Subtype="Folder" DisplayName="Destination of stub files" Visible="True" Default="$(ProjectDir)$(IntermediateOutputPath)" Description="Destination folder for the stub.">
+        <StringProperty.DataSource>
+            <DataSource Persistence="ProjectFile" Label="nanoFramework" PersistedName="NF_GenerateStubsDirectory" HasConfigurationCondition="False" />
         </StringProperty.DataSource>
     </StringProperty>
 
     <!-- Advanced category properties -->
-    <BoolProperty Category="Advanced" Name="NFMDP_DUMP_SKIP" DisplayName="Generate dump files" Visible="True" ReverseSwitch="True"  Default="true" Description="Enable this to generate dump files during build.">
+    <BoolProperty Category="Advanced" Name="NFMDP_DUMP_FILES" DisplayName="Generate dump files" Visible="True" Default="false" Description="Enable this to generate dump files during build.">
         <BoolProperty.DataSource>
-            <DataSource Persistence="ProjectFile" Label="NanoFramework" PersistedName="NFMDP_DUMP_SKIP" HasConfigurationCondition="False" />
+            <DataSource Persistence="ProjectFile" Label="nanoFramework" PersistedName="NFMDP_DUMP_FILES" HasConfigurationCondition="False" />
         </BoolProperty.DataSource>
     </BoolProperty>
-    <BoolProperty Category="Advanced" Name="NFMDP_DAT_SKIP" DisplayName="Generate .dat files" Visible="True" ReverseSwitch="True" Default="true" Description="Enable this to generate .dat files during build.">
+    <BoolProperty Category="Advanced" Name="NFMDP_DAT_FILES" DisplayName="Generate .dat files" Visible="True" Default="false" Description="Enable this to generate .dat files during build.">
         <BoolProperty.DataSource>
-            <DataSource Persistence="ProjectFile" Label="NanoFramework" PersistedName="NFMDP_DAT_SKIP" HasConfigurationCondition="False" />
+            <DataSource Persistence="ProjectFile" Label="nanoFramework" PersistedName="NFMDP_DAT_FILES" HasConfigurationCondition="False" />
         </BoolProperty.DataSource>
     </BoolProperty>
-    <BoolProperty Category="Advanced" Name="NFMDP_XML_SKIP" DisplayName="Generate XML files" Visible="True" ReverseSwitch="True" Default="true" Description="Enable this to generate XML files during build.">
+    <BoolProperty Category="Advanced" Name="NFMDP_XML_FILES" DisplayName="Generate XML files" Visible="True" Default="false" Description="Enable this to generate XML files during build.">
         <BoolProperty.DataSource>
-            <DataSource Persistence="ProjectFile" Label="NanoFramework" PersistedName="NFMDP_XML_SKIP" HasConfigurationCondition="False" />
+            <DataSource Persistence="ProjectFile" Label="nanoFramework" PersistedName="NFMDP_XML_FILES" HasConfigurationCondition="False" />
         </BoolProperty.DataSource>
     </BoolProperty>
     <BoolProperty Category="Advanced" Name="NFMDP_CMD_LINE_OUTPUT" DisplayName="Output MDP command line" Visible="True" Default="false" Description="Enable this to output a verbose output of the command lines sent to MetaDataProcessor. (Only usefull for debugging the command execution)">
         <BoolProperty.DataSource>
-            <DataSource Persistence="ProjectFile" Label="NanoFramework" PersistedName="NFMDP_CMD_LINE_OUTPUT" HasConfigurationCondition="True" />
+            <DataSource Persistence="UserFile" Label="nanoFramework" PersistedName="NFMDP_CMD_LINE_OUTPUT" HasConfigurationCondition="True" />
         </BoolProperty.DataSource>
     </BoolProperty>
 

--- a/source/VisualStudio.Extension/Targets/NFProjectSystem.MDP.targets
+++ b/source/VisualStudio.Extension/Targets/NFProjectSystem.MDP.targets
@@ -263,7 +263,7 @@
     <NFMDP_PE_DumpAll>$(ProjectDir)$(IntermediateOutputPath)$(TargetName)_all.txt</NFMDP_PE_DumpAll>
 
     <!-- nanoFramework MetaDataProcessor DUMP options -->
-    <NFMDP_DUMP_SKIP>false</NFMDP_DUMP_SKIP>
+    <NFMDP_DUMP_FILES>true</NFMDP_DUMP_FILES>
     <NFMDP_DUMP_DumpAll>$(ProjectDir)$(IntermediateOutputPath)$(TargetName).dump</NFMDP_DUMP_DumpAll>
 
     <!-- nanoFramework MetaDataProcessor STUB options -->
@@ -344,7 +344,7 @@
         $(NFMDP_PE_GenerateDependency)"
 
     DependsOnTargets="ResolveRuntimeDependencies"
-    Condition="'$(NFMDP_PE_SKIP)' != 'true'">
+    Condition="'$(NFMDP_GENERATE_PE)' == 'true'">
 
     <ItemGroup>
       <NFMDP_PE_CreatedFiles Include="$(NFMDP_PE_CreateDatabaseFile)" Condition="'$(NFMDP_PE_CreateDatabaseFile)'!=''"/>
@@ -361,7 +361,7 @@
 
     <PropertyGroup>
       <!-- correct path for stubs output if set -->
-      <NFMDP_STUB_GenerateSkeletonFile Condition="'$(NFMDP_STUB_SKIP)' != 'true' AND '$(NFMDP_STUB_GenerateSkeletonFile)'!=''">$(ProjectDir)$(OutDir)$(NFMDP_STUB_GenerateSkeletonFile)</NFMDP_STUB_GenerateSkeletonFile>
+      <NFMDP_STUB_GenerateSkeletonFile Condition="'$(NFMDP_GENERATE_STUBS)' == 'true' AND '$(NFMDP_STUB_GenerateSkeletonFile)'!=''">$(ProjectDir)$(OutDir)$(NFMDP_STUB_GenerateSkeletonFile)</NFMDP_STUB_GenerateSkeletonFile>
     </PropertyGroup>
 
     <ItemGroup>
@@ -369,7 +369,7 @@
       <NFMDP_STUB_CreatedFiles Include="$(NFMDP_STUB_GenerateSkeletonFile)"  Condition="'$(NFMDP_STUB_GenerateSkeletonFile)'!=''"/>
       <NFMDP_STUB_CreatedFiles Include="$(NFMDP_STUB_GenerateDependency)"  Condition="'$(NFMDP_STUB_GenerateDependency)'!=''"/>
     </ItemGroup>
-    <MakeDir Directories="@(NFMDP_STUB_CreatedFiles->'%(RootDir)%(Directory)')" Condition="'$(NFMDP_STUB_SKIP)' != 'true'"/>
+    <MakeDir Directories="@(NFMDP_STUB_CreatedFiles->'%(RootDir)%(Directory)')" Condition="'$(NFMDP_GENERATE_STUBS)' == 'true'"/>
 
     <PropertyGroup>
       <NFMDP_STUB_GenerateSkeletonProject Condition="'$(NFMDP_STUB_GenerateSkeletonProject)'==''" >$(AssemblyName)</NFMDP_STUB_GenerateSkeletonProject>
@@ -441,7 +441,7 @@
       LoadDatabase="@(NFMDP_STUB_LoadDatabase)"
       ExcludeClassByName="@(NFMDP_STUB_ExcludeClassByName)"
       OutputCommandLine="$(NFMDP_CMD_LINE_OUTPUT)"
-      Condition="'$(NFMDP_STUB_SKIP)' != 'true'">
+      Condition="'$(NFMDP_GENERATE_STUBS)' == 'true'">
 
       <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
 
@@ -481,7 +481,7 @@
         $(NFMDP_DAT_RefreshAssemblyOutput);
         $(NFMDP_DAT_CreateDatabaseFile);
         $(NFMDP_DAT_GenerateDependency)"
-    Condition="'$(NFMDP_DAT_SKIP)' != 'true'">
+    Condition="'$(NFMDP_DAT_FILES)' == 'true'">
 
     <CallTarget Targets="MetaDataProcessorDat_MSG" Condition="'$(NFMDP_DAT_Verbose)'=='true'" />
 
@@ -541,7 +541,7 @@
         $(NFMDP_XML_RefreshAssemblyOutput);
         $(NFMDP_XML_CreateDatabaseFile);
         $(NFMDP_XML_GenerateDependency)"
-    Condition="'$(NFMDP_XML_SKIP)' != 'true'">
+    Condition="'$(NFMDP_XML_FILES)' == 'true'">
 
     <Message Text="Creating dependency map $(NFMDP_XML_GenerateDependency)..." />
 
@@ -663,7 +663,7 @@
         $(NFMDP_DUMP_RefreshAssemblyOutput);
         $(NFMDP_DUMP_CreateDatabaseFile);
         $(NFMDP_DUMP_GenerateDependency)"
-    Condition="'$(NFMDP_DUMP_SKIP)' != 'true'"
+    Condition="'$(NFMDP_DUMP_FILES)' == 'true'"
     >
     <!-- Create DUMP file -->
     <MetaDataProcessorTask
@@ -777,9 +777,6 @@
       GenerateSkeletonName="$(TargetName)"
       GenerateSkeletonFile="$(NF_GenerateSkeletonFile)"
       GenerateSkeletonProject="$(NF_GenerateSkeletonProjectName)"
-      RefreshAssemblyName="$(AssemblyName)"
-      RefreshAssemblyOutput="$(NanoFramework_IntermediateAssembly).pe"
-      Resolve="true"
       OutputCommandLine="$(NFMDP_CMD_LINE_OUTPUT)">
 
       <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>

--- a/source/VisualStudio.Extension/Targets/NFProjectSystem.props
+++ b/source/VisualStudio.Extension/Targets/NFProjectSystem.props
@@ -28,20 +28,20 @@
 
   <!-- set default NF properties for CoreLibrary project -->
   <PropertyGroup Condition="'$(NF_IsCoreLibrary)' == 'True' ">
-    <NFMDP_PE_SKIP Condition="'$(NFMDP_PE_SKIP)'==''">false</NFMDP_PE_SKIP>
-    <NFMDP_DUMP_SKIP Condition="'$(NFMDP_DUMP_SKIP)'==''">false</NFMDP_DUMP_SKIP>
-    <NFMDP_STUB_SKIP Condition="'$(NFMDP_STUB_SKIP)'==''">false</NFMDP_STUB_SKIP>
-    <NFMDP_DAT_SKIP Condition="'$(NFMDP_DAT_SKIP)'==''">false</NFMDP_DAT_SKIP>
-    <NFMDP_XML_SKIP Condition="'$(NFMDP_XML_SKIP)'==''">false</NFMDP_XML_SKIP>
+    <NFMDP_GENERATE_PE Condition="'$(NFMDP_GENERATE_PE)'==''">true</NFMDP_GENERATE_PE>
+    <NFMDP_DUMP_FILES Condition="'$(NFMDP_DUMP_FILES)'==''">true</NFMDP_DUMP_FILES>
+    <NFMDP_GENERATE_STUBS Condition="'$(NFMDP_GENERATE_STUBS)'==''">true</NFMDP_GENERATE_STUBS>
+    <NFMDP_DAT_FILES Condition="'$(NFMDP_DAT_FILES)'==''">true</NFMDP_DAT_FILES>
+    <NFMDP_XML_FILES Condition="'$(NFMDP_XML_FILES)'==''">true</NFMDP_XML_FILES>
   </PropertyGroup>
 
   <!-- set default NF properties for regular project (not CoreLibrary) -->
   <PropertyGroup Condition="'$(NF_IsCoreLibrary)' != 'True' Or '$(NF_IsCoreLibrary)' == '' ">
-    <NFMDP_PE_SKIP Condition="'$(NFMDP_PE_SKIP)'==''">true</NFMDP_PE_SKIP>
-    <NFMDP_DUMP_SKIP Condition="'$(NFMDP_DUMP_SKIP)'==''">true</NFMDP_DUMP_SKIP>
-    <NFMDP_STUB_SKIP Condition="'$(NFMDP_STUB_SKIP)'==''">true</NFMDP_STUB_SKIP>
-    <NFMDP_DAT_SKIP Condition="'$(NFMDP_DAT_SKIP)'==''">true</NFMDP_DAT_SKIP>
-    <NFMDP_XML_SKIP Condition="'$(NFMDP_XML_SKIP)'==''">true</NFMDP_XML_SKIP>
+    <NFMDP_GENERATE_PE Condition="'$(NFMDP_GENERATE_PE)'==''">false</NFMDP_GENERATE_PE>
+    <NFMDP_DUMP_FILES Condition="'$(NFMDP_DUMP_FILES)'==''">false</NFMDP_DUMP_FILES>
+    <NFMDP_GENERATE_STUBS Condition="'$(NFMDP_GENERATE_STUBS)'==''">false</NFMDP_GENERATE_STUBS>
+    <NFMDP_DAT_FILES Condition="'$(NFMDP_DAT_FILES)'==''">false</NFMDP_DAT_FILES>
+    <NFMDP_XML_FILES Condition="'$(NFMDP_XML_FILES)'==''">false</NFMDP_XML_FILES>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## Description
- Rename and invert several msbuild properties to make it's use intuitive (were being used negated which was confusing)
- Rework nF project properties page accordingly
- Rework nF project properties page to properly set the msbuild options to generate interop stubs
- Correct case name of label to match project name


# ⚠️  BREAKING CHANGES ⚠️
The following project properties have changed their name which will cause unwanted results, such the project stubs not being generated:
- NFMDP_PE_SKIP  >>  NFMDP_GENERATE_PE
- NFMDP_DUMP_SKIP >> NFMDP_DUMP_FILES
- NFMDP_STUB_SKIP >> NFMDP_GENERATE_STUBS
- NFMDP_DAT_SKIP >> NFMDP_DAT_FILES
- NFMDP_XML_SKIP >> NFMDP_XML_FILES)


## Motivation and Context
- Improves usability
- Fixes nanoFramework/Home#315

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
