### PR TITLE
Add task to copy referenced DLLs to obj folder

### DIFF
--- a/source/VisualStudio.Extension/Targets/NFProjectSystem.MDP.targets
+++ b/source/VisualStudio.Extension/Targets/NFProjectSystem.MDP.targets
@@ -80,7 +80,8 @@
     <PrepareForRunDependsOn>
       MetaDataProcessor;
       CopyFilesToOutputDirectory;
-      CopyNanoFrameworkFiles
+      CopyNanoFrameworkFiles;
+      CopyBackNanoFrameworkDlls
     </PrepareForRunDependsOn>
 
     <PrepareResourcesDependsOn>
@@ -170,6 +171,18 @@
         SourceFiles="@(ReferenceCopyLocalPaths->'%(RootDir)%(Directory)%(Filename).pdbx')"
         DestinationFiles="@(ReferenceCopyLocalPaths->'$(OutDir)%(DestinationSubDirectory)%(Filename).pdbx')"
         SkipUnchangedFiles="true">
+      <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
+    </Copy>
+
+  </Target>
+
+  <Target Name="CopyBackNanoFrameworkDlls" >
+
+    <Copy
+        SourceFiles="@(ReferenceCopyLocalPaths)"
+        DestinationFiles="@(ReferenceCopyLocalPaths->'$(IntermediateOutputPath)%(Filename)%(Extension)')"
+        SkipUnchangedFiles="false"
+            >
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
     </Copy>
 
@@ -459,6 +472,7 @@
     <!-- Copy files (dll, pe, pdb and pdbx) to ouput directory -->
     <CallTarget Targets="CopyFilesToOutputDirectory" />
     <CallTarget Targets="CopyNanoFrameworkFiles" />
+    <CallTarget Targets="CopyBackNanoFrameworkDlls" />
   </Target>
 
 


### PR DESCRIPTION
## Description
- Add new task to MDP targets.

## Motivation and Context
- Required for Babel obfuscator to find referenced libraries.


## How Has This Been Tested?<!-- (if applicable) -->
- Building Blinky sample in experimental instance and checking that the referenced DLLs are present in the obj folder.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
