### PR TITLE
Improve attach to engine step

### DIFF
--- a/source/VisualStudio.Extension/CorDebug/CorDebugProcess.cs
+++ b/source/VisualStudio.Extension/CorDebug/CorDebugProcess.cs
@@ -408,21 +408,18 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                         _engine.OnProcessExit += new EventHandler(OnProcessExit);
                     }
 
-                    MessageCentre.InternalErrorMessage($"Attempting to connect to device ({retry + 1}/{ maxOperationRetries }).");
+                    MessageCentre.InternalErrorMessage($"Attempting to update device debugger flags ({retry + 1}/{ maxOperationRetries }).");
 
-                    var connect = ThreadHelper.JoinableTaskFactory.Run(
-                        async () =>
-                        {
-                           return await  _engine.ConnectAsync(retrySleepTime, true, ConnectionSource.Unknown);
-                        }
-                    );
-
-                    if (connect)
+                    if (_engine.UpdateDebugFlags())
                     {
                         _engine.ThrowOnCommunicationFailure = true;
                         _engine.SetExecutionMode(Commands.DebuggingExecutionChangeConditions.State.SourceLevelDebugging, 0);
 
                         break;
+                    }
+                    else
+                    {
+                        MessageCentre.InternalErrorMessage($"Error update device debugger flags.");
                     }
 
                     Thread.Yield();


### PR DESCRIPTION
## Description
- Improve attach to engine step.

## Motivation and Context
- When the execution reach that point the target has been connected for ages. The existing approach was an heritage of the times where connecting to a target and keeping the connection was really hard. Right now a operation to update the debugger flags is all it takes to validate the connection and move forward. Calling ConnectAsync was a performance killer and completely useless.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
