### PR TITLE
Rename framework define symbol to NANOFRAMEWORK_1_0

### DIFF
--- a/source/VisualStudio.Extension-2019/Targets/NFProjectSystem.CSharp.targets
+++ b/source/VisualStudio.Extension-2019/Targets/NFProjectSystem.CSharp.targets
@@ -11,7 +11,7 @@
     <TargetFrameworkMonikerDisplayName>.NET nanoFramework 1.0</TargetFrameworkMonikerDisplayName>
     <GenerateTargetFrameworkAttribute>true</GenerateTargetFrameworkAttribute>
     <GenerateManifests>true</GenerateManifests>
-    <DefineConstants>$(DefineConstants),NANOFRAMEWORK_V1_0</DefineConstants>
+    <DefineConstants>$(DefineConstants),NANOFRAMEWORK_1_0</DefineConstants>
   </PropertyGroup>
   
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/source/VisualStudio.Extension/Targets/NFProjectSystem.CSharp.targets
+++ b/source/VisualStudio.Extension/Targets/NFProjectSystem.CSharp.targets
@@ -11,7 +11,7 @@
     <TargetFrameworkMonikerDisplayName>.NET nanoFramework 1.0</TargetFrameworkMonikerDisplayName>
     <GenerateTargetFrameworkAttribute>true</GenerateTargetFrameworkAttribute>
     <GenerateManifests>true</GenerateManifests>
-    <DefineConstants>$(DefineConstants),NANOFRAMEWORK_V1_0</DefineConstants>
+    <DefineConstants>$(DefineConstants),NANOFRAMEWORK_1_0</DefineConstants>
   </PropertyGroup>
   
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
## Description
- Rename framework define symbol to `NANOFRAMEWORK_1_0`.

## Motivation and Context
- This is to follow the pattern with all other .NET frameworks. (dropping the v letter)

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>