### PR TITLE
Fix file locking on MDP task

### DIFF
--- a/source/Tools.BuildTasks/MetaDataProcessorTask.cs
+++ b/source/Tools.BuildTasks/MetaDataProcessorTask.cs
@@ -219,6 +219,16 @@ namespace nanoFramework.Tools
             {
                 Log.LogErrorFromException(ex, true);
             }
+            finally
+            {
+                // need to dispose the AssemblyDefinition before leaving because Mono.Cecil assembly loading and resolution
+                // operations leave the assembly file locked in the AppDomain preventing it from being open on subsequent Tasks
+                // see https://github.com/nanoframework/Home/issues/553
+                if (_assemblyDefinition != null)
+                {
+                    _assemblyDefinition.Dispose();
+                }
+            }
 
             // if we've logged any errors that's because there were errors (WOW!)
             return !Log.HasLoggedErrors;


### PR DESCRIPTION
## Description
- AssemblyDefinition is now disposed on task end.

## Motivation and Context
- Need to dispose the AssemblyDefinition before leaving because Mono.Cecil assembly loading and resolution operations leave the assembly file locked in the AppDomain preventing it from being open on subsequent Tasks.
- Fixes nanoFramework/Home#553.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
