### PR TITLE
Fix assembly reference on network config dialog

### DIFF
--- a/source/VisualStudio.Extension-2019/ToolWindow.DeviceExplorer/NetworkConfigurationDialog.xaml
+++ b/source/VisualStudio.Extension-2019/ToolWindow.DeviceExplorer/NetworkConfigurationDialog.xaml
@@ -5,7 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:vsp="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
              xmlns:extension="clr-namespace:nanoFramework.Tools.VisualStudio.Extension"
-             xmlns:debuglib="clr-namespace:nanoFramework.Tools.Debugger;assembly=nanoFramework.Tools.Debugger"
+             xmlns:debuglib="clr-namespace:nanoFramework.Tools.Debugger;assembly=nanoFramework.Tools.Debugger.Net"
              xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
              xmlns:Converters="clr-namespace:nanoFramework.Tools.VisualStudio.Extension.Converters"
              xmlns:ViewModel="clr-namespace:nanoFramework.Tools.VisualStudio.Extension.ToolWindow.ViewModel"

--- a/source/VisualStudio.Extension/ToolWindow.DeviceExplorer/NetworkConfigurationDialog.xaml
+++ b/source/VisualStudio.Extension/ToolWindow.DeviceExplorer/NetworkConfigurationDialog.xaml
@@ -5,7 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:vsp="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
              xmlns:extension="clr-namespace:nanoFramework.Tools.VisualStudio.Extension"
-             xmlns:debuglib="clr-namespace:nanoFramework.Tools.Debugger;assembly=nanoFramework.Tools.Debugger"
+             xmlns:debuglib="clr-namespace:nanoFramework.Tools.Debugger;assembly=nanoFramework.Tools.Debugger.Net"
              xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
              xmlns:Converters="clr-namespace:nanoFramework.Tools.VisualStudio.Extension.Converters"
              xmlns:ViewModel="clr-namespace:nanoFramework.Tools.VisualStudio.Extension.ToolWindow.ViewModel"


### PR DESCRIPTION
## Description
- Fix assembly reference on network config dialog.

## Motivation and Context
- Network configuration window was unusable.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>