### PR TITLE
Add Windows version check on extension load

### DIFF
--- a/source/VisualStudio.Extension/NanoFrameworkPackage.cs
+++ b/source/VisualStudio.Extension/NanoFrameworkPackage.cs
@@ -237,6 +237,18 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 MessageCentre.OutputMessage("Star our GitHub repos: https://github.com/nanoframework/Home");
                 MessageCentre.OutputMessage("Add a short review or rate the VS extension: https://marketplace.visualstudio.com/items?itemName=vs-publisher-1470366.nanoFrameworkVS2017Extension");
                 MessageCentre.OutputMessage(Environment.NewLine);
+
+                // check Windows version
+                if(Environment.OSVersion.Version < new Version(6, 2, 9200, 0))
+                {
+                    // this is running on a Windows version lower than Windows 10
+                    MessageCentre.OutputMessage(Environment.NewLine);
+                    MessageCentre.OutputMessage("*************************************************************************");
+                    MessageCentre.OutputMessage("** Seems that you are running this on a Window version earlier than 10 **");
+                    MessageCentre.OutputMessage("** nanoFramework debug engine component requires Windows 10            **");
+                    MessageCentre.OutputMessage("*************************************************************************");
+                    MessageCentre.OutputMessage(Environment.NewLine);
+                }
             });
         }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
- Checks Windows version when extension is loaded. In case it's running on a Windows machine earlier than Windows 10 outputs a warning message to the user. This can save some frustration when trying to use it on a wrong Windows version.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
