### PR TITLE
Replace metadata processor with managed version

### DIFF
--- a/source/Tools.BuildTasks-2019/Tools.BuildTasks.csproj
+++ b/source/Tools.BuildTasks-2019/Tools.BuildTasks.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>nanoFramework.Tools</RootNamespace>
     <AssemblyName>nanoFramework.Tools.BuildTasks</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
@@ -41,9 +41,36 @@
   <ItemGroup>
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
+    <Reference Include="Mono.Cecil, Version=0.11.1.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.11.1\lib\net40\Mono.Cecil.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Mdb, Version=0.11.1.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.11.1\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Pdb, Version=0.11.1.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.11.1\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Rocks, Version=0.11.1.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.11.1\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
+    </Reference>
+    <Reference Include="nanoFramework.Tools.MetadataProcessor.Core, Version=2.3.11.2534, Culture=neutral, PublicKeyToken=562e3cb1ad703850, processorArchitecture=MSIL">
+      <HintPath>..\packages\nanoFramework.Tools.MetadataProcessor.Core.2.3.11\lib\net461\nanoFramework.Tools.MetadataProcessor.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Stubble.Core, Version=1.7.0.0, Culture=neutral, PublicKeyToken=3291e04f27be773d, processorArchitecture=MSIL">
+      <HintPath>..\packages\Stubble.Core.1.7.2\lib\net45\Stubble.Core.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.5.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
+    </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.1\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/source/Tools.BuildTasks/Tools.BuildTasks.csproj
+++ b/source/Tools.BuildTasks/Tools.BuildTasks.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>nanoFramework.Tools</RootNamespace>
     <AssemblyName>nanoFramework.Tools.BuildTasks</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
@@ -41,9 +41,36 @@
   <ItemGroup>
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
+    <Reference Include="Mono.Cecil, Version=0.11.1.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.11.1\lib\net40\Mono.Cecil.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Mdb, Version=0.11.1.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.11.1\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Pdb, Version=0.11.1.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.11.1\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Rocks, Version=0.11.1.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.11.1\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
+    </Reference>
+    <Reference Include="nanoFramework.Tools.MetadataProcessor.Core, Version=2.4.2.15844, Culture=neutral, PublicKeyToken=562e3cb1ad703850, processorArchitecture=MSIL">
+      <HintPath>..\packages\nanoFramework.Tools.MetadataProcessor.Core.2.4.2\lib\net461\nanoFramework.Tools.MetadataProcessor.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Stubble.Core, Version=1.7.0.0, Culture=neutral, PublicKeyToken=3291e04f27be773d, processorArchitecture=MSIL">
+      <HintPath>..\packages\Stubble.Core.1.7.2\lib\net45\Stubble.Core.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.5.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
+    </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.1\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -81,8 +108,10 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.209\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.209\build\Microsoft.VisualStudio.Threading.Analyzers.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.SDK.Analyzers.15.8.36\build\Microsoft.VisualStudio.SDK.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VisualStudio.SDK.Analyzers.15.8.36\build\Microsoft.VisualStudio.SDK.Analyzers.targets'))" />
+    <Error Condition="!Exists('..\packages\nanoFramework.Tools.MetadataProcessor.Core.2.4.2\build\nanoFramework.Tools.MetaDataProcessor.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\nanoFramework.Tools.MetadataProcessor.Core.2.4.2\build\nanoFramework.Tools.MetaDataProcessor.Core.targets'))" />
   </Target>
   <Import Project="..\packages\Microsoft.VisualStudio.SDK.Analyzers.15.8.36\build\Microsoft.VisualStudio.SDK.Analyzers.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.SDK.Analyzers.15.8.36\build\Microsoft.VisualStudio.SDK.Analyzers.targets')" />
+  <Import Project="..\packages\nanoFramework.Tools.MetadataProcessor.Core.2.4.2\build\nanoFramework.Tools.MetaDataProcessor.Core.targets" Condition="Exists('..\packages\nanoFramework.Tools.MetadataProcessor.Core.2.4.2\build\nanoFramework.Tools.MetaDataProcessor.Core.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/source/Tools.BuildTasks/Utilities/DebuggerHelper.cs
+++ b/source/Tools.BuildTasks/Utilities/DebuggerHelper.cs
@@ -19,7 +19,7 @@ namespace nanoFramework.Tools.Utilities
             var debugEnabled = Environment.GetEnvironmentVariable(varName);
             if (!string.IsNullOrEmpty(debugEnabled) && debugEnabled.Equals("1", StringComparison.Ordinal))
             {
-                Console.WriteLine($"Waiting {timeoutSeconds} seconds for debugger attachment...");
+                Console.WriteLine($"nanoFramework Metadata Processor msbuild instrumentation task debugging is enabled. Waiting {timeoutSeconds} seconds for debugger attachment...");
 
                 var currentProcessId = Process.GetCurrentProcess().Id;
                 var currentProcessName = Process.GetProcessById(currentProcessId).ProcessName;
@@ -27,7 +27,7 @@ namespace nanoFramework.Tools.Utilities
                     string.Format("Process Id: {0}, Name: {1}", currentProcessId, currentProcessName)
                     );
 
