### PR TITLE
Remove deployment workaround for ESP32

### DIFF
--- a/source/VisualStudio.Extension/DeployProvider/DeployProvider.cs
+++ b/source/VisualStudio.Extension/DeployProvider/DeployProvider.cs
@@ -103,18 +103,6 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                     {
                         MessageCentre.InternalErrorMessage("Erase deployment area successful.");
 
-                        // ESP32 tends to be a bit stubborn to start a debug session 
-                        // fully rebooting the device after erasing seems to improves this behaviour
-                        if (device.DebugEngine.Capabilities.SolutionReleaseInfo.targetVendorInfo.Contains("ESP32"))
-                        {
-                            // this makes sure that we are connecting to the device debugger engine after the CLR reboots following the deployment erase
-                            device.Ping();
-
-                            MessageCentre.InternalErrorMessage("Request full reboot of nanoDevice.");
-
-                            device.DebugEngine.RebootDevice(RebootOptions.NormalReboot);
-                        }
-
                         // initial check 
                         if (device.DebugEngine.IsDeviceInInitializeState())
                         {


### PR DESCRIPTION
## Description
- Remove deployment workaround for ESP32.

## Motivation and Context
- After the last improvements in erase memory and disabling the SmartConfig thread, the deployment on ESP32 devices does not require this anymore.

## How Has This Been Tested?<!-- (if applicable) -->
- Several deployments test in VS experimental instance.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>