### PR TITLE
Fix copy of referenced assemblies marked with CopyLocal

### DIFF
--- a/source/VisualStudio.Extension/Targets/NFProjectSystem.MDP.targets
+++ b/source/VisualStudio.Extension/Targets/NFProjectSystem.MDP.targets
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <!-- Declares the MSBuild tasks that are provided by nanoFramework tools.
@@ -156,21 +156,21 @@
         that are marked as CopyLocal. A couple of notes.  @(ReferenceCopyLocalPaths) can contain the
         .dll and .pdb files, so there is likely duplicate copying going on here: the copy command
         is a little smart, but we are still doing a bit more work than necessary.
-        Also, if the pdbx files are in a separate directory from the .dll, then this may fail.
-        I haven't tried yet.
+        The ContinueOnError set to true is required because the local paths on the referenced file contain the extension.
+        This would cause the task to fail because it would be trying to copy myreferenced.dll.pe and myreferenced.dll.pbx, which obviously don't exit.
         -->
 
     <Copy
         SourceFiles="@(ReferenceCopyLocalPaths->'%(RootDir)%(Directory)%(Filename).pe')"
         DestinationFiles="@(ReferenceCopyLocalPaths->'$(OutDir)%(DestinationSubDirectory)%(Filename).pe')"
-        SkipUnchangedFiles="true" >
+        SkipUnchangedFiles="true" ContinueOnError="true" >
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
     </Copy>
 
     <Copy
         SourceFiles="@(ReferenceCopyLocalPaths->'%(RootDir)%(Directory)%(Filename).pdbx')"
         DestinationFiles="@(ReferenceCopyLocalPaths->'$(OutDir)%(DestinationSubDirectory)%(Filename).pdbx')"
-        SkipUnchangedFiles="true">
+        SkipUnchangedFiles="true" ContinueOnError="true">
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
     </Copy>
 


### PR DESCRIPTION
## Description
- Fix copy of referenced assemblies marked with CopyLocal.

## Motivation and Context
- This task was failing on projects that use "out-of-project" path for the output folder and referenced assemblies marked with CopyLocal.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
