### PR TITLE
Fix issue with launch command line

### DIFF
--- a/source/VisualStudio.Extension/DebugLauncher/NanoDebuggerLaunchProvider.cs
+++ b/source/VisualStudio.Extension/DebugLauncher/NanoDebuggerLaunchProvider.cs
@@ -75,53 +75,57 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
             cb.AddArguments("/waitfordebugger");
 
-            ///////////////////////////////////////////////////////
-            // get the list of assemblies referenced by the project
-            var referencedAssemblies = await Properties.ConfiguredProject.Services.AssemblyReferences.GetResolvedReferencesAsync();
+            // For a known project output assembly path, this shall contain the corresponding
+            // ConfiguredProject:
+            Dictionary<string, ConfiguredProject> configuredProjectsByOutputAssemblyPath =
+                new Dictionary<string, ConfiguredProject>();
 
-            //////////////////////////////////////////////////////////////////////////
-            // get the list of other projects referenced by the project being deployed
-            var referencedProjects = await Properties.ConfiguredProject.Services.ProjectReferences.GetResolvedReferencesAsync();
+            // For a known ConfiguredProject, this shall contain the corresponding project output assembly
+            // path:
+            Dictionary<ConfiguredProject, string> outputAssemblyPathsByConfiguredProject =
+                new Dictionary<ConfiguredProject, string>();
 
-            /////////////////////////////////////////////////////////
-            // get the target path to reach the PE for the executable
 
-            //... we need to access the target path using reflection (step by step)
-            // get type for ConfiguredProject
-            var projSystemType = Properties.ConfiguredProject.GetType();
+            // Fill these two dictionaries for all projects contained in the solution
+            // (whether they belong to the deployment or not):
+            await ReferenceCrawler.CollectProjectsAndOutputAssemblyPathsAsync(
+                ProjectService,
+                configuredProjectsByOutputAssemblyPath,
+                outputAssemblyPathsByConfiguredProject);
 
-            // get private property MSBuildProject
-            var buildProject = projSystemType.GetTypeInfo().GetDeclaredProperty("MSBuildProject");
+            // This HashSet shall contain a list of full paths to all assemblies to be deployed, including
+            // the compiled output assemblies of our solution's project and also all assemblies such as
+            // NuGet packages referenced by those projects.
+            // The HashSet will take care of only containing any string once even if added multiple times.
+            // However, this is dependent on getting all paths always in the same casing.
+            // Be aware that on file systems which ignore casing, we would end up having assemblies added
+            // more than once here if the GetFullPathAsync() methods used below should not always reliably
+            // return the path to the same assembly in the same casing.
+            HashSet<string> assemblyPathsToDeploy = new HashSet<string>();
 
-            // get value of MSBuildProject property from ConfiguredProject object
-            // this result is of type Microsoft.Build.Evaluation.Project
-            var projectResult = await ((System.Threading.Tasks.Task<Microsoft.Build.Evaluation.Project>)buildProject.GetValue(Properties.ConfiguredProject));
+            // Starting with the startup project, collect all assemblies to be deployed.
+            // This will only add assemblies of projects which are actually referenced directly or
+            // indirectly by the startup project. Any project in the solution which is not referenced
+            // directly or indirectly by the startup project will not be included in the list of assemblies
+            // to be deployed.
+            await ReferenceCrawler.CollectAssembliesToDeployAsync(
+                configuredProjectsByOutputAssemblyPath,
+                outputAssemblyPathsByConfiguredProject,
+                assemblyPathsToDeploy,
+                Properties.ConfiguredProject);
 
-            // we want the target path property
-            var targetPath = projectResult.Properties.First(p => p.Name == "TargetPath").EvaluatedValue;
 
             // build a list with the full path for each DLL, referenced DLL and EXE
             List<string> assemblyList = new List<string>();
 
-            foreach (IAssemblyReference reference in referencedAssemblies)
+            foreach (string assemblyPath in assemblyPathsToDeploy)
             {
-                assemblyList.Add(await reference.GetFullPathAsync());
+                assemblyList.Add(assemblyPath);
             }
 
