### PR TITLE
Add check for type resolution failure on debug start

### DIFF
--- a/source/VisualStudio.Extension/CorDebug/CorDebugProcess.cs
+++ b/source/VisualStudio.Extension/CorDebug/CorDebugProcess.cs
@@ -323,9 +323,22 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                             break;
                         }
 
-                        MessageCentre.InternalErrorMessage($"Device is running CLR, requesting reboot and pause for debugger ({retries + 1}/{ maxOperationRetries }).");
+                        // check to see if the device has type resolution failed flag set
+                        if (_engine.IsDeviceStoppedOnTypeResolutionFailed())
+                        {
+                            MessageCentre.DebugMessage("******************************************************************************");
+                            MessageCentre.DebugMessage("** Error: Device stopped after type resolution failure.                     **");
+                            MessageCentre.DebugMessage("** Check in each assembly which assemblies are referenced and their version **");
+                            MessageCentre.DebugMessage("******************************************************************************");
 
-                        _engine.RebootDevice(RebootOptions.ClrOnly | RebootOptions.WaitForDebugger);
+                            throw new Exception("Device stopped after type resolution failure. Can't start execution.");
+                        }
+                        else
+                        {
+                            MessageCentre.InternalErrorMessage($"Device is running CLR, requesting reboot and pause for debugger ({retries + 1}/{ maxOperationRetries }).");
+
+                            _engine.RebootDevice(RebootOptions.ClrOnly | RebootOptions.WaitForDebugger);
+                        }
                     }
                     else if(_engine.ConnectionSource == ConnectionSource.nanoBooter)
                     {


### PR DESCRIPTION
## Description
- Add check for type resolution failure on debug start.

## Motivation and Context
- When type resolution fails there is no error shown in VS but prevents the debug session from starting without any indication to the developer on what is the reason for that.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
