### PR TITLE
Fix project icon not showing on VS project tree

### DIFF
--- a/source/VisualStudio.Extension/ProjectSystem/ProjectTreePropertiesProvider.cs
+++ b/source/VisualStudio.Extension/ProjectSystem/ProjectTreePropertiesProvider.cs
@@ -9,10 +9,12 @@ using System.ComponentModel.Composition;
 namespace nanoFramework.Tools.VisualStudio.Extension
 {
     /// <summary>
-    /// Updates nodes in the project tree by overriding property values calcuated so far by lower priority providers.
+    /// Updates nodes in the project tree by overriding property values calculated so far by lower priority providers.
     /// </summary>
     [Export(typeof(IProjectTreePropertiesProvider))]
     [AppliesTo(NanoCSharpProjectUnconfigured.UniqueCapability)]
+    // need to set an order here so it can override the default CPS icon
+    [Order(100)]
     internal class ProjectTreePropertiesProvider : IProjectTreePropertiesProvider
     {
         /// <summary>


### PR DESCRIPTION
## Description
- Add `Order` attribute to `ProjectTreePropertiesProvider`.

## Motivation and Context
- Expanded project icon wasn't showing on project tree, instead the default one.
- Reported on [VS Developer Community](https://developercommunity.visualstudio.com/content/problem/597813/icon-property-in-iprojecttreepropertiesprovider-is.html) and fix suggested in dotnet/project-system#5183 (thank you so much @drewnoakes and @davkean 👏 😃 ).
- Fixes dotnet/project-system#5183.

## How Has This Been Tested?<!-- (if applicable) -->
- Loading nF project in VS experimental instance.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
