### PR TITLE
Add check for Windows version on extension load

### DIFF
--- a/source/VisualStudio.Extension/NanoFrameworkPackage.cs
+++ b/source/VisualStudio.Extension/NanoFrameworkPackage.cs
@@ -20,6 +20,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows;
 
 [assembly: ProjectTypeRegistration(projectTypeGuid: NanoFrameworkPackage.ProjectTypeGuid,
                                 displayName: "NanoCSharpProject",
@@ -191,39 +192,47 @@ namespace nanoFramework.Tools.VisualStudio.Extension
         {
             await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
-                // make sure "our" key exists and it's writeable
-                s_instance.UserRegistryRoot.CreateSubKey(EXTENSION_SUBKEY, true);
-
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-
-                AddService(typeof(NanoDeviceCommService), CreateNanoDeviceCommServiceAsync);
-
-                NanoDeviceCommService = await GetServiceAsync(typeof(NanoDeviceCommService)) as INanoDeviceCommService;
-
-                // Need to add the View model Locator to the application resource dictionary programmatically 
-                // because at the extension level we don't have 'XAML' access to it
-                // try to find if the view model locator is already in the app resources dictionary
-                if (System.Windows.Application.Current.TryFindResource("Locator") == null)
+                // check Windows version
+                if (Environment.OSVersion.Version.Major < 10)
                 {
-                    // instantiate the view model locator...
-                    ViewModelLocator = new ViewModelLocator();
-
-                    // ... and add it there
-                    System.Windows.Application.Current.Resources.Add("Locator", ViewModelLocator);
+                    // the extension won't run properly if we are not on Windows 10, warn user
+                    MessageBox.Show("nanoFramework Extension requires Windows 10!", "nanoFramework extension", MessageBoxButton.OK, MessageBoxImage.Error);
                 }
+                else
+                {
+                    // make sure "our" key exists and it's writeable
+                    s_instance.UserRegistryRoot.CreateSubKey(EXTENSION_SUBKEY, true);
 
-                SimpleIoc.Default.GetInstance<DeviceExplorerViewModel>().Package = this;
+                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-                await MessageCentre.InitializeAsync(this, "nanoFramework Extension");
+                    AddService(typeof(NanoDeviceCommService), CreateNanoDeviceCommServiceAsync);
 
-                await DeviceExplorerCommand.InitializeAsync(this, ViewModelLocator);
-                DeployProvider.Initialize(this, ViewModelLocator);
+                    NanoDeviceCommService = await GetServiceAsync(typeof(NanoDeviceCommService)) as INanoDeviceCommService;
 
-                // Enable debugger UI context
-                UIContext.FromUIContextGuid(CorDebug.EngineGuid).IsActive = true;
+                    // Need to add the View model Locator to the application resource dictionary programmatically 
+                    // because at the extension level we don't have 'XAML' access to it
+                    // try to find if the view model locator is already in the app resources dictionary
+                    if (System.Windows.Application.Current.TryFindResource("Locator") == null)
+                    {
+                        // instantiate the view model locator...
+                        ViewModelLocator = new ViewModelLocator();
 
-                OutputWelcomeMessage();
+                        // ... and add it there
+                        System.Windows.Application.Current.Resources.Add("Locator", ViewModelLocator);
+                    }
 
+                    SimpleIoc.Default.GetInstance<DeviceExplorerViewModel>().Package = this;
+
+                    await MessageCentre.InitializeAsync(this, "nanoFramework Extension");
+
+                    await DeviceExplorerCommand.InitializeAsync(this, ViewModelLocator);
+                    DeployProvider.Initialize(this, ViewModelLocator);
+
+                    // Enable debugger UI context
+                    UIContext.FromUIContextGuid(CorDebug.EngineGuid).IsActive = true;
+
+                    OutputWelcomeMessage();
+                }
             });
 
             await base.InitializeAsync(cancellationToken, progress);


### PR DESCRIPTION
## Description
- In case Windows version is below 10, the extension shows an error message and wont load it's internal components.

## Motivation and Context
- The debugger library requires UWP USB API to communicate with devices. Only Windows 10 and above have those.
- Resolves nanoFramework/Home#479.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
