### PR TITLE
Binary output file is now processed in msbuild task

### DIFF
--- a/source/Tools.BuildTasks/GenerateBinaryOutputTask.cs
+++ b/source/Tools.BuildTasks/GenerateBinaryOutputTask.cs
@@ -1,0 +1,77 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Text;
+namespace nanoFramework.Tools
+{
+    [Description("GenerateBinaryOutputTaskEntry")]
+
+    public class GenerateBinaryOutputTask : Task
+    {
+        #region public properties for the task
+
+        public string Assembly { get; set; }
+
+        public string AssemblyPE { get; set; }
+
+        public ITaskItem[] AssemblyReferences { get; set; }
+
+
+        /// <summary>
+        /// The name(s) of binary file created.
+        /// </summary>
+        [Output]
+        public ITaskItem FileWritten { get; private set; }
+
+        #endregion
+
+        public override bool Execute()
+        {
+            // report to VS output window what step the build is 
+            Log.LogMessage(MessageImportance.Normal, "Generating binary output file...");
+
+            // default with null, indicating that we've generated nothing
+            FileWritten = null;
+
+            // get paths for PE files
+            // rename extension .dll with .pe
+            List<string> peCollection = new List<string>();
+            peCollection = AssemblyReferences?.Select(a => { return a.GetMetadata("FullPath").Replace(".dll", ".pe").Replace(".exe", ".pe"); }).ToList();
+
+            // add executable PE
+            peCollection.Add(AssemblyPE);
+
+            // get executable path and file name
+            // rename executable extension .exe with .bin
+            var binOutputFile = Assembly.Replace(".exe", ".bin");
+
+            using (FileStream binFile = new FileStream(binOutputFile, FileMode.Create))
+            {
+                // now we will re-deploy all system assemblies
+                foreach (string peItem in peCollection)
+                {
+                    // append to the deploy blob the assembly
+                    using (FileStream fs = File.Open(peItem, FileMode.Open, FileAccess.Read))
+                    {
+                        long length = (fs.Length + 3) / 4 * 4;
+                        byte[] buffer = new byte[length];
+
+                        fs.Read(buffer, 0, (int)fs.Length);
+
+                        // copy this assembly to the bin file too
+                        binFile.Write(buffer, 0, (int)length);
+                    }
+                }
+            }
+
+            // bin file written
+            FileWritten = new TaskItem(binOutputFile);
+
+            return true;
+        }
+    }
+}

--- a/source/Tools.BuildTasks/Tools.BuildTasks.csproj
+++ b/source/Tools.BuildTasks/Tools.BuildTasks.csproj
@@ -48,6 +48,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="GenerateBinaryOutputTask.cs" />
     <Compile Include="MetaDataProcessorTask.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Extensions\CommandLineBuilderExtensions.cs" />

--- a/source/VisualStudio.Extension/DeployProvider/DeployProvider.cs
+++ b/source/VisualStudio.Extension/DeployProvider/DeployProvider.cs
@@ -78,8 +78,6 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
             List<byte[]> assemblies = new List<byte[]>();
 
-            FileStream binFile = null;
-
             // device needs to be in 'initialized state' for a successful and correct deployment 
             // meaning that is not running nor stopped
             int retryCount = 0;
@@ -218,13 +216,6 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                         // Keep track of total assembly size
                         long totalSizeOfAssemblies = 0;
 
-                        // get path to executable
-                        var pathToExe = await ReferenceCrawler.GetProjectOutputPathAsync(Properties.ConfiguredProject);
-                        // rename executable extension with .bin
-                        pathToExe = pathToExe.Replace(".exe", ".bin");
-                        // create bin file 
-                        binFile = new FileStream(pathToExe, FileMode.Create);
-
                         // now we will re-deploy all system assemblies
                         foreach ((string path, string version) peItem in peCollection)
                         {
@@ -237,9 +228,6 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
                                 await fs.ReadAsync(buffer, 0, (int)fs.Length);
                                 assemblies.Add(buffer);
-
-                                // copy this assembly to the bin file too
-                                await binFile.WriteAsync(buffer, 0, (int)length);
 
                                 // Increment totalizer
                                 totalSizeOfAssemblies += length;
@@ -260,9 +248,6 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
                         // deployment successful
                         await outputPaneWriter.WriteLineAsync("Deployment successful.");
-
-                        // output message about bin file
-                        await outputPaneWriter.WriteLineAsync($"Wrote '{Path.GetFileName(pathToExe)}' binary file to output folder.");
 
                         // reset the hash for the connected device so the deployment information can be refreshed
                         _viewModelLocator.DeviceExplorer.LastDeviceConnectedHash = 0;
@@ -289,17 +274,6 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 MessageCentre.InternalErrorMessage($"Unhandled exception with deployment provider: {ex.Message}.");
 
                 throw new Exception("Unexpected error. Please retry the deployment. If the situation persists reboot the device.");
-            }
-            finally
-            {
-                // flush & dispose bin file
-                if (binFile != null)
-                {
-                    // flush the bin file to disk and...
-                    await binFile.FlushAsync();
-                    // ... dispose the stream
-                    binFile.Dispose();
-                }
             }
         }
 

