### PR TITLE
Fix bad handling of devices collection

### DIFF
--- a/source/VisualStudio.Extension/ToolWindow.DeviceExplorer/DeviceExplorerCommand.cs
+++ b/source/VisualStudio.Extension/ToolWindow.DeviceExplorer/DeviceExplorerCommand.cs
@@ -692,6 +692,9 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
             NanoDeviceCommService.DebugClient.ReScanDevices();
 
+            // need to remove event handler
+            NanoDeviceCommService.DebugClient.NanoFrameworkDevices.CollectionChanged -= ViewModelLocator.DeviceExplorer.NanoFrameworkDevices_CollectionChanged;
+
             // don't enable the button here to prevent compulsive developers to click it when the operation is still ongoing
             // it will be enabled back at NanoDevicesCollectionChangedHandlerAsync
         }
@@ -731,6 +734,9 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 MessageCentre.InternalErrorMessage("Stopping device watchers.");
 
                 NanoDeviceCommService.DebugClient.StopDeviceWatchers();
+
+                // need to remove event handler
+                NanoDeviceCommService.DebugClient.NanoFrameworkDevices.CollectionChanged -= ViewModelLocator.DeviceExplorer.NanoFrameworkDevices_CollectionChanged;
 
                 MessageCentre.OutputMessage(Environment.NewLine);
                 MessageCentre.OutputMessage("*******************************************************************************");

--- a/source/VisualStudio.Extension/ToolWindow.DeviceExplorer/ViewModel/DeviceExplorerViewModel.cs
+++ b/source/VisualStudio.Extension/ToolWindow.DeviceExplorer/ViewModel/DeviceExplorerViewModel.cs
@@ -168,7 +168,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension.ToolWindow.ViewModel
             }
         }
 
-        private void NanoFrameworkDevices_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        public void NanoFrameworkDevices_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
         {
             // handle this according to the selected device type 
             switch (SelectedTransportType)


### PR DESCRIPTION
## Description
- After adding the device watcher and rescan feature the devices collection was not being properly managed as every new arrival/rescan/reenable was adding more devices to the existing collection and adding a new event handler on top of the existing ones.

## How Has This Been Tested?<!-- (if applicable) -->
- Tested by adding and removing devices on Visual Studio Experimental Instance.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: sjmneves <sergio.neves@eclo.solutions>
