### PR TITLE
Deploy provider now only deploys startup project

### DIFF
--- a/source/VisualStudio.Extension-2019/version.json
+++ b/source/VisualStudio.Extension-2019/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "release": {
     "branchName" : "release-v{version}",
     "versionIncrement" : "minor",

--- a/source/VisualStudio.Extension/version.json
+++ b/source/VisualStudio.Extension/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "release": {
     "branchName" : "release-v{version}",
     "versionIncrement" : "minor",


### PR DESCRIPTION
## Description
- Add code to check if project being deployed is the startup project. If not returns immediately.
- Bump version to 1.2.4.

## Motivation and Context
- On Solutions with multiple projects the deploy provider deploys all projects marked to deploy in the Configuration Manager. This is unnecessary because the reference crawler takes care of listing all the required assemblies. Plus it can add a serious amount of wasted time to start debugging when it's deploying unnecessary projects one after the other.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
