### PR TITLE
nF project system targets don't generate  binding redirects anymore

### DIFF
--- a/source/VisualStudio.Extension-2019/Targets/NFProjectSystem.props
+++ b/source/VisualStudio.Extension-2019/Targets/NFProjectSystem.props
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
@@ -14,8 +14,9 @@
 
     <!-- This prevents the default MsBuild targets from referencing System.Core.dll -->
     <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
-
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    
+    <!-- This prevents VS from adding app.config with binding redirects -->
+    <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
 
     <!-- TODO add documentation about this
     See https://msdn.microsoft.com/en-us/library/ms242202.aspx

--- a/source/VisualStudio.Extension/Targets/NFProjectSystem.props
+++ b/source/VisualStudio.Extension/Targets/NFProjectSystem.props
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
@@ -15,7 +15,8 @@
     <!-- This prevents the default MsBuild targets from referencing System.Core.dll -->
     <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
 
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <!-- This prevents VS from adding app.config with binding redirects -->
+    <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
 
     <!-- TODO add documentation about this
     See https://msdn.microsoft.com/en-us/library/ms242202.aspx


### PR DESCRIPTION
## Description
- Change targets option to prevent VS from auto generating binding redirects (within app.config).

## Motivation and Context
- Binding redirects aren't supported in nF plus this was causing a lot of issues like deployment errors, version mismatches, etc.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