-            // loop through each project that is set to build
-            foreach (IBuildDependencyProjectReference project in referencedProjects)
-            {
-                if (await project.GetReferenceOutputAssemblyAsync())
-                {
-                    assemblyList.Add(await project.GetFullPathAsync());
-                }
-            }
-
-            // now add the executable to this list
-            assemblyList.Add(targetPath);
-
+            // if there are referenced project, the assembly list contains repeated assemblies so need to use Linq Distinct()
             // build a list with the PE files corresponding to each DLL and EXE
-            List<string> peCollection = assemblyList.Select(a => a.Replace(".dll", ".pe").Replace(".exe", ".pe")).ToList();
+            List<string> peCollection = assemblyList.Distinct().Select(a => a.Replace(".dll", ".pe").Replace(".exe", ".pe")).ToList();
 
             foreach (string peFile in peCollection)
             {

--- a/source/VisualStudio.Extension/DeployProvider/DeployProvider.cs
+++ b/source/VisualStudio.Extension/DeployProvider/DeployProvider.cs
@@ -166,7 +166,8 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
                         // Fill these two dictionaries for all projects contained in the solution
                         // (whether they belong to the deployment or not):
-                        await CollectProjectsAndOutputAssemblyPathsAsync(
+                        await ReferenceCrawler.CollectProjectsAndOutputAssemblyPathsAsync(
+                            ProjectService,
                             configuredProjectsByOutputAssemblyPath, 
                             outputAssemblyPathsByConfiguredProject);
 
@@ -185,7 +186,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                         // indirectly by the startup project. Any project in the solution which is not referenced
                         // directly or indirectly by the startup project will not be included in the list of assemblies
                         // to be deployed.
-                        await CollectAssembliesToDeployAsync(
+                        await ReferenceCrawler.CollectAssembliesToDeployAsync(
                             configuredProjectsByOutputAssemblyPath,
                             outputAssemblyPathsByConfiguredProject,
                             assemblyPathsToDeploy,
@@ -274,130 +275,6 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
                 throw new Exception("Unexpected error. Please retry the deployment. If the situation persists reboot the device.");
             }
-        }
-
-        /// <summary>
-        /// Fills two dictionaries with the <see cref="ConfiguredProject"/> objects and their compiled output full path
-        /// to make either one findable if we know the other one.
-        /// </summary>
-        /// <param name="configuredProjectsByOutputAssemblyPath">A dictionary to be filled for getting a
-        /// <see cref="ConfiguredProject"/> object by its output assembly path.</param>
-        /// <param name="outputAssemblyPathsByConfiguredProject">A dictionary to be filled for getting the compiled
-        /// output path for a given <see cref="ConfiguredProject"/> object.</param>
-        /// <returns>The task to be awaited.</returns>
-        private async Task CollectProjectsAndOutputAssemblyPathsAsync(
-            Dictionary<string, ConfiguredProject> configuredProjectsByOutputAssemblyPath,
-            Dictionary<ConfiguredProject, string> outputAssemblyPathsByConfiguredProject)
-        {
-            // Loop through all projects which exist in the solution:
-            foreach (UnconfiguredProject unconfiguredProject in ProjectService.LoadedUnconfiguredProjects)
-            {
-                // Get the right "configured" project, that is, the project in, for example, Debug/AnyCPU:
-                ConfiguredProject configuredProject = await unconfiguredProject.GetSuggestedConfiguredProjectAsync();
-
-                if (configuredProject != null)
-                {
-                    string path = await GetProjectOutputPathAsync(configuredProject);
-
-                    configuredProjectsByOutputAssemblyPath.Add(path, configuredProject);
-                    outputAssemblyPathsByConfiguredProject.Add(configuredProject, path);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Recursively steps down from a given project down by its referenced projects to collect the full paths of
-        /// all assemblies which are used and thus need to be deployed, including the compiled output assemblies of the
-        /// project as well as natively referenced assemblies such as NuGet packages used by the projects.
-        /// </summary>
-        /// <param name="configuredProjectsByOutputAssemblyPath">A filled dictionary over all
-        /// <see cref="ConfiguredProject">ConfiguredProjects</see> in the solution indexed by their compiled output
-        /// paths.</param>
-        /// <param name="outputAssemblyPathsByConfiguredProject">A filled dictionary indexing all
-        /// <see cref="ConfiguredProject">ConfiguredProjects</see> in the solution to find their compiled output paths.
-        /// </param>
-        /// <param name="assemblyPathsToDeploy">The set of full paths of all assemblies to be deployed which gets filled
-        /// by this method.</param>
-        /// <param name="project">The <see cref="ConfiguredProject"/> to start with. It gets added including its native
-        /// references such as NuGet packages, and all of its directly or indirectly referenced projects get collected
-        /// also.</param>
-        /// <returns>The task to be awaited.</returns>
-        private async Task CollectAssembliesToDeployAsync(
-            Dictionary<string, ConfiguredProject> configuredProjectsByOutputAssemblyPath,
-            Dictionary<ConfiguredProject, string> outputAssemblyPathsByConfiguredProject,
-            HashSet<string> assemblyPathsToDeploy,
-            ConfiguredProject project)
-        {
-            string path;
-
-            // Get the full path to the compiled assembly of this project by looking in the already collected
-            // dictionary:
-            path = outputAssemblyPathsByConfiguredProject[project];
-
-            // Did we process this assembly already?
-            if (assemblyPathsToDeploy.Add(path))
-            {
-                // We did not process this assembly yet, but now its output assembly path is included for deployment.
-
-                // Collect the paths to all referenced assemblies of the configured project, such as NuGet references:
-                foreach (IAssemblyReference assemblyReference in
-                         await project.Services.AssemblyReferences.GetResolvedReferencesAsync())
-                {
-                    // As assemblyPathsToDeploy is a HashSet, the same path will not occure more than once even if added
-                    // more than once by distinct projects referencing the same NuGet package for example.
-                    assemblyPathsToDeploy.Add(await assemblyReference.GetFullPathAsync());
-                }
-
-                // Recursively process referenced projects in the solution:
-                foreach (IBuildDependencyProjectReference projectReference in
-                         await project.Services.ProjectReferences.GetResolvedReferencesAsync())
-                {
-                    // Get the path to the compiled output assembly of this project reference:
-                    path = await projectReference.GetFullPathAsync();
-
-                    // There should be a configured project for that path. As we collected all ConfiguredProjects and
-                    // their output paths in advance, we can find the project by using the corresponding Dictionary.
-                    if (configuredProjectsByOutputAssemblyPath.ContainsKey(path))
-                    {
-                        
-                        // Recursively process this referenced project to collect what assemblies it consists of:
-                        await CollectAssembliesToDeployAsync(
-                            configuredProjectsByOutputAssemblyPath, 
-                            outputAssemblyPathsByConfiguredProject, 
-                            assemblyPathsToDeploy, 
-                            configuredProjectsByOutputAssemblyPath[path]);
-
-                    }
-                    else
-                    {
-                        // If this ever happens, check whether the "same" path does come along in different casing.
-                        // If so, consider improving this code to correctly handle that case.
-                        throw new DeploymentException($"No ConfiguredProject found for output assembly path: {path}");
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        /// Gets the full path to the compiled output of a <see cref="ConfiguredProject"/>.
-        /// </summary>
-        /// <param name="project">The <see cref="ConfiguredProject"/> whose full ouput assembly path is wanted.</param>
-        /// <returns>The full path of the compiled output assembly of the <paramref name="project"/>.</returns>
-        private async System.Threading.Tasks.Task<string> GetProjectOutputPathAsync(ConfiguredProject project)
-        {
-            //... we need to access the target path using reflection (step by step)
-            // get type for ConfiguredProject
-            var projSystemType = project.GetType();
-
-            // get private property MSBuildProject
-            var buildProject = projSystemType.GetTypeInfo().GetDeclaredProperty("MSBuildProject");
-
-            // get value of MSBuildProject property from ConfiguredProject object
-            // this result is of type Microsoft.Build.Evaluation.Project
-            var projectResult = await ((System.Threading.Tasks.Task<Microsoft.Build.Evaluation.Project>)buildProject.GetValue(project));
-
-            // we want the target path property
-            return projectResult.Properties.First(p => p.Name == "TargetPath").EvaluatedValue;
         }
 
         private async System.Threading.Tasks.Task<string> CheckNativeAssembliesAvailabilityAsync(List<CLRCapabilities.NativeAssemblyProperties> nativeAssemblies, List<(string path, string version)> peCollection)

--- a/source/VisualStudio.Extension/Utilities/ReferenceCrawler.cs
+++ b/source/VisualStudio.Extension/Utilities/ReferenceCrawler.cs
@@ -1,0 +1,144 @@
+﻿//
+// Copyright (c) 2018 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.VisualStudio.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.References;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace nanoFramework.Tools.VisualStudio.Extension
+{
+    public class ReferenceCrawler
+    {
+
+        /// <summary>
+        /// Fills two dictionaries with the <see cref="ConfiguredProject"/> objects and their compiled output full path
+        /// to make either one findable if we know the other one.
+        /// </summary>
+        /// <param name="configuredProjectsByOutputAssemblyPath">A dictionary to be filled for getting a
+        /// <see cref="ConfiguredProject"/> object by its output assembly path.</param>
+        /// <param name="outputAssemblyPathsByConfiguredProject">A dictionary to be filled for getting the compiled
+        /// output path for a given <see cref="ConfiguredProject"/> object.</param>
+        /// <returns>The task to be awaited.</returns>
+        public static async Task CollectProjectsAndOutputAssemblyPathsAsync(
+            IProjectService projectService,
+            Dictionary<string, ConfiguredProject> configuredProjectsByOutputAssemblyPath,
+            Dictionary<ConfiguredProject, string> outputAssemblyPathsByConfiguredProject)
+        {
+            // Loop through all projects which exist in the solution:
+            foreach (UnconfiguredProject unconfiguredProject in projectService.LoadedUnconfiguredProjects)
+            {
+                // Get the right "configured" project, that is, the project in, for example, Debug/AnyCPU:
+                ConfiguredProject configuredProject = await unconfiguredProject.GetSuggestedConfiguredProjectAsync();
+
+                if (configuredProject != null)
+                {
+                    string path = await GetProjectOutputPathAsync(configuredProject);
+
+                    configuredProjectsByOutputAssemblyPath.Add(path, configuredProject);
+                    outputAssemblyPathsByConfiguredProject.Add(configuredProject, path);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Recursively steps down from a given project down by its referenced projects to collect the full paths of
+        /// all assemblies which are used and thus need to be deployed, including the compiled output assemblies of the
+        /// project as well as natively referenced assemblies such as NuGet packages used by the projects.
+        /// </summary>
+        /// <param name="configuredProjectsByOutputAssemblyPath">A filled dictionary over all
+        /// <see cref="ConfiguredProject">ConfiguredProjects</see> in the solution indexed by their compiled output
+        /// paths.</param>
+        /// <param name="outputAssemblyPathsByConfiguredProject">A filled dictionary indexing all
+        /// <see cref="ConfiguredProject">ConfiguredProjects</see> in the solution to find their compiled output paths.
+        /// </param>
+        /// <param name="assemblyPathsToDeploy">The set of full paths of all assemblies to be deployed which gets filled
+        /// by this method.</param>
+        /// <param name="project">The <see cref="ConfiguredProject"/> to start with. It gets added including its native
+        /// references such as NuGet packages, and all of its directly or indirectly referenced projects get collected
+        /// also.</param>
+        /// <returns>The task to be awaited.</returns>
+        public static async Task CollectAssembliesToDeployAsync(
+            Dictionary<string, ConfiguredProject> configuredProjectsByOutputAssemblyPath,
+            Dictionary<ConfiguredProject, string> outputAssemblyPathsByConfiguredProject,
+            HashSet<string> assemblyPathsToDeploy,
+            ConfiguredProject project)
+        {
+            string path;
+
+            // Get the full path to the compiled assembly of this project by looking in the already collected
+            // dictionary:
+            path = outputAssemblyPathsByConfiguredProject[project];
+
+            // Did we process this assembly already?
+            if (assemblyPathsToDeploy.Add(path))
+            {
+                // We did not process this assembly yet, but now its output assembly path is included for deployment.
+
+                // Collect the paths to all referenced assemblies of the configured project, such as NuGet references:
+                foreach (IAssemblyReference assemblyReference in
+                         await project.Services.AssemblyReferences.GetResolvedReferencesAsync())
+                {
+                    // As assemblyPathsToDeploy is a HashSet, the same path will not occure more than once even if added
+                    // more than once by distinct projects referencing the same NuGet package for example.
+                    assemblyPathsToDeploy.Add(await assemblyReference.GetFullPathAsync());
+                }
+
+                // Recursively process referenced projects in the solution:
+                foreach (IBuildDependencyProjectReference projectReference in
+                         await project.Services.ProjectReferences.GetResolvedReferencesAsync())
+                {
+                    // Get the path to the compiled output assembly of this project reference:
+                    path = await projectReference.GetFullPathAsync();
+
+                    // There should be a configured project for that path. As we collected all ConfiguredProjects and
+                    // their output paths in advance, we can find the project by using the corresponding Dictionary.
+                    if (configuredProjectsByOutputAssemblyPath.ContainsKey(path))
+                    {
+
+                        // Recursively process this referenced project to collect what assemblies it consists of:
+                        await CollectAssembliesToDeployAsync(
+                            configuredProjectsByOutputAssemblyPath,
+                            outputAssemblyPathsByConfiguredProject,
+                            assemblyPathsToDeploy,
+                            configuredProjectsByOutputAssemblyPath[path]);
+
+                    }
+                    else
+                    {
+                        // If this ever happens, check whether the "same" path does come along in different casing.
+                        // If so, consider improving this code to correctly handle that case.
+                        throw new DeploymentException($"No ConfiguredProject found for output assembly path: {path}");
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the full path to the compiled output of a <see cref="ConfiguredProject"/>.
+        /// </summary>
+        /// <param name="project">The <see cref="ConfiguredProject"/> whose full ouput assembly path is wanted.</param>
+        /// <returns>The full path of the compiled output assembly of the <paramref name="project"/>.</returns>
+        public static async Task<string> GetProjectOutputPathAsync(ConfiguredProject project)
+        {
+            //... we need to access the target path using reflection (step by step)
+            // get type for ConfiguredProject
+            var projSystemType = project.GetType();
+
+            // get private property MSBuildProject
+            var buildProject = projSystemType.GetTypeInfo().GetDeclaredProperty("MSBuildProject");
+
+            // get value of MSBuildProject property from ConfiguredProject object
+            // this result is of type Microsoft.Build.Evaluation.Project
+            var projectResult = await ((Task<Microsoft.Build.Evaluation.Project>)buildProject.GetValue(project));
+
+            // we want the target path property
+            return projectResult.Properties.First(p => p.Name == "TargetPath").EvaluatedValue;
+        }
+    }
+}

--- a/source/VisualStudio.Extension/VisualStudio.Extension.csproj
+++ b/source/VisualStudio.Extension/VisualStudio.Extension.csproj
@@ -144,6 +144,7 @@
     <Compile Include="ToolWindow.DeviceExplorer\ViewModel\DeviceExplorerViewModel.cs" />
     <Compile Include="ToolWindow.DeviceExplorer\ViewModel\IDataService.cs" />
     <Compile Include="ToolWindow.DeviceExplorer\ViewModel\ViewModelLocator.cs" />
+    <Compile Include="Utilities\ReferenceCrawler.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\packages\nanoFramework.CoreLibrary.1.0.0-preview062\nanoFramework.CoreLibrary.1.0.0-preview062.nupkg">


### PR DESCRIPTION
## Description
- The command line wasn't being properly build with nested referenced projects. Because the loaded assemblies path list was incomplete some assemblyes were missing causing the debugger engine to crash VS
- Create new class ReferenceCrawler. Moved relevant methods there to allow reuse from deploy and launch providers

## Motivation and Context
- Fixes nanoFramework/Home#378

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