--- a/source/VisualStudio.Extension/Targets/NFProjectSystem.MDP.targets
+++ b/source/VisualStudio.Extension/Targets/NFProjectSystem.MDP.targets
@@ -7,6 +7,7 @@
   <UsingTask TaskName="MetaDataProcessorTask"             AssemblyFile="$(MSBuildThisFileDirectory)nanoFramework.Tools.BuildTasks.dll" />
   <UsingTask TaskName="ResolveRuntimeDependenciesTask"    AssemblyFile="$(MSBuildThisFileDirectory)nanoFramework.Tools.BuildTasks.dll" />
   <UsingTask TaskName="GenerateNanoResourceTask"          AssemblyFile="$(MSBuildThisFileDirectory)nanoFramework.Tools.BuildTasks.dll" />
+  <UsingTask TaskName="GenerateBinaryOutputTask"          AssemblyFile="$(MSBuildThisFileDirectory)nanoFramework.Tools.BuildTasks.dll" />
 
   <!-- 
     ###########################################################
@@ -105,7 +106,7 @@
     <Delete Condition="EXISTS('$(ProjectDir)$(OutDir)$(TargetName).pdbx')" Files="$(ProjectDir)$(OutDir)$(TargetName).pdbx" />
   </Target>
 
-  <Target Name="CopyToOutDir" >
+  <Target Name="CopyToOutDir">
     <Copy
         Condition="Exists('$(ProjectDir)$(IntermediateOutputPath)$(TargetName).exe')"
         SourceFiles="$(ProjectDir)$(IntermediateOutputPath)$(TargetName).exe"
@@ -121,6 +122,12 @@
     <Copy
         Condition="Exists('$(ProjectDir)$(IntermediateOutputPath)$(TargetName).pdbx')"
         SourceFiles="$(ProjectDir)$(IntermediateOutputPath)$(TargetName).pdbx"
+        DestinationFolder="$(ProjectDir)$(OutDir)" >
+      <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
+    </Copy>
+    <Copy
+        Condition="Exists('$(ProjectDir)$(IntermediateOutputPath)$(TargetName).bin')"
+        SourceFiles="$(ProjectDir)$(IntermediateOutputPath)$(TargetName).bin"
         DestinationFolder="$(ProjectDir)$(OutDir)" >
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
     </Copy>
@@ -190,6 +197,8 @@
 
     <!--CallTarget is less than ideal... NF_GeneratedStubFile isn't a complete list...-->
     <CallTarget Targets="GenerateStubs" Condition="'$(NF_GenerateStubs)'=='true'" />
+
+    <CallTarget Targets="NanoGenerateBinaryOutput"/>
 
   </Target>
 
@@ -830,4 +839,16 @@
       />
   </Target>
 
+  <Target Name="NanoGenerateBinaryOutput">
+
+    <GenerateBinaryOutputTask
+        AssemblyPE="$(NanoFramework_IntermediateAssembly).pe"
+        Assembly="$(NanoFramework_Assembly)$(TargetExt)"
+        AssemblyReferences="@(ReferencePath);@(ReferenceDependencyPaths)">
+
+      <Output TaskParameter="FileWritten" ItemName="FileWrites" />
+    </GenerateBinaryOutputTask>
+
+  </Target>
+  
 </Project>


### PR DESCRIPTION
## Description
- Remove code from DeployProvider.
- Update MDP.targets to accomodate this.
- Add new build task: GenerateBinaryOutputTask.

## Motivation and Context
- The previous approach required that a valid target was present. Plus it was part of the deploy workflow which was a bit of a stretch and in violation of the separation of concerns principle (one could need the binary file without necessarily deploy anything to a connected target).

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
