### PR TITLE
Correcting placeholder of output message on reboot

### DIFF
--- a/source/VisualStudio.Extension/ToolWindow.DeviceExplorer/DeviceExplorerCommand.cs
+++ b/source/VisualStudio.Extension/ToolWindow.DeviceExplorer/DeviceExplorerCommand.cs
@@ -667,7 +667,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
                             NanoDeviceCommService.Device.DebugEngine.RebootDevice(RebootOptions.NormalReboot);
 
-                            MessageCentre.OutputMessage($"Sent reboot command to {ViewModelLocator.DeviceExplorer.PreviousSelectedDeviceDescription}.");
+                            MessageCentre.OutputMessage($"Sent reboot command to {ViewModelLocator.DeviceExplorer.SelectedDevice.Description}.");
 
                             // yield to give the UI thread a chance to respond to user input
                             await Task.Yield();


### PR DESCRIPTION
I'm observing that the output message is never placing any text at this point.
Looks like this variable doesn't get filled at a different place.
So instead of using the dead variable, I replaced it with one that is alive and used by the ping feature.

Signed-off-by: Thomas Karl Pietrowski <thopiekar@gmail.com>
