### PR TITLE
Fix deployment issues

### DIFF
--- a/source/VisualStudio.Extension-2019/VisualStudio.Extension.csproj
+++ b/source/VisualStudio.Extension-2019/VisualStudio.Extension.csproj
@@ -584,8 +584,8 @@
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.Tools.Debugger, Version=1.3.0.11, Culture=neutral, PublicKeyToken=e520bb6b53f04733, processorArchitecture=MSIL">
-      <HintPath>..\packages\nanoFramework.Tools.Debugger.Net.1.3.0-preview.11\lib\net461\nanoFramework.Tools.Debugger.dll</HintPath>
+    <Reference Include="nanoFramework.Tools.Debugger, Version=1.3.0.14, Culture=neutral, PublicKeyToken=e520bb6b53f04733, processorArchitecture=MSIL">
+      <HintPath>..\packages\nanoFramework.Tools.Debugger.Net.1.3.0-preview.14\lib\net461\nanoFramework.Tools.Debugger.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/source/VisualStudio.Extension-2019/packages.config
+++ b/source/VisualStudio.Extension-2019/packages.config
@@ -51,7 +51,7 @@
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net472" />
   <package id="MvvmLightLibsStd10" version="5.4.1.1" targetFramework="net47" />
   <package id="nanoFramework.CoreLibrary" version="1.2.6-preview.16" targetFramework="net472" />
-  <package id="nanoFramework.Tools.Debugger.Net" version="1.3.0-preview.11" targetFramework="net472" />
+  <package id="nanoFramework.Tools.Debugger.Net" version="1.3.0-preview.14" targetFramework="net472" />
   <package id="nanoFramework.Tools.MetadataProcessor" version="1.12.5" targetFramework="net472" />
   <package id="Nerdbank.GitVersioning" version="3.0.6-beta" targetFramework="net462" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net472" />

--- a/source/VisualStudio.Extension/DebugLauncher/NanoDebuggerLaunchProvider.cs
+++ b/source/VisualStudio.Extension/DebugLauncher/NanoDebuggerLaunchProvider.cs
@@ -43,6 +43,9 @@ namespace nanoFramework.Tools.VisualStudio.Extension
             var deployDeviceName = SimpleIoc.Default.GetInstance<DeviceExplorerViewModel>().SelectedDevice.Description;
             var portName = SimpleIoc.Default.GetInstance<DeviceExplorerViewModel>().SelectedTransportType.ToString();
 
+            // make sure that the device is connected
+            await SimpleIoc.Default.GetInstance<DeviceExplorerViewModel>().SelectedDevice.DebugEngine.ConnectAsync(5000);
+
             string commandLine = await GetCommandLineForLaunchAsync();
             commandLine = string.Format("{0} \"{1}{2}\"", commandLine, CorDebugProcess.DeployDeviceName, deployDeviceName);
 

--- a/source/VisualStudio.Extension/VisualStudio.Extension.csproj
+++ b/source/VisualStudio.Extension/VisualStudio.Extension.csproj
@@ -424,8 +424,9 @@
     <Reference Include="Microsoft.Win32.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Win32.Primitives.4.3.0\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Tools.Debugger, Version=1.3.0.11, Culture=neutral, PublicKeyToken=e520bb6b53f04733, processorArchitecture=MSIL">
-      <HintPath>..\packages\nanoFramework.Tools.Debugger.Net.1.3.0-preview.11\lib\net461\nanoFramework.Tools.Debugger.dll</HintPath>
+    <Reference Include="nanoFramework.Tools.Debugger, Version=1.3.0.14, Culture=neutral, PublicKeyToken=e520bb6b53f04733, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\nanoFramework.Tools.Debugger.Net.1.3.0-preview.14\lib\net461\nanoFramework.Tools.Debugger.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/source/VisualStudio.Extension/VisualStudio.Extension.previous.nugetreferenceswitcher
+++ b/source/VisualStudio.Extension/VisualStudio.Extension.previous.nugetreferenceswitcher
@@ -1,1 +1,1 @@
-nanoFramework.Tools.DebugLibrary.Net	../../nf-debugger/source/nanoFramework.Tools.DebugLibrary.Net/nanoFramework.Tools.DebugLibrary.Net.csproj	../packages/nanoFramework.Tools.Debugger.Net.1.2.1-preview.13/lib/net461/nanoFramework.Tools.Debugger.dll
+nanoFramework.Tools.DebugLibrary.Net	../../nf-debugger/source/nanoFramework.Tools.DebugLibrary.Net/nanoFramework.Tools.DebugLibrary.Net.csproj	../packages/nanoFramework.Tools.Debugger.Net.1.3.0-preview.14/lib/net461/nanoFramework.Tools.Debugger.dll

--- a/source/VisualStudio.Extension/packages.config
+++ b/source/VisualStudio.Extension/packages.config
@@ -59,7 +59,7 @@
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net46" />
   <package id="MvvmLightLibsStd10" version="5.4.1.1" targetFramework="net46" />
   <package id="nanoFramework.CoreLibrary" version="1.2.6-preview.16" targetFramework="net461" developmentDependency="true" />
-  <package id="nanoFramework.Tools.Debugger.Net" version="1.3.0-preview.11" targetFramework="net461" />
+  <package id="nanoFramework.Tools.Debugger.Net" version="1.3.0-preview.14" targetFramework="net461" />
   <package id="nanoFramework.Tools.MetadataProcessor" version="1.12.5" targetFramework="net461" />
   <package id="Nerdbank.GitVersioning" version="2.3.38" targetFramework="net46" developmentDependency="true" />
   <package id="NETStandard.Library" version="2.0.3" targetFramework="net46" requireReinstallation="true" />


### PR DESCRIPTION
## Description
- QueryDebugTargetsAsync now explicitely connects to target device before launching debugger.
- Update debugger NuGet to 1.3.0-preview.14.
- Update debugger sub-module @130a833e.

## Motivation and Context
- Fixes issues with deployment after increasing baud rate on WP.

## How Has This Been Tested?<!-- (if applicable) -->
- VS experimental instance. Deployment on STM32F769I and ESP32-WROVER.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