-                // wait 30 seconds for debugger to attach
+                // wait N seconds for debugger to attach
                 while (!Debugger.IsAttached && waitForDebugToAttach.TotalSeconds > 0)
                 {
                     Thread.Sleep(1000);

--- a/source/Tools.BuildTasks/packages.config
+++ b/source/Tools.BuildTasks/packages.config
@@ -2,4 +2,10 @@
 <packages>
   <package id="Microsoft.VisualStudio.SDK.Analyzers" version="15.8.36" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Threading.Analyzers" version="15.8.209" targetFramework="net46" />
+  <package id="Mono.Cecil" version="0.11.1" targetFramework="net461" />
+  <package id="nanoFramework.Tools.MetadataProcessor.Core" version="2.4.2" targetFramework="net461" />
+  <package id="Stubble.Core" version="1.7.2" targetFramework="net461" />
+  <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net461" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net461" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net461" />
 </packages>

--- a/source/VisualStudio.Extension-2019/Targets/NFProjectSystem.MDP.targets
+++ b/source/VisualStudio.Extension-2019/Targets/NFProjectSystem.MDP.targets
@@ -108,33 +108,39 @@
   </Target>
 
   <Target Name="CopyToOutDir">
+
     <Copy
         Condition="Exists('$(ProjectDir)$(IntermediateOutputPath)$(TargetName).exe')"
         SourceFiles="$(ProjectDir)$(IntermediateOutputPath)$(TargetName).exe"
         DestinationFolder="$(ProjectDir)$(OutDir)\" >
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
     </Copy>
+
     <Copy
         Condition="Exists('$(ProjectDir)$(IntermediateOutputPath)$(TargetName).dll')"
         SourceFiles="$(ProjectDir)$(IntermediateOutputPath)$(TargetName).dll"
         DestinationFolder="$(ProjectDir)$(OutDir)\" >
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
     </Copy>
+
     <Copy
         Condition="Exists('$(ProjectDir)$(IntermediateOutputPath)$(TargetName).pdbx')"
         SourceFiles="$(ProjectDir)$(IntermediateOutputPath)$(TargetName).pdbx"
         DestinationFolder="$(ProjectDir)$(OutDir)" >
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
     </Copy>
+
     <Copy
         Condition="Exists('$(ProjectDir)$(IntermediateOutputPath)$(TargetName).bin')"
         SourceFiles="$(ProjectDir)$(IntermediateOutputPath)$(TargetName).bin"
         DestinationFolder="$(ProjectDir)$(OutDir)" >
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
     </Copy>
+
   </Target>
 
-  <Target Name="CopyNanoFrameworkFiles" >
+  <Target Name="CopyNanoFrameworkFiles">
+
     <Copy
         Condition="Exists('$(NanoFramework_IntermediateAssembly).pe')"
         SourceFiles="$(NanoFramework_IntermediateAssembly).pe"
@@ -159,7 +165,6 @@
         The ContinueOnError set to true is required because the local paths on the referenced file contain the extension.
         This would cause the task to fail because it would be trying to copy myreferenced.dll.pe and myreferenced.dll.pbx, which obviously don't exit.
         -->
-
     <Copy
         SourceFiles="@(ReferenceCopyLocalPaths->'%(RootDir)%(Directory)%(Filename).pe')"
         DestinationFiles="@(ReferenceCopyLocalPaths->'$(OutDir)%(DestinationSubDirectory)%(Filename).pe')"
@@ -181,21 +186,20 @@
     <Copy
         SourceFiles="@(ReferenceCopyLocalPaths)"
         DestinationFiles="@(ReferenceCopyLocalPaths->'$(IntermediateOutputPath)%(Filename)%(Extension)')"
-        SkipUnchangedFiles="false"
-            >
+        SkipUnchangedFiles="false">
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
     </Copy>
 
   </Target>
 
   <Target Name="MetaDataProcessor"
-      Inputs="$(NanoFramework_Assembly)$(TargetExt);
-        @(ReferencePath);
-        @(ReferenceDependencyPaths);
-        @(ReferenceSatellitePaths);
-        @(NanoFramework_Resources)"
-      Outputs="$(NanoFramework_IntermediateAssembly).pe"
-      DependsOnTargets="$(MetaDataProcessorDependsOn)">
+          Inputs="$(NanoFramework_Assembly)$(TargetExt);
+            @(ReferencePath);
+            @(ReferenceDependencyPaths);
+            @(ReferenceSatellitePaths);
+            @(NanoFramework_Resources)"
+          Outputs="$(NanoFramework_IntermediateAssembly).pe"
+          DependsOnTargets="$(MetaDataProcessorDependsOn)">
 
     <MetaDataProcessorTask
         LoadHints="@(ReferencePath);@(ReferenceDependencyPaths);@(ReferenceSatellitePaths)"
@@ -203,19 +207,15 @@
         Compile="$(NanoFramework_IntermediateAssembly).pe"
         ImportResources="@(NanoFramework_Resources)"
         Minimize="true">
-
       <Output TaskParameter="FilesWritten" ItemName="FileWrites" />
-
     </MetaDataProcessorTask>
-
-    <!--CallTarget is less than ideal... NF_GeneratedStubFile isn't a complete list...-->
-    <CallTarget Targets="GenerateStubs" Condition="'$(NF_GenerateStubs)'=='true'" />
 
     <CallTarget Targets="NanoGenerateBinaryOutput"/>
 
   </Target>
 
-  <Target Name="ResolveRuntimeDependencies" Condition="'$(NF_IsCoreLibrary)' != 'True' ">
+  <Target Name="ResolveRuntimeDependencies"
+          Condition="'$(NF_IsCoreLibrary)' != 'True' ">
 
     <ItemGroup>
       <NanoFramework_StartProgramItem Include="$(NanoFramework_StartProgram)" Condition=" '$(NanoFramework_StartProgram)' != '' " />
@@ -231,13 +231,13 @@
         InstalledAssemblyTables="@(InstalledAssemblyTables)"
         CandidateAssemblyFiles="@(Content);@(None)"
         SearchPaths="{CandidateAssemblyFiles};
-                         $(ReferencePath);
-                         {HintPathFromItem};
-                         $(TargetFrameworkDirectory);
-                         {Registry:$(FrameworkRegistryBase),$(TargetFrameworkVersion),$(AssemblyFoldersSuffix)$(AssemblyFoldersExConditions)};
-                         {RawFileName};
-                         $(OutputPath);
-                         @(NanoFramework_StartProgramItem->'%(RootDir)%(Directory)')"
+                      $(ReferencePath);
+                      {HintPathFromItem};
+                      $(TargetFrameworkDirectory);
+                      {Registry:$(FrameworkRegistryBase),$(TargetFrameworkVersion),$(AssemblyFoldersSuffix)$(AssemblyFoldersExConditions)};
+                      {RawFileName};
+                      $(OutputPath);
+                      @(NanoFramework_StartProgramItem->'%(RootDir)%(Directory)')"
         AppConfigFile="@(_ResolveAssemblyReferencesApplicationConfigFileForExes)"
         AutoUnify="$(AutoUnifyAssemblyReferences)"
         FindDependencies="true"
@@ -245,7 +245,6 @@
         FindRelatedFiles="true"
         Silent="!$(BuildingProject)"
         StateFile="$(NanoFramework_DebugReferencesStateFile)">
-
       <Output TaskParameter="ResolvedFiles" ItemName="NanoFramework_StartProgram_ResolvedFiles"/>
       <Output TaskParameter="ResolvedDependencyFiles" ItemName="NanoFramework_StartProgram_ResolvedDependencyFiles"/>
       <Output TaskParameter="RelatedFiles" ItemName="NanoFramework_ReferenceRelatedPaths"/>
@@ -253,7 +252,6 @@
       <Output TaskParameter="CopyLocalFiles" ItemName="NanoFramework_ReferenceCopyLocalPaths"/>
       <Output TaskParameter="SuggestedRedirects" ItemName="NanoFramework_SuggestedBindingRedirects"/>
       <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
-
     </ResolveAssemblyReferences>
 
     <ResolveRuntimeDependenciesTask
@@ -284,22 +282,15 @@
     <NFMDP_PE_DumpExports>$(ProjectDir)$(IntermediateOutputPath)$(TargetName)_exports.txt</NFMDP_PE_DumpExports>
     <NFMDP_PE_DumpAll>$(ProjectDir)$(IntermediateOutputPath)$(TargetName)_all.txt</NFMDP_PE_DumpAll>
 
-    <!-- nanoFramework MetaDataProcessor DUMP options -->
-    <NFMDP_DUMP_FILES>true</NFMDP_DUMP_FILES>
-    <NFMDP_DUMP_DumpAll>$(ProjectDir)$(IntermediateOutputPath)$(TargetName).dump</NFMDP_DUMP_DumpAll>
-
     <!-- nanoFramework MetaDataProcessor STUB options -->
     <NFMDP_STUBS_DumpAll>$(ProjectDir)$(IntermediateOutputPath)$(TargetName)_exports2.txt</NFMDP_STUBS_DumpAll>
     <NFMDP_STUB_GenerateSkeletonName>$(AssemblyName)</NFMDP_STUB_GenerateSkeletonName>
-    <NFMDP_STUB_RefreshAssemblyName>$(AssemblyName)</NFMDP_STUB_RefreshAssemblyName>
-    <NFMDP_STUB_RefreshAssemblyOutput>$(NFMDP_PE_Compile)</NFMDP_STUB_RefreshAssemblyOutput>
     <NFMDP_STUB_Resolve>true</NFMDP_STUB_Resolve>
 
     <!-- nanoFramework MetaDataProcessor DAT options -->
 
     <!-- nanoFramework MetaDataProcessor XML options -->
-    <NFMDP_XML_Resolve>true</NFMDP_XML_Resolve>
-  <NFMDP_XML_GenerateDependency>$(ProjectDir)$(IntermediateOutputPath)$(TargetName)_dependency_map.xml</NFMDP_XML_GenerateDependency>
+    <NFMDP_PE_GenerateDependency>$(ProjectDir)$(IntermediateOutputPath)$(TargetName)_dependency_map.xml</NFMDP_PE_GenerateDependency>
 
     <!-- misc -->
     <NanoCLR_DisasmInput>$(ProjectDir)$(IntermediateOutputPath)$(TargetFileName)</NanoCLR_DisasmInput>
@@ -342,35 +333,36 @@
     </NFMDP_STUB_Load>
   </ItemGroup>
 
-  <Target Name="NFMDP_CreateDatabaseAndDependencyMap" DependsOnTargets="MetaDataProcessorDump;MetaDataProcessorDat;MetadataProcessorXML" />
+  <Target Name="NFMDP_CreateDatabaseAndDependencyMap"
+          DependsOnTargets="MetaDataProcessorDat" />
 
   <Target Name="MetaDataProcessorCompile"
-    Inputs="
-        $(NFMDP_PE_Parse);
-        @(NFMDP_PE_LoadHints);
-        $(NFMDP_PE_LoadStrings);
-        @(NFMDP_PE_Load);
-        @(NFMDP_PE_LoadDatabase);
-        @(NFMDP_PE_CreateDatabase);
-        @(NFMDP_PE_Resource)"
-    Outputs="
-        $(NFMDP_PE_SaveStrings);
-        $(NFMDP_PE_GenerateStringsTable);
-        $(NFMDP_PE_DumpAll);
-        $(NFMDP_PE_DumpExports);
-        $(NFMDP_PE_Compile);
-        $(NFMDP_PE_RefreshAssemblyOutput);
-        $(NFMDP_PE_CreateDatabaseFile);
-        $(NFMDP_PE_GenerateDependency)"
-
-    DependsOnTargets="ResolveRuntimeDependencies"
-    Condition="'$(NFMDP_GENERATE_PE)' == 'true'">
+          Inputs="
+            $(NFMDP_PE_Parse);
+            @(NFMDP_PE_LoadHints);
+            $(NFMDP_PE_LoadStrings);
+            @(NFMDP_PE_Load);
+            @(NFMDP_PE_LoadDatabase);
+            @(NFMDP_PE_CreateDatabase);
+            @(NFMDP_PE_Resource)"
+          Outputs="
+            $(NFMDP_PE_SaveStrings);
+            $(NFMDP_PE_GenerateStringsTable);
+            $(NFMDP_PE_DumpAll);
+            $(NFMDP_PE_DumpExports);
+            $(NFMDP_PE_Compile);
+            $(NFMDP_PE_RefreshAssemblyOutput);
+            $(NFMDP_PE_CreateDatabaseFile);
+            $(NFMDP_PE_GenerateDependency)"
+          DependsOnTargets="ResolveRuntimeDependencies"
+          Condition="'$(NFMDP_GENERATE_PE)' == 'true'">
 
     <ItemGroup>
       <NFMDP_PE_CreatedFiles Include="$(NFMDP_PE_CreateDatabaseFile)" Condition="'$(NFMDP_PE_CreateDatabaseFile)'!=''"/>
       <NFMDP_PE_CreatedFiles Include="$(NFMDP_PE_GenerateSkeletonFile)"  Condition="'$(NFMDP_PE_GenerateSkeletonFile)'!=''"/>
       <NFMDP_PE_CreatedFiles Include="$(NFMDP_PE_GenerateDependency)"  Condition="'$(NFMDP_PE_GenerateDependency)'!=''"/>
     </ItemGroup>
+
     <MakeDir Directories="@(NFMDP_PE_CreatedFiles->'%(RootDir)%(Directory)')" />
 
     <ItemGroup>
@@ -395,84 +387,75 @@
       <NFMDP_STUB_GenerateSkeletonProject Condition="'$(NFMDP_STUB_GenerateSkeletonProject)'==''" >$(AssemblyName)</NFMDP_STUB_GenerateSkeletonProject>
     </PropertyGroup>
 
-    <Message Text="Distilling assemblies to nanoCLR PE files..." />
+    <Message Text="Distilling assemblies to nanoCLR PE files (no stubs)..." Condition="'$(NFMDP_GENERATE_STUBS)' == 'false'" />
     <!-- Compile to PE -->
     <MetaDataProcessorTask
-      Minimize="$(NFMDP_PE_Minimize)"
-      Verbose="$(NFMDP_PE_Verbose)"
-      Parse="$(NFMDP_PE_Parse)"
-      VerboseMinimize="$(NFMDP_PE_VerboseMinimize)"
-      NoByteCode="$(NFMDP_PE_NoByteCode)"
-      NoAttributes="$(NFMDP_PE_NoAttributes)"
-      SaveStrings="$(NFMDP_PE_SaveStrings)"
-      LoadStrings="$(NFMDP_PE_LoadStrings)"
-      ImportResources="@(NFMDP_PE_Resource)"
-      GenerateStringsTable="$(NFMDP_PE_GenerateStringsTable)"
-      Compile="$(NFMDP_PE_Compile)"
-      DumpAll="$(NFMDP_PE_DumpAll)"
-      DumpExports="$(NFMDP_PE_DumpExports)"
-      GenerateSkeletonFile="$(NFMDP_PE_GenerateSkeletonFile)"
-      GenerateSkeletonName="$(NFMDP_PE_GenerateSkeletonName)"
-      GenerateSkeletonProject="$(NFMDP_PE_GenerateSkeletonProject)"
-      GenerateDependency="$(NFMDP_PE_GenerateDependency)"
-      CreateDatabase="@(NFMDP_PE_CreateDatabase)"
-      RefreshAssemblyName="$(NFMDP_PE_RefreshAssemblyName)"
-      RefreshAssemblyOutput="$(NFMDP_PE_RefreshAssemblyOutput)"
-      CreateDatabaseFile="$(NFMDP_PE_CreateDatabaseFile)"
-      Resolve="$(NFMDP_PE_Resolve)"
-      LoadHints="@(NFMDP_PE_LoadHints)"
-      IgnoreAssembly="@(NFMDP_PE_IgnoreAssembly)"
-      Load="@(NFMDP_PE_Load)"
-      LoadDatabase="@(NFMDP_PE_LoadDatabase)"
-      OutputCommandLine="$(NFMDP_CMD_LINE_OUTPUT)"
-      ExcludeClassByName="@(NFMDP_PE_ExcludeClassByName)">
-
+        Minimize="$(NFMDP_PE_Minimize)"
+        Verbose="$(NFMDP_PE_Verbose)"
+        Parse="$(NFMDP_PE_Parse)"
+        VerboseMinimize="$(NFMDP_PE_VerboseMinimize)"
+        NoByteCode="$(NFMDP_PE_NoByteCode)"
+        NoAttributes="$(NFMDP_PE_NoAttributes)"
+        SaveStrings="$(NFMDP_PE_SaveStrings)"
+        LoadStrings="$(NFMDP_PE_LoadStrings)"
+        ImportResources="@(NFMDP_PE_Resource)"
+        GenerateStringsTable="$(NFMDP_PE_GenerateStringsTable)"
+        Compile="$(NFMDP_PE_Compile)"
+        DumpAll="$(NFMDP_PE_DumpAll)"
+        DumpExports="$(NFMDP_PE_DumpExports)"
+        GenerateSkeletonFile="$(NFMDP_PE_GenerateSkeletonFile)"
+        GenerateSkeletonName="$(NFMDP_PE_GenerateSkeletonName)"
+        GenerateSkeletonProject="$(NFMDP_PE_GenerateSkeletonProject)"
+        GenerateDependency="$(NFMDP_PE_GenerateDependency)"
+        CreateDatabase="@(NFMDP_PE_CreateDatabase)"
+        RefreshAssemblyName="$(NFMDP_PE_RefreshAssemblyName)"
+        RefreshAssemblyOutput="$(NFMDP_PE_RefreshAssemblyOutput)"
+        CreateDatabaseFile="$(NFMDP_PE_CreateDatabaseFile)"
+        LoadHints="@(NFMDP_PE_LoadHints)"
+        IgnoreAssembly="@(NFMDP_PE_IgnoreAssembly)"
+        ExcludeClassByName="@(NFMDP_PE_ExcludeClassByName)"
+        OutputCommandLine="$(NFMDP_CMD_LINE_OUTPUT)"
+        Condition="'$(NFMDP_GENERATE_STUBS)' == 'false'">
       <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
-
     </MetaDataProcessorTask>
 
+    <Message Text="Distilling assemblies to nanoCLR PE files along with stubs and skeleton files..." Condition="'$(NFMDP_GENERATE_STUBS)' == 'true'"/>
     <!-- Create STUB file -->
     <MetaDataProcessorTask
-      Minimize="$(NFMDP_STUB_Minimize)"
-      Verbose="$(NFMDP_STUB_Verbose)"
-      Parse="$(NFMDP_STUB_Parse)"
-      VerboseMinimize="$(NFMDP_STUB_VerboseMinimize)"
-      NoByteCode="$(NFMDP_STUB_NoByteCode)"
-      NoAttributes="$(NFMDP_STUB_NoAttributes)"
-      SaveStrings="$(NFMDP_STUB_SaveStrings)"
-      LoadStrings="$(NFMDP_STUB_LoadStrings)"
-      GenerateStringsTable="$(NFMDP_STUB_GenerateStringsTable)"
-      Compile="$(NFMDP_STUB_Compile)"
-      DumpAll="$(NFMDP_STUB_DumpAll)"
-      DumpExports="$(NFMDP_STUB_DumpExports)"
-      GenerateSkeletonFile="$(NFMDP_STUB_GenerateSkeletonFile)"
-      GenerateSkeletonName="$(NFMDP_STUB_GenerateSkeletonName)"
-      GenerateSkeletonProject="$(NFMDP_STUB_GenerateSkeletonProject)"
-      SkeletonWithoutInterop="$(NFMDP_STUB_SkeletonWithoutInterop)"
-      GenerateDependency="$(NFMDP_STUB_GenerateDependency)"
-      CreateDatabase="@(NFMDP_STUB_CreateDatabase)"
-      RefreshAssemblyName="$(NFMDP_STUB_RefreshAssemblyName)"
-      RefreshAssemblyOutput="$(NFMDP_STUB_RefreshAssemblyOutput)"
-      CreateDatabaseFile="$(NFMDP_STUB_CreateDatabaseFile)"
-      Resolve="$(NFMDP_STUB_Resolve)"
-      LoadHints="@(NFMDP_STUB_LoadHints)"
-      IgnoreAssembly="@(NFMDP_STUB_IgnoreAssembly)"
-      Load="@(NFMDP_STUB_Load)"
-      LoadDatabase="@(NFMDP_STUB_LoadDatabase)"
-      ExcludeClassByName="@(NFMDP_STUB_ExcludeClassByName)"
-      OutputCommandLine="$(NFMDP_CMD_LINE_OUTPUT)"
-      Condition="'$(NFMDP_GENERATE_STUBS)' == 'true'">
-
+        Minimize="$(NFMDP_PE_Minimize)"
+        Verbose="$(NFMDP_PE_Verbose)"
+        Parse="$(NFMDP_PE_Parse)"
+        VerboseMinimize="$(NFMDP_PE_VerboseMinimize)"
+        NoByteCode="$(NFMDP_STUB_NoByteCode)"
+        NoAttributes="$(NFMDP_STUB_NoAttributes)"
+        SaveStrings="$(NFMDP_STUB_SaveStrings)"
+        LoadStrings="$(NFMDP_STUB_LoadStrings)"
+        GenerateStringsTable="$(NFMDP_STUB_GenerateStringsTable)"
+        Compile="$(NFMDP_PE_Compile)"
+        DumpAll="$(NFMDP_STUBS_DumpAll)"
+        DumpExports="$(NFMDP_STUB_DumpExports)"
+        GenerateSkeletonFile="$(NFMDP_STUB_GenerateSkeletonFile)"
+        GenerateSkeletonName="$(NFMDP_STUB_GenerateSkeletonName)"
+        GenerateSkeletonProject="$(NFMDP_STUB_GenerateSkeletonProject)"
+        SkeletonWithoutInterop="$(NFMDP_STUB_SkeletonWithoutInterop)"
+        GenerateDependency="$(NFMDP_STUB_GenerateDependency)"
+        CreateDatabase="@(NFMDP_STUB_CreateDatabase)"
+        RefreshAssemblyName="$(NFMDP_STUB_RefreshAssemblyName)"
+        RefreshAssemblyOutput="$(NFMDP_STUB_RefreshAssemblyOutput)"
+        CreateDatabaseFile="$(NFMDP_STUB_CreateDatabaseFile)"
+        LoadHints="@(NFMDP_PE_LoadHints)"
+        IgnoreAssembly="@(NFMDP_STUB_IgnoreAssembly)"
+        ExcludeClassByName="@(NFMDP_PE_ExcludeClassByName)"
+        OutputCommandLine="$(NFMDP_CMD_LINE_OUTPUT)"
+        Condition="'$(NFMDP_GENERATE_STUBS)' == 'true'">
       <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
-
     </MetaDataProcessorTask>
 
-    <CallTarget Targets="GenerateStubs" Condition="'$(NF_GenerateStubs)'=='true'" />
-    
     <!-- Copy files (dll, pe, pdb and pdbx) to ouput directory -->
     <CallTarget Targets="CopyFilesToOutputDirectory" />
     <CallTarget Targets="CopyNanoFrameworkFiles" />
     <CallTarget Targets="CopyBackNanoFrameworkDlls" />
+
   </Target>
 
 
@@ -482,27 +465,26 @@
   </Target>
 
   <!-- MetaDataProcessor DAT -->
-  <Target
-    Name="MetaDataProcessorDat"
-    Inputs="
-        $(NFMDP_DAT_Parse);
-        @(NFMDP_DAT_LoadHints);
-        $(NFMDP_DAT_LoadStrings);
-        @(NFMDP_DAT_Load);
-        @(NFMDP_DAT_LoadDatabase);
-        @(NFMDP_DAT_CreateDatabase);
-        @(ResolvedPEFile);
-        $(MsBuildProjectFullPath)"
-    Outputs="
-        $(NFMDP_DAT_SaveStrings);
-        $(NFMDP_DAT_GenerateStringsTable);
-        $(NFMDP_DAT_DumpAll);
-        $(NFMDP_DAT_DumpExports);
-        $(NFMDP_DAT_Compile);
-        $(NFMDP_DAT_RefreshAssemblyOutput);
-        $(NFMDP_DAT_CreateDatabaseFile);
-        $(NFMDP_DAT_GenerateDependency)"
-    Condition="'$(NFMDP_DAT_FILES)' == 'true'">
+  <Target Name="MetaDataProcessorDat"
+          Inputs="
+            $(NFMDP_DAT_Parse);
+            @(NFMDP_DAT_LoadHints);
+            $(NFMDP_DAT_LoadStrings);
+            @(NFMDP_DAT_Load);
+            @(NFMDP_DAT_LoadDatabase);
+            @(NFMDP_DAT_CreateDatabase);
+            @(ResolvedPEFile);
+            $(MsBuildProjectFullPath)"
+          Outputs="
+            $(NFMDP_DAT_SaveStrings);
+            $(NFMDP_DAT_GenerateStringsTable);
+            $(NFMDP_DAT_DumpAll);
+            $(NFMDP_DAT_DumpExports);
+            $(NFMDP_DAT_Compile);
+            $(NFMDP_DAT_RefreshAssemblyOutput);
+            $(NFMDP_DAT_CreateDatabaseFile);
+            $(NFMDP_DAT_GenerateDependency)"
+          Condition="'$(NFMDP_DAT_FILES)' == 'true'">
 
     <CallTarget Targets="MetaDataProcessorDat_MSG" Condition="'$(NFMDP_DAT_Verbose)'=='true'" />
 
@@ -515,99 +497,45 @@
     <MakeDir Directories="@(NFMDP_DAT_CreatedFiles->'%(RootDir)%(Directory)')" />
 
     <MetaDataProcessorTask
-      Minimize="$(NFMDP_DAT_Minimize)"
-      Verbose="$(NFMDP_DAT_Verbose)"
-      Parse="$(NFMDP_DAT_Parse)"
-      VerboseMinimize="$(NFMDP_DAT_VerboseMinimize)"
-      NoByteCode="$(NFMDP_DAT_NoByteCode)"
-      NoAttributes="$(NFMDP_DAT_NoAttributes)"
-      SaveStrings="$(NFMDP_DAT_SaveStrings)"
-      LoadStrings="$(NFMDP_DAT_LoadStrings)"
-      GenerateStringsTable="$(NFMDP_DAT_GenerateStringsTable)"
-      Compile="$(NFMDP_DAT_Compile)"
-      DumpAll="$(NFMDP_DAT_DumpAll)"
-      DumpExports="$(NFMDP_DAT_DumpExports)"
-      GenerateSkeletonFile="$(NFMDP_DAT_GenerateSkeletonFile)"
-      GenerateSkeletonName="$(NFMDP_DAT_GenerateSkeletonName)"
-      GenerateSkeletonProject="$(NFMDP_DAT_GenerateSkeletonProject)"
-      GenerateDependency="$(NFMDP_DAT_GenerateDependency)"
-      CreateDatabase="@(NFMDP_DAT_CreateDatabase)"
-      RefreshAssemblyName="$(NFMDP_DAT_RefreshAssemblyName)"
-      RefreshAssemblyOutput="$(NFMDP_DAT_RefreshAssemblyOutput)"
-      CreateDatabaseFile="$(NFMDP_DAT_CreateDatabaseFile)"
-      Resolve="$(NFMDP_DAT_Resolve)"
-      LoadHints="@(NFMDP_DAT_LoadHints)"
-      IgnoreAssembly="@(NFMDP_DAT_IgnoreAssembly)"
-      Load="@(NFMDP_DAT_Load)"
-      LoadDatabase="@(NFMDP_DAT_LoadDatabase)"
-      ExcludeClassByName="@(NFMDP_DAT_ExcludeClassByName)"
-      OutputCommandLine="$(NFMDP_CMD_LINE_OUTPUT)">
-
+        Minimize="$(NFMDP_DAT_Minimize)"
+        Verbose="$(NFMDP_DAT_Verbose)"
+        Parse="$(NFMDP_DAT_Parse)"
+        VerboseMinimize="$(NFMDP_DAT_VerboseMinimize)"
+        NoByteCode="$(NFMDP_DAT_NoByteCode)"
+        NoAttributes="$(NFMDP_DAT_NoAttributes)"
+        SaveStrings="$(NFMDP_DAT_SaveStrings)"
+        LoadStrings="$(NFMDP_DAT_LoadStrings)"
+        GenerateStringsTable="$(NFMDP_DAT_GenerateStringsTable)"
+        Compile="$(NFMDP_DAT_Compile)"
+        DumpAll="$(NFMDP_DAT_DumpAll)"
+        DumpExports="$(NFMDP_DAT_DumpExports)"
+        GenerateSkeletonFile="$(NFMDP_DAT_GenerateSkeletonFile)"
+        GenerateSkeletonName="$(NFMDP_DAT_GenerateSkeletonName)"
+        GenerateSkeletonProject="$(NFMDP_DAT_GenerateSkeletonProject)"
+        GenerateDependency="$(NFMDP_DAT_GenerateDependency)"
+        CreateDatabase="@(NFMDP_DAT_CreateDatabase)"
+        RefreshAssemblyName="$(NFMDP_DAT_RefreshAssemblyName)"
+        RefreshAssemblyOutput="$(NFMDP_DAT_RefreshAssemblyOutput)"
+        CreateDatabaseFile="$(NFMDP_DAT_CreateDatabaseFile)"
+        Resolve="$(NFMDP_DAT_Resolve)"
+        LoadHints="@(NFMDP_DAT_LoadHints)"
+        IgnoreAssembly="@(NFMDP_DAT_IgnoreAssembly)"
+        Load="@(NFMDP_DAT_Load)"
+        LoadDatabase="@(NFMDP_DAT_LoadDatabase)"
+        ExcludeClassByName="@(NFMDP_DAT_ExcludeClassByName)"
+        OutputCommandLine="$(NFMDP_CMD_LINE_OUTPUT)">
       <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
-
-    </MetaDataProcessorTask>
-
-  </Target>
-
-  <!-- NFMDP_XML -->
-  <Target
-    Name="MetaDataProcessorXml"
-    Inputs="@(NFMDP_XML_Load)"
-    Outputs="
-        $(NFMDP_XML_SaveStrings);
-        $(NFMDP_XML_GenerateStringsTable);
-        $(NFMDP_XML_DumpAll);
-        $(NFMDP_XML_DumpExports);
-        $(NFMDP_XML_Compile);
-        $(NFMDP_XML_RefreshAssemblyOutput);
-        $(NFMDP_XML_CreateDatabaseFile);
-        $(NFMDP_XML_GenerateDependency)"
-    Condition="'$(NFMDP_XML_FILES)' == 'true'">
-
-    <Message Text="Creating dependency map $(NFMDP_XML_GenerateDependency)..." />
-
-    <MetaDataProcessorTask
-      Minimize="$(NFMDP_XML_Minimize)"
-      Verbose="$(NFMDP_XML_Verbose)"
-      Parse="$(NFMDP_XML_Parse)"
-      VerboseMinimize="$(NFMDP_XML_VerboseMinimize)"
-      NoByteCode="$(NFMDP_XML_NoByteCode)"
-      NoAttributes="$(NFMDP_XML_NoAttributes)"
-      SaveStrings="$(NFMDP_XML_SaveStrings)"
-      LoadStrings="$(NFMDP_XML_LoadStrings)"
-      GenerateStringsTable="$(NFMDP_XML_GenerateStringsTable)"
-      Compile="$(NFMDP_XML_Compile)"
-      DumpAll="$(NFMDP_XML_DumpAll)"
-      DumpExports="$(NFMDP_XML_DumpExports)"
-      GenerateSkeletonFile="$(NFMDP_XML_GenerateSkeletonFile)"
-      GenerateSkeletonName="$(NFMDP_XML_GenerateSkeletonName)"
-      GenerateSkeletonProject="$(NFMDP_XML_GenerateSkeletonProject)"
-      GenerateDependency="$(NFMDP_XML_GenerateDependency)"
-      CreateDatabase="$(NFMDP_XML_CreateDatabase)"
-      RefreshAssemblyName="$(NFMDP_XML_RefreshAssemblyName)"
-      RefreshAssemblyOutput="$(NFMDP_XML_RefreshAssemblyOutput)"
-      CreateDatabaseFile="$(NFMDP_XML_CreateDatabaseFile)"
-      Resolve="$(NFMDP_XML_Resolve)"
-      LoadHints="@(NFMDP_XML_LoadHints)"
-      IgnoreAssembly="@(NFMDP_XML_IgnoreAssembly)"
-      Load="@(NFMDP_XML_Load)"
-      LoadDatabase="@(NFMDP_XML_LoadDatabase)"
-      ExcludeClassByName="@(NFMDP_XML_ExcludeClassByName)"
-      OutputCommandLine="$(NFMDP_CMD_LINE_OUTPUT)">
-
-      <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
-
     </MetaDataProcessorTask>
 
   </Target>
 
   <!-- this target is to be used when building A CORE ASSEMBLY -->
-  <Target Name="ResolveRuntimeDependencies" Condition="'$(NF_IsCoreLibrary)' == 'True' ">
+  <Target Name="ResolveRuntimeDependencies"
+          Condition="'$(NF_IsCoreLibrary)' == 'True' ">
 
     <CreateItem
         Include="$(NanoFramework_StartProgram)"
-        Condition=" '$(NanoFramework_StartProgram)' != '' "
-        >
+        Condition=" '$(NanoFramework_StartProgram)' != '' ">
       <Output TaskParameter="Include" ItemName="NanoFramework_StartProgramItem"/>
     </CreateItem>
 
@@ -635,7 +563,6 @@
         FindRelatedFiles="true"
         Silent="!$(BuildingProject)"
         StateFile="$(NanoFramework_DebugReferencesStateFile)">
-
       <Output TaskParameter="ResolvedFiles" ItemName="NanoFramework_StartProgram_ResolvedFiles"/>
       <Output TaskParameter="ResolvedDependencyFiles" ItemName="NanoFramework_StartProgram_ResolvedDependencyFiles"/>
       <Output TaskParameter="RelatedFiles" ItemName="NanoFramework_ReferenceRelatedPaths"/>
@@ -643,16 +570,13 @@
       <Output TaskParameter="CopyLocalFiles" ItemName="NanoFramework_ReferenceCopyLocalPaths"/>
       <Output TaskParameter="SuggestedRedirects" ItemName="NanoFramework_SuggestedBindingRedirects"/>
       <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
-
     </ResolveAssemblyReference>
 
     <ItemGroup>
       <_ResolvedPEFile Include="@(NanoFramework_StartProgram_ResolvedFiles->'%(RootDir)%(Directory)%(filename).pe')" />
       <_ResolvedPEFile Include="@(NanoFramework_StartProgram_ResolvedFiles->'%(RootDir)%(Directory)%(filename).pe')" />
-
       <_ResolvedPEFile Include="@(NanoFramework_StartProgram_ResolvedDependencyFiles->'%(RootDir)%(Directory)%(filename).pe')" />
       <_ResolvedPEFile Include="@(NanoFramework_StartProgram_ResolvedDependencyFiles->'%(RootDir)%(Directory)%(filename).pe')" />
-
       <ResolvedPEFile Include="%(_ResolvedPEFile.identity)" Condition="EXISTS(%(_ResolvedPEFile.identity))" />
     </ItemGroup>
 
@@ -665,63 +589,9 @@
 
   </Target>
 
-
   <Target
-    Name="MetaDataProcessorDump"
-    Inputs="
-        $(NFMDP_DUMP_Parse);
-        @(NFMDP_DUMP_LoadHints);
-        $(NFMDP_DUMP_LoadStrings);
-        @(NFMDP_DUMP_Load);
-        @(NFMDP_DUMP_LoadDatabase);
-        @(NFMDP_DUMP_CreateDatabase)"
-    Outputs="
-        $(NFMDP_DUMP_SaveStrings);
-        $(NFMDP_DUMP_GenerateStringsTable);
-        $(NFMDP_DUMP_DumpAll);
-        $(NFMDP_DUMP_Compile);
-        $(NFMDP_DUMP_DumpExports);
-        $(NFMDP_DUMP_RefreshAssemblyOutput);
-        $(NFMDP_DUMP_CreateDatabaseFile);
-        $(NFMDP_DUMP_GenerateDependency)"
-    Condition="'$(NFMDP_DUMP_FILES)' == 'true'"
-    >
-    <!-- Create DUMP file -->
-    <MetaDataProcessorTask
-      Minimize="$(NFMDP_DUMP_Minimize)"
-      Verbose="$(NFMDP_DUMP_Verbose)"
-      Parse="$(NFMDP_DUMP_Parse)"
-      VerboseMinimize="$(NFMDP_DUMP_VerboseMinimize)"
-      NoByteCode="$(NFMDP_DUMP_NoByteCode)"
-      NoAttributes="$(NFMDP_DUMP_NoAttributes)"
-      SaveStrings="$(NFMDP_DUMP_SaveStrings)"
-      LoadStrings="$(NFMDP_DUMP_LoadStrings)"
-      GenerateStringsTable="$(NFMDP_DUMP_GenerateStringsTable)"
-      Compile="$(NFMDP_DUMP_Compile)"
-      DumpAll="$(NFMDP_DUMP_DumpAll)"
-      DumpExports="$(NFMDP_DUMP_DumpExports)"
-      GenerateSkeletonFile="$(NFMDP_DUMP_GenerateSkeletonFile)"
-      GenerateSkeletonName="$(NFMDP_DUMP_GenerateSkeletonName)"
-      GenerateSkeletonProject="$(NFMDP_DUMP_GenerateSkeletonProject)"
-      GenerateDependency="$(NFMDP_DUMP_GenerateDependency)"
-      CreateDatabase="@(NFMDP_DUMP_CreateDatabase)"
-      RefreshAssemblyName="$(NFMDP_DUMP_RefreshAssemblyName)"
-      RefreshAssemblyOutput="$(NFMDP_DUMP_RefreshAssemblyOutput)"
-      CreateDatabaseFile="$(NFMDP_DUMP_CreateDatabaseFile)"
-      Resolve="$(NFMDP_DUMP_Resolve)"
-      LoadHints="@(NFMDP_DUMP_LoadHints)"
-      IgnoreAssembly="@(NFMDP_DUMP_IgnoreAssembly)"
-      Load="@(NFMDP_DUMP_Load)"
-      LoadDatabase="@(NFMDP_DUMP_LoadDatabase)"
-      ExcludeClassByName="@(NFMDP_DUMP_ExcludeClassByName)"
-      OutputCommandLine="$(NFMDP_CMD_LINE_OUTPUT)">
-
-      <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
-
-    </MetaDataProcessorTask>
-  </Target>
-
-  <Target Name="NanoCLR_CleanExtraFiles" Condition="'$(NF_IsCoreLibrary)' == 'True' ">
+    Name="NanoCLR_CleanExtraFiles"
+    Condition="'$(NF_IsCoreLibrary)' == 'True' ">
     <Delete Files="
             $(NFMDP_PE_SaveStrings);
             $(NFMDP_PE_GenerateStringsTable);
@@ -732,21 +602,21 @@
             $(NFMDP_PE_CreateDatabaseFile);
             $(NFMDP_PE_GenerateDependency);
             $(NFMDP_PE_SaveStrings);
-            $(NFMDP_DUMP_GenerateStringsTable);
-            $(NFMDP_DUMP_DumpAll);
-            $(NFMDP_DUMP_Compile);
-            $(NFMDP_DUMP_DumpExports);
-            $(NFMDP_DUMP_RefreshAssemblyOutput);
-            $(NFMDP_DUMP_CreateDatabaseFile);
-            $(NFMDP_DUMP_GenerateDependency);
-            $(NFMDP_XML_SaveStrings);
-            $(NFMDP_XML_GenerateStringsTable);
-            $(NFMDP_XML_DumpAll);
-            $(NFMDP_XML_Compile);
-            $(NFMDP_XML_DumpExports);
-            $(NFMDP_XML_RefreshAssemblyOutput);
-            $(NFMDP_XML_CreateDatabaseFile);
-            $(NFMDP_XML_GenerateDependency);
+            $(NFMDP_PE_GenerateStringsTable);
+            $(NFMDP_PE_DumpAll);
+            $(NFMDP_PE_Compile);
+            $(NFMDP_PE_DumpExports);
+            $(NFMDP_PE_RefreshAssemblyOutput);
+            $(NFMDP_PE_CreateDatabaseFile);
+            $(NFMDP_PE_GenerateDependency);
+            $(NFMDP_PE_SaveStrings);
+            $(NFMDP_PE_GenerateStringsTable);
+            $(NFMDP_PE_DumpAll);
+            $(NFMDP_PE_Compile);
+            $(NFMDP_PE_DumpExports);
+            $(NFMDP_PE_RefreshAssemblyOutput);
+            $(NFMDP_PE_CreateDatabaseFile);
+            $(NFMDP_PE_GenerateDependency);
             $(NFMDP_STUBS_SaveStrings);
             $(NFMDP_STUBS_GenerateStringsTable);
             $(NFMDP_STUBS_DumpAll);
@@ -770,29 +640,26 @@
   </Target>
 
   <Target Name="NanoResourceGenerator"
-    Condition="'@(EmbeddedResource)'!='' and '$(NF_IsCoreLibrary)' == 'True'"
-    DependsOnTargets="$(NanoResourceGeneratorDependsOn)"
-    >
+          Condition="'@(EmbeddedResource)'!='' and '$(NF_IsCoreLibrary)' == 'True'"
+          DependsOnTargets="$(NanoResourceGeneratorDependsOn)">
+
     <GenerateNanoResourceTask
       Sources="@(EmbeddedResource)"
       Condition=" '%(EmbeddedResource.Type)' == 'Resx' and '%(EmbeddedResource.GenerateResource)' != 'false'"
       References="@(ReferencePath)"
       UseSourcePath="$(UseSourcePath)"
       StateFile="$(IntermediateOutputPath)$(MSBuildProjectFile).NanoResourceGenerator.Cache"
-      OutputResources="@(EmbeddedResource->'$(ProjectDir)$(IntermediateOutputPath)%(ManifestResourceName).nanoresources')"
-      >
-
+      OutputResources="@(EmbeddedResource->'$(ProjectDir)$(IntermediateOutputPath)%(ManifestResourceName).nanoresources')">
       <Output TaskParameter="OutputResources" ItemName="NFMDP_PE_Resource"/>
       <Output TaskParameter="OutputResources" ItemName="FileWrites"/>
     </GenerateNanoResourceTask>
+
   </Target>
 
-
   <Target Name="Disasm"
-    Condition="Exists('$(NanoFramework_DisasmInput)')"
-    Inputs="$(NanoFramework_DisasmInput)"
-    Outputs="$(NanoFramework_DisasmOutput)"
-    >
+          Condition="Exists('$(NanoFramework_DisasmInput)')"
+          Inputs="$(NanoFramework_DisasmInput)"
+          Outputs="$(NanoFramework_DisasmOutput)">
     <Exec Command="ildasm.exe $(ILDASM_FLAGS) /out=$(NanoFramework_DisasmOutput) $(NanoFramework_DisasmInput)" />
   </Target>
 
@@ -802,56 +669,32 @@
     ###########################################################
   -->
 
+  <Target Name="ReferencedAssemblyDllsToPeFiles"
+          DependsOnTargets="ResolveRuntimeDependencies">
 
-  <!-- Generate stubs for assemblies containing methods to be implemented in native code -->
-  <Target Name="GenerateStubs"
-    Inputs="$(NanoFramework_IntermediateAssembly).pe"
-    Outputs="@(NF_GeneratedStubFile)"
-    DependsOnTargets="ReferencedAssemblyDllsToPeFiles">
-
-    <MakeDir Condition="!Exists('$(NF_GenerateStubsDirectory)')" Directories="$(NF_GenerateStubsDirectory)" />
-
-    <MetaDataProcessorTask
-      Verbose="true"
-      Load="$(NanoFramework_IntermediateAssembly).pe;@(ReferencedPeFile)"
-      GenerateSkeletonName="$(TargetName)"
-      GenerateSkeletonFile="$(NF_GenerateSkeletonFile)"
-      GenerateSkeletonProject="$(NF_GenerateSkeletonProjectName)"
-      RefreshAssemblyName="$(TargetName)"
-      RefreshAssemblyOutput="$(NanoFramework_IntermediateAssembly).pe"
-      OutputCommandLine="$(NFMDP_CMD_LINE_OUTPUT)">
-
-      <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
-
-    </MetaDataProcessorTask>
-
-  </Target>
-
-  <Target Name="ReferencedAssemblyDllsToPeFiles" DependsOnTargets="ResolveRuntimeDependencies">
     <ItemGroup>
       <_ReferencedAssemblyDll Include="@(NanoFramework_StartProgram_ResolvedFiles);@(NanoFramework_StartProgram_ResolvedDependencyFiles)" />
       <_ReferencedPeFile Include="@(_ReferencedAssemblyDll->'%(RootDir)%(Directory)%(filename).pe')" />
-
       <ReferencedPeFile Include="%(_ReferencedPeFile.identity)" Condition="EXISTS(%(_ReferencedPeFile.identity))" />
     </ItemGroup>
+
   </Target>
 
   <Target Name="NanoResourceGenerator"
-    Condition="'@(EmbeddedResource)'!=''"
-    DependsOnTargets="$(NanoResourceGeneratorDependsOn)"
-    >
-    <GenerateNanoResourceTask
-      Sources="@(EmbeddedResource)"
-      Condition=" '%(EmbeddedResource.Type)' == 'Resx' and '%(EmbeddedResource.GenerateResource)' != 'false'"
-      References="@(ReferencePath)"
-      UseSourcePath="$(UseSourcePath)"
-      StateFile="$(IntermediateOutputPath)$(MSBuildProjectFile).NanoGenerateResource.Cache"
-      OutputResources="@(EmbeddedResource->'$(ProjectDir)$(IntermediateOutputPath)%(ManifestResourceName).nanoresources')"
-      >
+          Condition="'@(EmbeddedResource)'!=''"
+          DependsOnTargets="$(NanoResourceGeneratorDependsOn)">
 
+    <GenerateNanoResourceTask
+        Sources="@(EmbeddedResource)"
+        Condition=" '%(EmbeddedResource.Type)' == 'Resx' and '%(EmbeddedResource.GenerateResource)' != 'false'"
+        References="@(ReferencePath)"
+        UseSourcePath="$(UseSourcePath)"
+        StateFile="$(IntermediateOutputPath)$(MSBuildProjectFile).NanoGenerateResource.Cache"
+        OutputResources="@(EmbeddedResource->'$(ProjectDir)$(IntermediateOutputPath)%(ManifestResourceName).nanoresources')">
       <Output TaskParameter="OutputResources" ItemName="NanoFramework_Resources"/>
       <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
     </GenerateNanoResourceTask>
+
   </Target>
 
   <!--
@@ -860,14 +703,14 @@
     -->
 
   <Target Name="ConvertResources"
-    Condition="Exists('$(OutDir)$(TargetFileName)')"
-    >
+          Condition="Exists('$(OutDir)$(TargetFileName)')">
+
     <ResourceConverter
       Condition=" '$(NanoFramework_Skip_ConvertResources)' != 'true' "
       AssemblyName="$(OutDir)$(TargetFileName)"
       OutputFile="$(ProjectDir)\Resources.resx"
-      ResourceDirectories="$(CONVERT_RESOURCES_DIR)"
-      />
+      ResourceDirectories="$(CONVERT_RESOURCES_DIR)"/>
+
   </Target>
 
   <Target Name="NanoGenerateBinaryOutput">
@@ -876,10 +719,9 @@
         AssemblyPE="$(NanoFramework_IntermediateAssembly).pe"
         Assembly="$(NanoFramework_Assembly)$(TargetExt)"
         AssemblyReferences="@(ReferencePath);@(ReferenceDependencyPaths)">
-
       <Output TaskParameter="FileWritten" ItemName="FileWrites" />
     </GenerateBinaryOutputTask>
 
   </Target>
-  
+
 </Project>

--- a/source/VisualStudio.Extension-2019/VisualStudio.Extension.csproj
+++ b/source/VisualStudio.Extension-2019/VisualStudio.Extension.csproj
@@ -1046,7 +1046,7 @@
     <Error Condition="!Exists('..\packages\PropertyChanging.Fody.1.29.3\build\PropertyChanging.Fody.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\PropertyChanging.Fody.1.29.3\build\PropertyChanging.Fody.props'))" />
     <Error Condition="!Exists('..\packages\PropertyChanged.Fody.2.6.1\build\PropertyChanged.Fody.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\PropertyChanged.Fody.2.6.1\build\PropertyChanged.Fody.props'))" />
     <Error Condition="!Exists('..\packages\Fody.4.2.1\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.4.2.1\build\Fody.targets'))" />
-    <Error Condition="!Exists('..\packages\nanoFramework.Tools.MetadataProcessor.1.15.2\build\nanoFramework.Tools.MetaDataProcessor.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\nanoFramework.Tools.MetadataProcessor.1.15.2\build\nanoFramework.Tools.MetaDataProcessor.targets'))" />
+    <Error Condition="!Exists('..\packages\nanoFramework.Tools.MetadataProcessor.Core.2.4.2\build\nanoFramework.Tools.MetaDataProcessor.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\nanoFramework.Tools.MetadataProcessor.Core.2.4.2\build\nanoFramework.Tools.MetaDataProcessor.Core.targets'))" />
   </Target>
   <Import Project="..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.27\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.27\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets')" />
   <Import Project="..\packages\Nerdbank.GitVersioning.3.0.6-beta\build\Nerdbank.GitVersioning.targets" Condition="Exists('..\packages\Nerdbank.GitVersioning.3.0.6-beta\build\Nerdbank.GitVersioning.targets')" />
@@ -1054,7 +1054,7 @@
   <Import Project="..\packages\Microsoft.VisualStudio.ProjectSystem.Sdk.Tools.15.8.243\build\Microsoft.VisualStudio.ProjectSystem.Sdk.Tools.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.ProjectSystem.Sdk.Tools.15.8.243\build\Microsoft.VisualStudio.ProjectSystem.Sdk.Tools.targets')" />
   <Import Project="..\packages\NuGet.VisualStudio.5.0.0\build\NuGet.VisualStudio.targets" Condition="Exists('..\packages\NuGet.VisualStudio.5.0.0\build\NuGet.VisualStudio.targets')" />
   <Import Project="..\packages\Fody.4.2.1\build\Fody.targets" Condition="Exists('..\packages\Fody.4.2.1\build\Fody.targets')" />
-  <Import Project="..\packages\nanoFramework.Tools.MetadataProcessor.1.15.2\build\nanoFramework.Tools.MetaDataProcessor.targets" Condition="Exists('..\packages\nanoFramework.Tools.MetadataProcessor.1.15.2\build\nanoFramework.Tools.MetaDataProcessor.targets')" />
+  <Import Project="..\packages\nanoFramework.Tools.MetadataProcessor.Core.2.4.2\build\nanoFramework.Tools.MetaDataProcessor.Core.targets" Condition="Exists('..\packages\nanoFramework.Tools.MetadataProcessor.Core.2.4.2\build\nanoFramework.Tools.MetaDataProcessor.Core.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/source/VisualStudio.Extension-2019/packages.config
+++ b/source/VisualStudio.Extension-2019/packages.config
@@ -52,7 +52,7 @@
   <package id="MvvmLightLibsStd10" version="5.4.1.1" targetFramework="net47" />
   <package id="nanoFramework.CoreLibrary" version="1.3.0" targetFramework="net472" />
   <package id="nanoFramework.Tools.Debugger.Net" version="1.5.0-preview.14" targetFramework="net472" />
-  <package id="nanoFramework.Tools.MetadataProcessor" version="1.15.2" targetFramework="net472" />
+  <package id="nanoFramework.Tools.MetadataProcessor.Core" version="2.3.11" targetFramework="net461" />
   <package id="Nerdbank.GitVersioning" version="3.0.6-beta" targetFramework="net462" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net472" />
   <package id="NuGet.VisualStudio" version="5.0.0" targetFramework="net472" />

--- a/source/VisualStudio.Extension-2019/version.json
+++ b/source/VisualStudio.Extension-2019/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "release": {
     "branchName" : "release-v{version}",
     "versionIncrement" : "minor",

--- a/source/VisualStudio.Extension/Targets/NFProjectSystem.MDP.targets
+++ b/source/VisualStudio.Extension/Targets/NFProjectSystem.MDP.targets
@@ -108,33 +108,39 @@
   </Target>
 
   <Target Name="CopyToOutDir">
+
     <Copy
         Condition="Exists('$(ProjectDir)$(IntermediateOutputPath)$(TargetName).exe')"
         SourceFiles="$(ProjectDir)$(IntermediateOutputPath)$(TargetName).exe"
         DestinationFolder="$(ProjectDir)$(OutDir)\" >
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
     </Copy>
+
     <Copy
         Condition="Exists('$(ProjectDir)$(IntermediateOutputPath)$(TargetName).dll')"
         SourceFiles="$(ProjectDir)$(IntermediateOutputPath)$(TargetName).dll"
         DestinationFolder="$(ProjectDir)$(OutDir)\" >
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
     </Copy>
+
     <Copy
         Condition="Exists('$(ProjectDir)$(IntermediateOutputPath)$(TargetName).pdbx')"
         SourceFiles="$(ProjectDir)$(IntermediateOutputPath)$(TargetName).pdbx"
         DestinationFolder="$(ProjectDir)$(OutDir)" >
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
     </Copy>
+
     <Copy
         Condition="Exists('$(ProjectDir)$(IntermediateOutputPath)$(TargetName).bin')"
         SourceFiles="$(ProjectDir)$(IntermediateOutputPath)$(TargetName).bin"
         DestinationFolder="$(ProjectDir)$(OutDir)" >
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
     </Copy>
+
   </Target>
 
-  <Target Name="CopyNanoFrameworkFiles" >
+  <Target Name="CopyNanoFrameworkFiles">
+
     <Copy
         Condition="Exists('$(NanoFramework_IntermediateAssembly).pe')"
         SourceFiles="$(NanoFramework_IntermediateAssembly).pe"
@@ -159,7 +165,6 @@
         The ContinueOnError set to true is required because the local paths on the referenced file contain the extension.
         This would cause the task to fail because it would be trying to copy myreferenced.dll.pe and myreferenced.dll.pbx, which obviously don't exit.
         -->
-
     <Copy
         SourceFiles="@(ReferenceCopyLocalPaths->'%(RootDir)%(Directory)%(Filename).pe')"
         DestinationFiles="@(ReferenceCopyLocalPaths->'$(OutDir)%(DestinationSubDirectory)%(Filename).pe')"
@@ -181,21 +186,20 @@
     <Copy
         SourceFiles="@(ReferenceCopyLocalPaths)"
         DestinationFiles="@(ReferenceCopyLocalPaths->'$(IntermediateOutputPath)%(Filename)%(Extension)')"
-        SkipUnchangedFiles="false"
-            >
+        SkipUnchangedFiles="false">
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
     </Copy>
 
   </Target>
 
   <Target Name="MetaDataProcessor"
-      Inputs="$(NanoFramework_Assembly)$(TargetExt);
-        @(ReferencePath);
-        @(ReferenceDependencyPaths);
-        @(ReferenceSatellitePaths);
-        @(NanoFramework_Resources)"
-      Outputs="$(NanoFramework_IntermediateAssembly).pe"
-      DependsOnTargets="$(MetaDataProcessorDependsOn)">
+          Inputs="$(NanoFramework_Assembly)$(TargetExt);
+            @(ReferencePath);
+            @(ReferenceDependencyPaths);
+            @(ReferenceSatellitePaths);
+            @(NanoFramework_Resources)"
+          Outputs="$(NanoFramework_IntermediateAssembly).pe"
+          DependsOnTargets="$(MetaDataProcessorDependsOn)">
 
     <MetaDataProcessorTask
         LoadHints="@(ReferencePath);@(ReferenceDependencyPaths);@(ReferenceSatellitePaths)"
@@ -203,19 +207,15 @@
         Compile="$(NanoFramework_IntermediateAssembly).pe"
         ImportResources="@(NanoFramework_Resources)"
         Minimize="true">
-
       <Output TaskParameter="FilesWritten" ItemName="FileWrites" />
-
     </MetaDataProcessorTask>
-
-    <!--CallTarget is less than ideal... NF_GeneratedStubFile isn't a complete list...-->
-    <CallTarget Targets="GenerateStubs" Condition="'$(NF_GenerateStubs)'=='true'" />
 
     <CallTarget Targets="NanoGenerateBinaryOutput"/>
 
   </Target>
 
-  <Target Name="ResolveRuntimeDependencies" Condition="'$(NF_IsCoreLibrary)' != 'True' ">
+  <Target Name="ResolveRuntimeDependencies"
+          Condition="'$(NF_IsCoreLibrary)' != 'True' ">
 
     <ItemGroup>
       <NanoFramework_StartProgramItem Include="$(NanoFramework_StartProgram)" Condition=" '$(NanoFramework_StartProgram)' != '' " />
@@ -245,7 +245,6 @@
         FindRelatedFiles="true"
         Silent="!$(BuildingProject)"
         StateFile="$(NanoFramework_DebugReferencesStateFile)">
-
       <Output TaskParameter="ResolvedFiles" ItemName="NanoFramework_StartProgram_ResolvedFiles"/>
       <Output TaskParameter="ResolvedDependencyFiles" ItemName="NanoFramework_StartProgram_ResolvedDependencyFiles"/>
       <Output TaskParameter="RelatedFiles" ItemName="NanoFramework_ReferenceRelatedPaths"/>
@@ -253,7 +252,6 @@
       <Output TaskParameter="CopyLocalFiles" ItemName="NanoFramework_ReferenceCopyLocalPaths"/>
       <Output TaskParameter="SuggestedRedirects" ItemName="NanoFramework_SuggestedBindingRedirects"/>
       <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
-
     </ResolveAssemblyReferences>
 
     <ResolveRuntimeDependenciesTask
@@ -284,22 +282,15 @@
     <NFMDP_PE_DumpExports>$(ProjectDir)$(IntermediateOutputPath)$(TargetName)_exports.txt</NFMDP_PE_DumpExports>
     <NFMDP_PE_DumpAll>$(ProjectDir)$(IntermediateOutputPath)$(TargetName)_all.txt</NFMDP_PE_DumpAll>
 
-    <!-- nanoFramework MetaDataProcessor DUMP options -->
-    <NFMDP_DUMP_FILES>true</NFMDP_DUMP_FILES>
-    <NFMDP_DUMP_DumpAll>$(ProjectDir)$(IntermediateOutputPath)$(TargetName).dump</NFMDP_DUMP_DumpAll>
-
     <!-- nanoFramework MetaDataProcessor STUB options -->
     <NFMDP_STUBS_DumpAll>$(ProjectDir)$(IntermediateOutputPath)$(TargetName)_exports2.txt</NFMDP_STUBS_DumpAll>
     <NFMDP_STUB_GenerateSkeletonName>$(AssemblyName)</NFMDP_STUB_GenerateSkeletonName>
-    <NFMDP_STUB_RefreshAssemblyName>$(AssemblyName)</NFMDP_STUB_RefreshAssemblyName>
-    <NFMDP_STUB_RefreshAssemblyOutput>$(NFMDP_PE_Compile)</NFMDP_STUB_RefreshAssemblyOutput>
     <NFMDP_STUB_Resolve>true</NFMDP_STUB_Resolve>
 
     <!-- nanoFramework MetaDataProcessor DAT options -->
 
     <!-- nanoFramework MetaDataProcessor XML options -->
-    <NFMDP_XML_Resolve>true</NFMDP_XML_Resolve>
-    <NFMDP_XML_GenerateDependency>$(ProjectDir)$(IntermediateOutputPath)$(TargetName)_dependency_map.xml</NFMDP_XML_GenerateDependency>
+    <NFMDP_PE_GenerateDependency>$(ProjectDir)$(IntermediateOutputPath)$(TargetName)_dependency_map.xml</NFMDP_PE_GenerateDependency>
 
     <!-- misc -->
     <NanoCLR_DisasmInput>$(ProjectDir)$(IntermediateOutputPath)$(TargetFileName)</NanoCLR_DisasmInput>
@@ -342,35 +333,36 @@
     </NFMDP_STUB_Load>
   </ItemGroup>
 
-  <Target Name="NFMDP_CreateDatabaseAndDependencyMap" DependsOnTargets="MetaDataProcessorDump;MetaDataProcessorDat;MetadataProcessorXML" />
+  <Target Name="NFMDP_CreateDatabaseAndDependencyMap"
+          DependsOnTargets="MetaDataProcessorDat" />
 
   <Target Name="MetaDataProcessorCompile"
-    Inputs="
-        $(NFMDP_PE_Parse);
-        @(NFMDP_PE_LoadHints);
-        $(NFMDP_PE_LoadStrings);
-        @(NFMDP_PE_Load);
-        @(NFMDP_PE_LoadDatabase);
-        @(NFMDP_PE_CreateDatabase);
-        @(NFMDP_PE_Resource)"
-    Outputs="
-        $(NFMDP_PE_SaveStrings);
-        $(NFMDP_PE_GenerateStringsTable);
-        $(NFMDP_PE_DumpAll);
-        $(NFMDP_PE_DumpExports);
-        $(NFMDP_PE_Compile);
-        $(NFMDP_PE_RefreshAssemblyOutput);
-        $(NFMDP_PE_CreateDatabaseFile);
-        $(NFMDP_PE_GenerateDependency)"
-
-    DependsOnTargets="ResolveRuntimeDependencies"
-    Condition="'$(NFMDP_GENERATE_PE)' == 'true'">
+          Inputs="
+            $(NFMDP_PE_Parse);
+            @(NFMDP_PE_LoadHints);
+            $(NFMDP_PE_LoadStrings);
+            @(NFMDP_PE_Load);
+            @(NFMDP_PE_LoadDatabase);
+            @(NFMDP_PE_CreateDatabase);
+            @(NFMDP_PE_Resource)"
+          Outputs="
+            $(NFMDP_PE_SaveStrings);
+            $(NFMDP_PE_GenerateStringsTable);
+            $(NFMDP_PE_DumpAll);
+            $(NFMDP_PE_DumpExports);
+            $(NFMDP_PE_Compile);
+            $(NFMDP_PE_RefreshAssemblyOutput);
+            $(NFMDP_PE_CreateDatabaseFile);
+            $(NFMDP_PE_GenerateDependency)"
+          DependsOnTargets="ResolveRuntimeDependencies"
+          Condition="'$(NFMDP_GENERATE_PE)' == 'true'">
 
     <ItemGroup>
       <NFMDP_PE_CreatedFiles Include="$(NFMDP_PE_CreateDatabaseFile)" Condition="'$(NFMDP_PE_CreateDatabaseFile)'!=''"/>
       <NFMDP_PE_CreatedFiles Include="$(NFMDP_PE_GenerateSkeletonFile)"  Condition="'$(NFMDP_PE_GenerateSkeletonFile)'!=''"/>
       <NFMDP_PE_CreatedFiles Include="$(NFMDP_PE_GenerateDependency)"  Condition="'$(NFMDP_PE_GenerateDependency)'!=''"/>
     </ItemGroup>
+
     <MakeDir Directories="@(NFMDP_PE_CreatedFiles->'%(RootDir)%(Directory)')" />
 
     <ItemGroup>
@@ -395,84 +387,75 @@
       <NFMDP_STUB_GenerateSkeletonProject Condition="'$(NFMDP_STUB_GenerateSkeletonProject)'==''" >$(AssemblyName)</NFMDP_STUB_GenerateSkeletonProject>
     </PropertyGroup>
 
-    <Message Text="Distilling assemblies to nanoCLR PE files..." />
+    <Message Text="Distilling assemblies to nanoCLR PE files (no stubs)..." Condition="'$(NFMDP_GENERATE_STUBS)' == 'false'" />
     <!-- Compile to PE -->
     <MetaDataProcessorTask
-      Minimize="$(NFMDP_PE_Minimize)"
-      Verbose="$(NFMDP_PE_Verbose)"
-      Parse="$(NFMDP_PE_Parse)"
-      VerboseMinimize="$(NFMDP_PE_VerboseMinimize)"
-      NoByteCode="$(NFMDP_PE_NoByteCode)"
-      NoAttributes="$(NFMDP_PE_NoAttributes)"
-      SaveStrings="$(NFMDP_PE_SaveStrings)"
-      LoadStrings="$(NFMDP_PE_LoadStrings)"
-      ImportResources="@(NFMDP_PE_Resource)"
-      GenerateStringsTable="$(NFMDP_PE_GenerateStringsTable)"
-      Compile="$(NFMDP_PE_Compile)"
-      DumpAll="$(NFMDP_PE_DumpAll)"
-      DumpExports="$(NFMDP_PE_DumpExports)"
-      GenerateSkeletonFile="$(NFMDP_PE_GenerateSkeletonFile)"
-      GenerateSkeletonName="$(NFMDP_PE_GenerateSkeletonName)"
-      GenerateSkeletonProject="$(NFMDP_PE_GenerateSkeletonProject)"
-      GenerateDependency="$(NFMDP_PE_GenerateDependency)"
-      CreateDatabase="@(NFMDP_PE_CreateDatabase)"
-      RefreshAssemblyName="$(NFMDP_PE_RefreshAssemblyName)"
-      RefreshAssemblyOutput="$(NFMDP_PE_RefreshAssemblyOutput)"
-      CreateDatabaseFile="$(NFMDP_PE_CreateDatabaseFile)"
-      Resolve="$(NFMDP_PE_Resolve)"
-      LoadHints="@(NFMDP_PE_LoadHints)"
-      IgnoreAssembly="@(NFMDP_PE_IgnoreAssembly)"
-      Load="@(NFMDP_PE_Load)"
-      LoadDatabase="@(NFMDP_PE_LoadDatabase)"
-      OutputCommandLine="$(NFMDP_CMD_LINE_OUTPUT)"
-      ExcludeClassByName="@(NFMDP_PE_ExcludeClassByName)">
-
+        Minimize="$(NFMDP_PE_Minimize)"
+        Verbose="$(NFMDP_PE_Verbose)"
+        Parse="$(NFMDP_PE_Parse)"
+        VerboseMinimize="$(NFMDP_PE_VerboseMinimize)"
+        NoByteCode="$(NFMDP_PE_NoByteCode)"
+        NoAttributes="$(NFMDP_PE_NoAttributes)"
+        SaveStrings="$(NFMDP_PE_SaveStrings)"
+        LoadStrings="$(NFMDP_PE_LoadStrings)"
+        ImportResources="@(NFMDP_PE_Resource)"
+        GenerateStringsTable="$(NFMDP_PE_GenerateStringsTable)"
+        Compile="$(NFMDP_PE_Compile)"
+        DumpAll="$(NFMDP_PE_DumpAll)"
+        DumpExports="$(NFMDP_PE_DumpExports)"
+        GenerateSkeletonFile="$(NFMDP_PE_GenerateSkeletonFile)"
+        GenerateSkeletonName="$(NFMDP_PE_GenerateSkeletonName)"
+        GenerateSkeletonProject="$(NFMDP_PE_GenerateSkeletonProject)"
+        GenerateDependency="$(NFMDP_PE_GenerateDependency)"
+        CreateDatabase="@(NFMDP_PE_CreateDatabase)"
+        RefreshAssemblyName="$(NFMDP_PE_RefreshAssemblyName)"
+        RefreshAssemblyOutput="$(NFMDP_PE_RefreshAssemblyOutput)"
+        CreateDatabaseFile="$(NFMDP_PE_CreateDatabaseFile)"
+        LoadHints="@(NFMDP_PE_LoadHints)"
+        IgnoreAssembly="@(NFMDP_PE_IgnoreAssembly)"
+        ExcludeClassByName="@(NFMDP_PE_ExcludeClassByName)"
+        OutputCommandLine="$(NFMDP_CMD_LINE_OUTPUT)"
+        Condition="'$(NFMDP_GENERATE_STUBS)' == 'false'">
       <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
-
     </MetaDataProcessorTask>
 
+    <Message Text="Distilling assemblies to nanoCLR PE files along with stubs and skeleton files..." Condition="'$(NFMDP_GENERATE_STUBS)' == 'true'"/>
     <!-- Create STUB file -->
     <MetaDataProcessorTask
-      Minimize="$(NFMDP_STUB_Minimize)"
-      Verbose="$(NFMDP_STUB_Verbose)"
-      Parse="$(NFMDP_STUB_Parse)"
-      VerboseMinimize="$(NFMDP_STUB_VerboseMinimize)"
-      NoByteCode="$(NFMDP_STUB_NoByteCode)"
-      NoAttributes="$(NFMDP_STUB_NoAttributes)"
-      SaveStrings="$(NFMDP_STUB_SaveStrings)"
-      LoadStrings="$(NFMDP_STUB_LoadStrings)"
-      GenerateStringsTable="$(NFMDP_STUB_GenerateStringsTable)"
-      Compile="$(NFMDP_STUB_Compile)"
-      DumpAll="$(NFMDP_STUB_DumpAll)"
-      DumpExports="$(NFMDP_STUB_DumpExports)"
-      GenerateSkeletonFile="$(NFMDP_STUB_GenerateSkeletonFile)"
-      GenerateSkeletonName="$(NFMDP_STUB_GenerateSkeletonName)"
-      GenerateSkeletonProject="$(NFMDP_STUB_GenerateSkeletonProject)"
-      SkeletonWithoutInterop="$(NFMDP_STUB_SkeletonWithoutInterop)"
-      GenerateDependency="$(NFMDP_STUB_GenerateDependency)"
-      CreateDatabase="@(NFMDP_STUB_CreateDatabase)"
-      RefreshAssemblyName="$(NFMDP_STUB_RefreshAssemblyName)"
-      RefreshAssemblyOutput="$(NFMDP_STUB_RefreshAssemblyOutput)"
-      CreateDatabaseFile="$(NFMDP_STUB_CreateDatabaseFile)"
-      Resolve="$(NFMDP_STUB_Resolve)"
-      LoadHints="@(NFMDP_STUB_LoadHints)"
-      IgnoreAssembly="@(NFMDP_STUB_IgnoreAssembly)"
-      Load="@(NFMDP_STUB_Load)"
-      LoadDatabase="@(NFMDP_STUB_LoadDatabase)"
-      ExcludeClassByName="@(NFMDP_STUB_ExcludeClassByName)"
-      OutputCommandLine="$(NFMDP_CMD_LINE_OUTPUT)"
-      Condition="'$(NFMDP_GENERATE_STUBS)' == 'true'">
-
+        Minimize="$(NFMDP_PE_Minimize)"
+        Verbose="$(NFMDP_PE_Verbose)"
+        Parse="$(NFMDP_PE_Parse)"
+        VerboseMinimize="$(NFMDP_PE_VerboseMinimize)"
+        NoByteCode="$(NFMDP_STUB_NoByteCode)"
+        NoAttributes="$(NFMDP_STUB_NoAttributes)"
+        SaveStrings="$(NFMDP_STUB_SaveStrings)"
+        LoadStrings="$(NFMDP_STUB_LoadStrings)"
+        GenerateStringsTable="$(NFMDP_STUB_GenerateStringsTable)"
+        Compile="$(NFMDP_PE_Compile)"
+        DumpAll="$(NFMDP_STUBS_DumpAll)"
+        DumpExports="$(NFMDP_STUB_DumpExports)"
+        GenerateSkeletonFile="$(NFMDP_STUB_GenerateSkeletonFile)"
+        GenerateSkeletonName="$(NFMDP_STUB_GenerateSkeletonName)"
+        GenerateSkeletonProject="$(NFMDP_STUB_GenerateSkeletonProject)"
+        SkeletonWithoutInterop="$(NFMDP_STUB_SkeletonWithoutInterop)"
+        GenerateDependency="$(NFMDP_STUB_GenerateDependency)"
+        CreateDatabase="@(NFMDP_STUB_CreateDatabase)"
+        RefreshAssemblyName="$(NFMDP_STUB_RefreshAssemblyName)"
+        RefreshAssemblyOutput="$(NFMDP_STUB_RefreshAssemblyOutput)"
+        CreateDatabaseFile="$(NFMDP_STUB_CreateDatabaseFile)"
+        LoadHints="@(NFMDP_PE_LoadHints)"
+        IgnoreAssembly="@(NFMDP_STUB_IgnoreAssembly)"
+        ExcludeClassByName="@(NFMDP_PE_ExcludeClassByName)"
+        OutputCommandLine="$(NFMDP_CMD_LINE_OUTPUT)"
+        Condition="'$(NFMDP_GENERATE_STUBS)' == 'true'">
       <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
-
     </MetaDataProcessorTask>
 
-    <CallTarget Targets="GenerateStubs" Condition="'$(NF_GenerateStubs)'=='true'" />
-    
     <!-- Copy files (dll, pe, pdb and pdbx) to ouput directory -->
     <CallTarget Targets="CopyFilesToOutputDirectory" />
     <CallTarget Targets="CopyNanoFrameworkFiles" />
     <CallTarget Targets="CopyBackNanoFrameworkDlls" />
+
   </Target>
 
 
@@ -482,27 +465,26 @@
   </Target>
 
   <!-- MetaDataProcessor DAT -->
-  <Target
-    Name="MetaDataProcessorDat"
-    Inputs="
-        $(NFMDP_DAT_Parse);
-        @(NFMDP_DAT_LoadHints);
-        $(NFMDP_DAT_LoadStrings);
-        @(NFMDP_DAT_Load);
-        @(NFMDP_DAT_LoadDatabase);
-        @(NFMDP_DAT_CreateDatabase);
-        @(ResolvedPEFile);
-        $(MsBuildProjectFullPath)"
-    Outputs="
-        $(NFMDP_DAT_SaveStrings);
-        $(NFMDP_DAT_GenerateStringsTable);
-        $(NFMDP_DAT_DumpAll);
-        $(NFMDP_DAT_DumpExports);
-        $(NFMDP_DAT_Compile);
-        $(NFMDP_DAT_RefreshAssemblyOutput);
-        $(NFMDP_DAT_CreateDatabaseFile);
-        $(NFMDP_DAT_GenerateDependency)"
-    Condition="'$(NFMDP_DAT_FILES)' == 'true'">
+  <Target Name="MetaDataProcessorDat"
+          Inputs="
+            $(NFMDP_DAT_Parse);
+            @(NFMDP_DAT_LoadHints);
+            $(NFMDP_DAT_LoadStrings);
+            @(NFMDP_DAT_Load);
+            @(NFMDP_DAT_LoadDatabase);
+            @(NFMDP_DAT_CreateDatabase);
+            @(ResolvedPEFile);
+            $(MsBuildProjectFullPath)"
+          Outputs="
+            $(NFMDP_DAT_SaveStrings);
+            $(NFMDP_DAT_GenerateStringsTable);
+            $(NFMDP_DAT_DumpAll);
+            $(NFMDP_DAT_DumpExports);
+            $(NFMDP_DAT_Compile);
+            $(NFMDP_DAT_RefreshAssemblyOutput);
+            $(NFMDP_DAT_CreateDatabaseFile);
+            $(NFMDP_DAT_GenerateDependency)"
+          Condition="'$(NFMDP_DAT_FILES)' == 'true'">
 
     <CallTarget Targets="MetaDataProcessorDat_MSG" Condition="'$(NFMDP_DAT_Verbose)'=='true'" />
 
@@ -515,99 +497,45 @@
     <MakeDir Directories="@(NFMDP_DAT_CreatedFiles->'%(RootDir)%(Directory)')" />
 
     <MetaDataProcessorTask
-      Minimize="$(NFMDP_DAT_Minimize)"
-      Verbose="$(NFMDP_DAT_Verbose)"
-      Parse="$(NFMDP_DAT_Parse)"
-      VerboseMinimize="$(NFMDP_DAT_VerboseMinimize)"
-      NoByteCode="$(NFMDP_DAT_NoByteCode)"
-      NoAttributes="$(NFMDP_DAT_NoAttributes)"
-      SaveStrings="$(NFMDP_DAT_SaveStrings)"
-      LoadStrings="$(NFMDP_DAT_LoadStrings)"
-      GenerateStringsTable="$(NFMDP_DAT_GenerateStringsTable)"
-      Compile="$(NFMDP_DAT_Compile)"
-      DumpAll="$(NFMDP_DAT_DumpAll)"
-      DumpExports="$(NFMDP_DAT_DumpExports)"
-      GenerateSkeletonFile="$(NFMDP_DAT_GenerateSkeletonFile)"
-      GenerateSkeletonName="$(NFMDP_DAT_GenerateSkeletonName)"
-      GenerateSkeletonProject="$(NFMDP_DAT_GenerateSkeletonProject)"
-      GenerateDependency="$(NFMDP_DAT_GenerateDependency)"
-      CreateDatabase="@(NFMDP_DAT_CreateDatabase)"
-      RefreshAssemblyName="$(NFMDP_DAT_RefreshAssemblyName)"
-      RefreshAssemblyOutput="$(NFMDP_DAT_RefreshAssemblyOutput)"
-      CreateDatabaseFile="$(NFMDP_DAT_CreateDatabaseFile)"
-      Resolve="$(NFMDP_DAT_Resolve)"
-      LoadHints="@(NFMDP_DAT_LoadHints)"
-      IgnoreAssembly="@(NFMDP_DAT_IgnoreAssembly)"
-      Load="@(NFMDP_DAT_Load)"
-      LoadDatabase="@(NFMDP_DAT_LoadDatabase)"
-      ExcludeClassByName="@(NFMDP_DAT_ExcludeClassByName)"
-      OutputCommandLine="$(NFMDP_CMD_LINE_OUTPUT)">
-
+        Minimize="$(NFMDP_DAT_Minimize)"
+        Verbose="$(NFMDP_DAT_Verbose)"
+        Parse="$(NFMDP_DAT_Parse)"
+        VerboseMinimize="$(NFMDP_DAT_VerboseMinimize)"
+        NoByteCode="$(NFMDP_DAT_NoByteCode)"
+        NoAttributes="$(NFMDP_DAT_NoAttributes)"
+        SaveStrings="$(NFMDP_DAT_SaveStrings)"
+        LoadStrings="$(NFMDP_DAT_LoadStrings)"
+        GenerateStringsTable="$(NFMDP_DAT_GenerateStringsTable)"
+        Compile="$(NFMDP_DAT_Compile)"
+        DumpAll="$(NFMDP_DAT_DumpAll)"
+        DumpExports="$(NFMDP_DAT_DumpExports)"
+        GenerateSkeletonFile="$(NFMDP_DAT_GenerateSkeletonFile)"
+        GenerateSkeletonName="$(NFMDP_DAT_GenerateSkeletonName)"
+        GenerateSkeletonProject="$(NFMDP_DAT_GenerateSkeletonProject)"
+        GenerateDependency="$(NFMDP_DAT_GenerateDependency)"
+        CreateDatabase="@(NFMDP_DAT_CreateDatabase)"
+        RefreshAssemblyName="$(NFMDP_DAT_RefreshAssemblyName)"
+        RefreshAssemblyOutput="$(NFMDP_DAT_RefreshAssemblyOutput)"
+        CreateDatabaseFile="$(NFMDP_DAT_CreateDatabaseFile)"
+        Resolve="$(NFMDP_DAT_Resolve)"
+        LoadHints="@(NFMDP_DAT_LoadHints)"
+        IgnoreAssembly="@(NFMDP_DAT_IgnoreAssembly)"
+        Load="@(NFMDP_DAT_Load)"
+        LoadDatabase="@(NFMDP_DAT_LoadDatabase)"
+        ExcludeClassByName="@(NFMDP_DAT_ExcludeClassByName)"
+        OutputCommandLine="$(NFMDP_CMD_LINE_OUTPUT)">
       <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
-
-    </MetaDataProcessorTask>
-
-  </Target>
-
-  <!-- NFMDP_XML -->
-  <Target
-    Name="MetaDataProcessorXml"
-    Inputs="@(NFMDP_XML_Load)"
-    Outputs="
-        $(NFMDP_XML_SaveStrings);
-        $(NFMDP_XML_GenerateStringsTable);
-        $(NFMDP_XML_DumpAll);
-        $(NFMDP_XML_DumpExports);
-        $(NFMDP_XML_Compile);
-        $(NFMDP_XML_RefreshAssemblyOutput);
-        $(NFMDP_XML_CreateDatabaseFile);
-        $(NFMDP_XML_GenerateDependency)"
-    Condition="'$(NFMDP_XML_FILES)' == 'true'">
-
-    <Message Text="Creating dependency map $(NFMDP_XML_GenerateDependency)..." />
-
-    <MetaDataProcessorTask
-      Minimize="$(NFMDP_XML_Minimize)"
-      Verbose="$(NFMDP_XML_Verbose)"
-      Parse="$(NFMDP_XML_Parse)"
-      VerboseMinimize="$(NFMDP_XML_VerboseMinimize)"
-      NoByteCode="$(NFMDP_XML_NoByteCode)"
-      NoAttributes="$(NFMDP_XML_NoAttributes)"
-      SaveStrings="$(NFMDP_XML_SaveStrings)"
-      LoadStrings="$(NFMDP_XML_LoadStrings)"
-      GenerateStringsTable="$(NFMDP_XML_GenerateStringsTable)"
-      Compile="$(NFMDP_XML_Compile)"
-      DumpAll="$(NFMDP_XML_DumpAll)"
-      DumpExports="$(NFMDP_XML_DumpExports)"
-      GenerateSkeletonFile="$(NFMDP_XML_GenerateSkeletonFile)"
-      GenerateSkeletonName="$(NFMDP_XML_GenerateSkeletonName)"
-      GenerateSkeletonProject="$(NFMDP_XML_GenerateSkeletonProject)"
-      GenerateDependency="$(NFMDP_XML_GenerateDependency)"
-      CreateDatabase="$(NFMDP_XML_CreateDatabase)"
-      RefreshAssemblyName="$(NFMDP_XML_RefreshAssemblyName)"
-      RefreshAssemblyOutput="$(NFMDP_XML_RefreshAssemblyOutput)"
-      CreateDatabaseFile="$(NFMDP_XML_CreateDatabaseFile)"
-      Resolve="$(NFMDP_XML_Resolve)"
-      LoadHints="@(NFMDP_XML_LoadHints)"
-      IgnoreAssembly="@(NFMDP_XML_IgnoreAssembly)"
-      Load="@(NFMDP_XML_Load)"
-      LoadDatabase="@(NFMDP_XML_LoadDatabase)"
-      ExcludeClassByName="@(NFMDP_XML_ExcludeClassByName)"
-      OutputCommandLine="$(NFMDP_CMD_LINE_OUTPUT)">
-
-      <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
-
     </MetaDataProcessorTask>
 
   </Target>
 
   <!-- this target is to be used when building A CORE ASSEMBLY -->
-  <Target Name="ResolveRuntimeDependencies" Condition="'$(NF_IsCoreLibrary)' == 'True' ">
+  <Target Name="ResolveRuntimeDependencies"
+          Condition="'$(NF_IsCoreLibrary)' == 'True' ">
 
     <CreateItem
         Include="$(NanoFramework_StartProgram)"
-        Condition=" '$(NanoFramework_StartProgram)' != '' "
-        >
+        Condition=" '$(NanoFramework_StartProgram)' != '' ">
       <Output TaskParameter="Include" ItemName="NanoFramework_StartProgramItem"/>
     </CreateItem>
 
@@ -620,13 +548,13 @@
         AssemblyFiles="$(NanoFramework_StartProgram);@(_ResolvedProjectReferencePaths)"
         CandidateAssemblyFiles="@(Content);@(None)"
         SearchPaths="{CandidateAssemblyFiles};
-                         $(ReferencePath);
-                         {HintPathFromItem};
-                         $(TargetFrameworkDirectory);
-                         {Registry:$(FrameworkRegistryBase),$(TargetFrameworkVersion),$(AssemblyFoldersSuffix)$(AssemblyFoldersExConditions)};
-                         {RawFileName};
-                         $(OutputPath);
-                         @(NanoFramework_StartProgramItem->'%(RootDir)%(Directory)')"
+                      $(ReferencePath);
+                      {HintPathFromItem};
+                      $(TargetFrameworkDirectory);
+                      {Registry:$(FrameworkRegistryBase),$(TargetFrameworkVersion),$(AssemblyFoldersSuffix)$(AssemblyFoldersExConditions)};
+                      {RawFileName};
+                      $(OutputPath);
+                      @(NanoFramework_StartProgramItem->'%(RootDir)%(Directory)')"
         TargetProcessorArchitecture="$(ProcessorArchitecture)"
         AppConfigFile="@(_ResolveAssemblyReferencesApplicationConfigFileForExes)"
         AutoUnify="$(AutoUnifyAssemblyReferences)"
@@ -635,7 +563,6 @@
         FindRelatedFiles="true"
         Silent="!$(BuildingProject)"
         StateFile="$(NanoFramework_DebugReferencesStateFile)">
-
       <Output TaskParameter="ResolvedFiles" ItemName="NanoFramework_StartProgram_ResolvedFiles"/>
       <Output TaskParameter="ResolvedDependencyFiles" ItemName="NanoFramework_StartProgram_ResolvedDependencyFiles"/>
       <Output TaskParameter="RelatedFiles" ItemName="NanoFramework_ReferenceRelatedPaths"/>
@@ -643,16 +570,13 @@
       <Output TaskParameter="CopyLocalFiles" ItemName="NanoFramework_ReferenceCopyLocalPaths"/>
       <Output TaskParameter="SuggestedRedirects" ItemName="NanoFramework_SuggestedBindingRedirects"/>
       <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
-
     </ResolveAssemblyReference>
 
     <ItemGroup>
       <_ResolvedPEFile Include="@(NanoFramework_StartProgram_ResolvedFiles->'%(RootDir)%(Directory)%(filename).pe')" />
       <_ResolvedPEFile Include="@(NanoFramework_StartProgram_ResolvedFiles->'%(RootDir)%(Directory)%(filename).pe')" />
-
       <_ResolvedPEFile Include="@(NanoFramework_StartProgram_ResolvedDependencyFiles->'%(RootDir)%(Directory)%(filename).pe')" />
       <_ResolvedPEFile Include="@(NanoFramework_StartProgram_ResolvedDependencyFiles->'%(RootDir)%(Directory)%(filename).pe')" />
-
       <ResolvedPEFile Include="%(_ResolvedPEFile.identity)" Condition="EXISTS(%(_ResolvedPEFile.identity))" />
     </ItemGroup>
 
@@ -665,63 +589,9 @@
 
   </Target>
 
-
   <Target
-    Name="MetaDataProcessorDump"
-    Inputs="
-        $(NFMDP_DUMP_Parse);
-        @(NFMDP_DUMP_LoadHints);
-        $(NFMDP_DUMP_LoadStrings);
-        @(NFMDP_DUMP_Load);
-        @(NFMDP_DUMP_LoadDatabase);
-        @(NFMDP_DUMP_CreateDatabase)"
-    Outputs="
-        $(NFMDP_DUMP_SaveStrings);
-        $(NFMDP_DUMP_GenerateStringsTable);
-        $(NFMDP_DUMP_DumpAll);
-        $(NFMDP_DUMP_Compile);
-        $(NFMDP_DUMP_DumpExports);
-        $(NFMDP_DUMP_RefreshAssemblyOutput);
-        $(NFMDP_DUMP_CreateDatabaseFile);
-        $(NFMDP_DUMP_GenerateDependency)"
-    Condition="'$(NFMDP_DUMP_FILES)' == 'true'"
-    >
-    <!-- Create DUMP file -->
-    <MetaDataProcessorTask
-      Minimize="$(NFMDP_DUMP_Minimize)"
-      Verbose="$(NFMDP_DUMP_Verbose)"
-      Parse="$(NFMDP_DUMP_Parse)"
-      VerboseMinimize="$(NFMDP_DUMP_VerboseMinimize)"
-      NoByteCode="$(NFMDP_DUMP_NoByteCode)"
-      NoAttributes="$(NFMDP_DUMP_NoAttributes)"
-      SaveStrings="$(NFMDP_DUMP_SaveStrings)"
-      LoadStrings="$(NFMDP_DUMP_LoadStrings)"
-      GenerateStringsTable="$(NFMDP_DUMP_GenerateStringsTable)"
-      Compile="$(NFMDP_DUMP_Compile)"
-      DumpAll="$(NFMDP_DUMP_DumpAll)"
-      DumpExports="$(NFMDP_DUMP_DumpExports)"
-      GenerateSkeletonFile="$(NFMDP_DUMP_GenerateSkeletonFile)"
-      GenerateSkeletonName="$(NFMDP_DUMP_GenerateSkeletonName)"
-      GenerateSkeletonProject="$(NFMDP_DUMP_GenerateSkeletonProject)"
-      GenerateDependency="$(NFMDP_DUMP_GenerateDependency)"
-      CreateDatabase="@(NFMDP_DUMP_CreateDatabase)"
-      RefreshAssemblyName="$(NFMDP_DUMP_RefreshAssemblyName)"
-      RefreshAssemblyOutput="$(NFMDP_DUMP_RefreshAssemblyOutput)"
-      CreateDatabaseFile="$(NFMDP_DUMP_CreateDatabaseFile)"
-      Resolve="$(NFMDP_DUMP_Resolve)"
-      LoadHints="@(NFMDP_DUMP_LoadHints)"
-      IgnoreAssembly="@(NFMDP_DUMP_IgnoreAssembly)"
-      Load="@(NFMDP_DUMP_Load)"
-      LoadDatabase="@(NFMDP_DUMP_LoadDatabase)"
-      ExcludeClassByName="@(NFMDP_DUMP_ExcludeClassByName)"
-      OutputCommandLine="$(NFMDP_CMD_LINE_OUTPUT)">
-
-      <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
-
-    </MetaDataProcessorTask>
-  </Target>
-
-  <Target Name="NanoCLR_CleanExtraFiles" Condition="'$(NF_IsCoreLibrary)' == 'True' ">
+    Name="NanoCLR_CleanExtraFiles"
+    Condition="'$(NF_IsCoreLibrary)' == 'True' ">
     <Delete Files="
             $(NFMDP_PE_SaveStrings);
             $(NFMDP_PE_GenerateStringsTable);
@@ -732,21 +602,21 @@
             $(NFMDP_PE_CreateDatabaseFile);
             $(NFMDP_PE_GenerateDependency);
             $(NFMDP_PE_SaveStrings);
-            $(NFMDP_DUMP_GenerateStringsTable);
-            $(NFMDP_DUMP_DumpAll);
-            $(NFMDP_DUMP_Compile);
-            $(NFMDP_DUMP_DumpExports);
-            $(NFMDP_DUMP_RefreshAssemblyOutput);
-            $(NFMDP_DUMP_CreateDatabaseFile);
-            $(NFMDP_DUMP_GenerateDependency);
-            $(NFMDP_XML_SaveStrings);
-            $(NFMDP_XML_GenerateStringsTable);
-            $(NFMDP_XML_DumpAll);
-            $(NFMDP_XML_Compile);
-            $(NFMDP_XML_DumpExports);
-            $(NFMDP_XML_RefreshAssemblyOutput);
-            $(NFMDP_XML_CreateDatabaseFile);
-            $(NFMDP_XML_GenerateDependency);
+            $(NFMDP_PE_GenerateStringsTable);
+            $(NFMDP_PE_DumpAll);
+            $(NFMDP_PE_Compile);
+            $(NFMDP_PE_DumpExports);
+            $(NFMDP_PE_RefreshAssemblyOutput);
+            $(NFMDP_PE_CreateDatabaseFile);
+            $(NFMDP_PE_GenerateDependency);
+            $(NFMDP_PE_SaveStrings);
+            $(NFMDP_PE_GenerateStringsTable);
+            $(NFMDP_PE_DumpAll);
+            $(NFMDP_PE_Compile);
+            $(NFMDP_PE_DumpExports);
+            $(NFMDP_PE_RefreshAssemblyOutput);
+            $(NFMDP_PE_CreateDatabaseFile);
+            $(NFMDP_PE_GenerateDependency);
             $(NFMDP_STUBS_SaveStrings);
             $(NFMDP_STUBS_GenerateStringsTable);
             $(NFMDP_STUBS_DumpAll);
@@ -770,29 +640,26 @@
   </Target>
 
   <Target Name="NanoResourceGenerator"
-    Condition="'@(EmbeddedResource)'!='' and '$(NF_IsCoreLibrary)' == 'True'"
-    DependsOnTargets="$(NanoResourceGeneratorDependsOn)"
-    >
-    <GenerateNanoResourceTask
-      Sources="@(EmbeddedResource)"
-      Condition=" '%(EmbeddedResource.Type)' == 'Resx' and '%(EmbeddedResource.GenerateResource)' != 'false'"
-      References="@(ReferencePath)"
-      UseSourcePath="$(UseSourcePath)"
-      StateFile="$(IntermediateOutputPath)$(MSBuildProjectFile).NanoResourceGenerator.Cache"
-      OutputResources="@(EmbeddedResource->'$(ProjectDir)$(IntermediateOutputPath)%(ManifestResourceName).nanoresources')"
-      >
+          Condition="'@(EmbeddedResource)'!='' and '$(NF_IsCoreLibrary)' == 'True'"
+          DependsOnTargets="$(NanoResourceGeneratorDependsOn)">
 
+    <GenerateNanoResourceTask
+        Sources="@(EmbeddedResource)"
+        Condition=" '%(EmbeddedResource.Type)' == 'Resx' and '%(EmbeddedResource.GenerateResource)' != 'false'"
+        References="@(ReferencePath)"
+        UseSourcePath="$(UseSourcePath)"
+        StateFile="$(IntermediateOutputPath)$(MSBuildProjectFile).NanoResourceGenerator.Cache"
+        OutputResources="@(EmbeddedResource->'$(ProjectDir)$(IntermediateOutputPath)%(ManifestResourceName).nanoresources')">
       <Output TaskParameter="OutputResources" ItemName="NFMDP_PE_Resource"/>
       <Output TaskParameter="OutputResources" ItemName="FileWrites"/>
     </GenerateNanoResourceTask>
+
   </Target>
 
-
   <Target Name="Disasm"
-    Condition="Exists('$(NanoFramework_DisasmInput)')"
-    Inputs="$(NanoFramework_DisasmInput)"
-    Outputs="$(NanoFramework_DisasmOutput)"
-    >
+          Condition="Exists('$(NanoFramework_DisasmInput)')"
+          Inputs="$(NanoFramework_DisasmInput)"
+          Outputs="$(NanoFramework_DisasmOutput)">
     <Exec Command="ildasm.exe $(ILDASM_FLAGS) /out=$(NanoFramework_DisasmOutput) $(NanoFramework_DisasmInput)" />
   </Target>
 
@@ -802,56 +669,32 @@
     ###########################################################
   -->
 
+  <Target Name="ReferencedAssemblyDllsToPeFiles"
+          DependsOnTargets="ResolveRuntimeDependencies">
 
-  <!-- Generate stubs for assemblies containing methods to be implemented in native code -->
-  <Target Name="GenerateStubs"
-    Inputs="$(NanoFramework_IntermediateAssembly).pe"
-    Outputs="@(NF_GeneratedStubFile)"
-    DependsOnTargets="ReferencedAssemblyDllsToPeFiles">
-
-    <MakeDir Condition="!Exists('$(NF_GenerateStubsDirectory)')" Directories="$(NF_GenerateStubsDirectory)" />
-
-    <MetaDataProcessorTask
-      Verbose="true"
-      Load="$(NanoFramework_IntermediateAssembly).pe;@(ReferencedPeFile)"
-      GenerateSkeletonName="$(TargetName)"
-      GenerateSkeletonFile="$(NF_GenerateSkeletonFile)"
-      GenerateSkeletonProject="$(NF_GenerateSkeletonProjectName)"
-      RefreshAssemblyName="$(TargetName)"
-      RefreshAssemblyOutput="$(NanoFramework_IntermediateAssembly).pe"
-      OutputCommandLine="$(NFMDP_CMD_LINE_OUTPUT)">
-
-      <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
-
-    </MetaDataProcessorTask>
-
-  </Target>
-
-  <Target Name="ReferencedAssemblyDllsToPeFiles" DependsOnTargets="ResolveRuntimeDependencies">
     <ItemGroup>
       <_ReferencedAssemblyDll Include="@(NanoFramework_StartProgram_ResolvedFiles);@(NanoFramework_StartProgram_ResolvedDependencyFiles)" />
       <_ReferencedPeFile Include="@(_ReferencedAssemblyDll->'%(RootDir)%(Directory)%(filename).pe')" />
-
       <ReferencedPeFile Include="%(_ReferencedPeFile.identity)" Condition="EXISTS(%(_ReferencedPeFile.identity))" />
     </ItemGroup>
+
   </Target>
 
   <Target Name="NanoResourceGenerator"
-    Condition="'@(EmbeddedResource)'!=''"
-    DependsOnTargets="$(NanoResourceGeneratorDependsOn)"
-    >
-    <GenerateNanoResourceTask
-      Sources="@(EmbeddedResource)"
-      Condition=" '%(EmbeddedResource.Type)' == 'Resx' and '%(EmbeddedResource.GenerateResource)' != 'false'"
-      References="@(ReferencePath)"
-      UseSourcePath="$(UseSourcePath)"
-      StateFile="$(IntermediateOutputPath)$(MSBuildProjectFile).NanoGenerateResource.Cache"
-      OutputResources="@(EmbeddedResource->'$(ProjectDir)$(IntermediateOutputPath)%(ManifestResourceName).nanoresources')"
-      >
+          Condition="'@(EmbeddedResource)'!=''"
+          DependsOnTargets="$(NanoResourceGeneratorDependsOn)">
 
+    <GenerateNanoResourceTask
+        Sources="@(EmbeddedResource)"
+        Condition=" '%(EmbeddedResource.Type)' == 'Resx' and '%(EmbeddedResource.GenerateResource)' != 'false'"
+        References="@(ReferencePath)"
+        UseSourcePath="$(UseSourcePath)"
+        StateFile="$(IntermediateOutputPath)$(MSBuildProjectFile).NanoGenerateResource.Cache"
+        OutputResources="@(EmbeddedResource->'$(ProjectDir)$(IntermediateOutputPath)%(ManifestResourceName).nanoresources')">
       <Output TaskParameter="OutputResources" ItemName="NanoFramework_Resources"/>
       <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
     </GenerateNanoResourceTask>
+
   </Target>
 
   <!--
@@ -860,14 +703,14 @@
     -->
 
   <Target Name="ConvertResources"
-    Condition="Exists('$(OutDir)$(TargetFileName)')"
-    >
+          Condition="Exists('$(OutDir)$(TargetFileName)')">
+
     <ResourceConverter
       Condition=" '$(NanoFramework_Skip_ConvertResources)' != 'true' "
       AssemblyName="$(OutDir)$(TargetFileName)"
       OutputFile="$(ProjectDir)\Resources.resx"
-      ResourceDirectories="$(CONVERT_RESOURCES_DIR)"
-      />
+      ResourceDirectories="$(CONVERT_RESOURCES_DIR)"/>
+
   </Target>
 
   <Target Name="NanoGenerateBinaryOutput">
@@ -876,10 +719,9 @@
         AssemblyPE="$(NanoFramework_IntermediateAssembly).pe"
         Assembly="$(NanoFramework_Assembly)$(TargetExt)"
         AssemblyReferences="@(ReferencePath);@(ReferenceDependencyPaths)">
-
       <Output TaskParameter="FileWritten" ItemName="FileWrites" />
     </GenerateBinaryOutputTask>
 
   </Target>
-  
+
 </Project>

--- a/source/VisualStudio.Extension/VisualStudio.Extension.csproj
+++ b/source/VisualStudio.Extension/VisualStudio.Extension.csproj
@@ -424,8 +424,23 @@
     <Reference Include="Microsoft.Win32.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Win32.Primitives.4.3.0\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
     </Reference>
+    <Reference Include="Mono.Cecil, Version=0.11.1.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.11.1\lib\net40\Mono.Cecil.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Mdb, Version=0.11.1.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.11.1\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Pdb, Version=0.11.1.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.11.1\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Rocks, Version=0.11.1.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.11.1\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
+    </Reference>
     <Reference Include="nanoFramework.Tools.Debugger, Version=1.5.0.14, Culture=neutral, PublicKeyToken=e520bb6b53f04733, processorArchitecture=MSIL">
       <HintPath>..\packages\nanoFramework.Tools.Debugger.Net.1.5.0-preview.14\lib\net461\nanoFramework.Tools.Debugger.dll</HintPath>
+    </Reference>
+    <Reference Include="nanoFramework.Tools.MetadataProcessor.Core, Version=2.4.2.15844, Culture=neutral, PublicKeyToken=562e3cb1ad703850, processorArchitecture=MSIL">
+      <HintPath>..\packages\nanoFramework.Tools.MetadataProcessor.Core.2.4.2\lib\net461\nanoFramework.Tools.MetadataProcessor.Core.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -449,6 +464,9 @@
     </Reference>
     <Reference Include="StreamJsonRpc, Version=1.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\StreamJsonRpc.1.5.43\lib\net46\StreamJsonRpc.dll</HintPath>
+    </Reference>
+    <Reference Include="Stubble.Core, Version=1.7.0.0, Culture=neutral, PublicKeyToken=3291e04f27be773d, processorArchitecture=MSIL">
+      <HintPath>..\packages\Stubble.Core.1.7.2\lib\net45\Stubble.Core.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -860,7 +878,7 @@
     <Error Condition="!Exists('..\packages\PropertyChanged.Fody.2.6.1\build\PropertyChanged.Fody.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\PropertyChanged.Fody.2.6.1\build\PropertyChanged.Fody.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.15.9.3039\build\Microsoft.VSSDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.15.9.3039\build\Microsoft.VSSDK.BuildTools.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.15.9.3039\build\Microsoft.VSSDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.15.9.3039\build\Microsoft.VSSDK.BuildTools.targets'))" />
-    <Error Condition="!Exists('..\packages\nanoFramework.Tools.MetadataProcessor.1.15.2\build\nanoFramework.Tools.MetaDataProcessor.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\nanoFramework.Tools.MetadataProcessor.1.15.2\build\nanoFramework.Tools.MetaDataProcessor.targets'))" />
+    <Error Condition="!Exists('..\packages\nanoFramework.Tools.MetadataProcessor.Core.2.4.2\build\nanoFramework.Tools.MetaDataProcessor.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\nanoFramework.Tools.MetadataProcessor.Core.2.4.2\build\nanoFramework.Tools.MetaDataProcessor.Core.targets'))" />
   </Target>
   <Import Project="..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.27\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.27\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets')" />
   <Import Project="..\packages\Nerdbank.GitVersioning.2.3.38\build\Nerdbank.GitVersioning.targets" Condition="Exists('..\packages\Nerdbank.GitVersioning.2.3.38\build\Nerdbank.GitVersioning.targets')" />
@@ -869,7 +887,7 @@
   <Import Project="..\packages\Microsoft.VisualStudio.SDK.Analyzers.15.8.36\build\Microsoft.VisualStudio.SDK.Analyzers.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.SDK.Analyzers.15.8.36\build\Microsoft.VisualStudio.SDK.Analyzers.targets')" />
   <Import Project="..\packages\Fody.4.2.1\build\Fody.targets" Condition="Exists('..\packages\Fody.4.2.1\build\Fody.targets')" />
   <Import Project="..\packages\Microsoft.VSSDK.BuildTools.15.9.3039\build\Microsoft.VSSDK.BuildTools.targets" Condition="Exists('..\packages\Microsoft.VSSDK.BuildTools.15.9.3039\build\Microsoft.VSSDK.BuildTools.targets')" />
-  <Import Project="..\packages\nanoFramework.Tools.MetadataProcessor.1.15.2\build\nanoFramework.Tools.MetaDataProcessor.targets" Condition="Exists('..\packages\nanoFramework.Tools.MetadataProcessor.1.15.2\build\nanoFramework.Tools.MetaDataProcessor.targets')" />
+  <Import Project="..\packages\nanoFramework.Tools.MetadataProcessor.Core.2.4.2\build\nanoFramework.Tools.MetaDataProcessor.Core.targets" Condition="Exists('..\packages\nanoFramework.Tools.MetadataProcessor.Core.2.4.2\build\nanoFramework.Tools.MetaDataProcessor.Core.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/source/VisualStudio.Extension/packages.config
+++ b/source/VisualStudio.Extension/packages.config
@@ -57,10 +57,11 @@
   <package id="Microsoft.VisualStudio.Validation" version="15.3.58" targetFramework="net46" />
   <package id="Microsoft.VSSDK.BuildTools" version="15.9.3039" targetFramework="net461" developmentDependency="true" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net46" />
+  <package id="Mono.Cecil" version="0.11.1" targetFramework="net461" />
   <package id="MvvmLightLibsStd10" version="5.4.1.1" targetFramework="net46" />
   <package id="nanoFramework.CoreLibrary" version="1.3.0" targetFramework="net461" developmentDependency="true" />
   <package id="nanoFramework.Tools.Debugger.Net" version="1.5.0-preview.14" targetFramework="net461" />
-  <package id="nanoFramework.Tools.MetadataProcessor" version="1.15.2" targetFramework="net461" />
+  <package id="nanoFramework.Tools.MetadataProcessor.Core" version="2.4.2" targetFramework="net461" />
   <package id="Nerdbank.GitVersioning" version="2.3.38" targetFramework="net46" developmentDependency="true" />
   <package id="NETStandard.Library" version="2.0.3" targetFramework="net46" requireReinstallation="true" />
   <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net46" />
@@ -69,6 +70,7 @@
   <package id="PropertyChanging.Fody" version="1.29.3" targetFramework="net46" />
   <package id="stdole" version="7.0.3303" targetFramework="net46" />
   <package id="StreamJsonRpc" version="1.5.43" targetFramework="net46" />
+  <package id="Stubble.Core" version="1.7.2" targetFramework="net461" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net46" />
   <package id="System.Buffers" version="4.5.0" targetFramework="net46" requireReinstallation="true" />
   <package id="System.Collections" version="4.3.0" targetFramework="net46" />

--- a/source/VisualStudio.Extension/version.json
+++ b/source/VisualStudio.Extension/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "release": {
     "branchName" : "release-v{version}",
     "versionIncrement" : "minor",

--- a/source/nanoFramework.Tools.VisualStudio-2019.sln
+++ b/source/nanoFramework.Tools.VisualStudio-2019.sln
@@ -23,6 +23,13 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSharp.ClassTemplate", "CSh
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSharp.ResourceTemplate", "CSharp.ResourceTemplate\CSharp.ResourceTemplate.csproj", "{8252022E-62FD-4A59-BE1E-90FD52DBA0FE}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{60B109AE-E582-4ECB-ABB4-B24E07DB87E1}"
+	ProjectSection(SolutionItems) = preProject
+		NuGet.Config = NuGet.Config
+		VisualStudio.Extension\version.json = VisualStudio.Extension\version.json
+		VisualStudio.Extension\vs2019-marketplace-overview.md = VisualStudio.Extension\vs2019-marketplace-overview.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/source/nanoFramework.Tools.VisualStudio.sln
+++ b/source/nanoFramework.Tools.VisualStudio.sln
@@ -37,6 +37,13 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "nanoFramework.Tools.DebugLi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSharp.ResourceTemplate", "CSharp.ResourceTemplate\CSharp.ResourceTemplate.csproj", "{8252022E-62FD-4A59-BE1E-90FD52DBA0FE}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{60B109AE-E582-4ECB-ABB4-B24E07DB87E1}"
+	ProjectSection(SolutionItems) = preProject
+		NuGet.Config = NuGet.Config
+		VisualStudio.Extension\version.json = VisualStudio.Extension\version.json
+		VisualStudio.Extension\vs2017-marketplace-overview.md = VisualStudio.Extension\vs2017-marketplace-overview.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		..\nf-debugger\source\nanoFramework.Tools.DebugLibrary.Shared\nanoFramework.Tools.DebugLibrary.Net.projitems*{101d57ad-d22f-4905-a992-de15e723f164}*SharedItemsImports = 4


### PR DESCRIPTION
## Description
- Replace MDP NuGet reference.
- Rework MetaDataProcessorTask to be a regular msbuild Task instead of a ToolTask.
- Rework MDP targets for project system.
- Minor cosmetic changes in BuildTasks debugger helper.
- Bump version to 1.3.0.

**⚠️ Interop stubs generation is not working yet ⚠️**

## Motivation and Context

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
