### PR TITLE
Fix deployment issue with repeated assemblies

### DIFF
--- a/source/VisualStudio.Extension/DeployProvider/DeploymentAssembly.cs
+++ b/source/VisualStudio.Extension/DeployProvider/DeploymentAssembly.cs
@@ -1,0 +1,21 @@
+﻿//
+// Copyright (c) 2019 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using System.Collections.Generic;
+
+namespace nanoFramework.Tools.VisualStudio.Extension
+{
+    public class DeploymentAssembly
+    {
+        public string Path { get; set; }
+        public string Version { get; set; }
+
+        public DeploymentAssembly(string path, string version)
+        {
+            Path = path;
+            Version = version;
+        }
+    }
+}

--- a/source/VisualStudio.Extension/DeployProvider/DeploymentAssemblyDistinctEquality.cs
+++ b/source/VisualStudio.Extension/DeployProvider/DeploymentAssemblyDistinctEquality.cs
@@ -1,0 +1,32 @@
+﻿//
+// Copyright (c) 2019 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using System.Collections.Generic;
+
+namespace nanoFramework.Tools.VisualStudio.Extension
+{
+    internal class DeploymentAssemblyDistinctEquality : IEqualityComparer<DeploymentAssembly>
+    {
+        public bool Equals(DeploymentAssembly assembly1, DeploymentAssembly assembly2)
+        {
+            var name1 = System.IO.Path.GetFileName(assembly1.Path);
+            var name2 = System.IO.Path.GetFileName(assembly2.Path);
+
+            if ((name1 == name2) && (assembly1.Version == assembly2.Version))
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public int GetHashCode(DeploymentAssembly assembly)
+        {
+            return System.IO.Path.GetFileName(assembly.Path).GetHashCode() ^ assembly.Version.GetHashCode();
+        }
+    }
+}

--- a/source/VisualStudio.Extension/VisualStudio.Extension.csproj
+++ b/source/VisualStudio.Extension/VisualStudio.Extension.csproj
@@ -102,6 +102,8 @@
     <Compile Include="CorDebug\Pdbx.cs" />
     <Compile Include="CorDebug\PdbxFile.cs" />
     <Compile Include="CorDebug\ProcessExitException.cs" />
+    <Compile Include="DeployProvider\DeploymentAssembly.cs" />
+    <Compile Include="DeployProvider\DeploymentAssemblyDistinctEquality.cs" />
     <Compile Include="DeployProvider\DeploymentException.cs" />
     <Compile Include="IPMaskedTextBox\IPMaskedTextBox.xaml.cs">
       <DependentUpon>IPMaskedTextBox.xaml</DependentUpon>


### PR DESCRIPTION
## Description
- Add new class DeploymentAssembly.
- Improve code in DeployProvider to correctly filter distinct assemblies.

## Motivation and Context
- The current implementation with Linq Distinct() was not filtering assemblies in different locations thus causing repeated items in the deployment blob.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
