### PR TITLE
Fix deployment for solutions with with more than one shared project

### DIFF
--- a/source/VisualStudio.Extension/Utilities/ReferenceCrawler.cs
+++ b/source/VisualStudio.Extension/Utilities/ReferenceCrawler.cs
@@ -40,6 +40,10 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 {
                     string path = await GetProjectOutputPathAsync(configuredProject);
 
+                    // Skip projects that do not have target output like shared projects
+                    if (string.IsNullOrEmpty(path))
+                        continue;
+
                     configuredProjectsByOutputAssemblyPath.Add(path, configuredProject);
                     outputAssemblyPathsByConfiguredProject.Add(configuredProject, path);
                 }

--- a/source/VisualStudio.Extension/Utilities/ReferenceCrawler.cs
+++ b/source/VisualStudio.Extension/Utilities/ReferenceCrawler.cs
@@ -42,7 +42,9 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
                     // Skip projects that do not have target output like shared projects
                     if (string.IsNullOrEmpty(path))
+                    {
                         continue;
+                    }
 
                     configuredProjectsByOutputAssemblyPath.Add(path, configuredProject);
                     outputAssemblyPathsByConfiguredProject.Add(configuredProject, path);


### PR DESCRIPTION
Shared projects have no target path because they do produce an output.

## Description
The target path is null, and only one null value can be added to the dictionary. More than one shared projects will fail.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template bellow (mind the link as all issues are open in the Home repository, not in this one) -->
Allows a solution to have more than one shared project.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I created a solution with 3 shared projects and successfully deployed to a device.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: manuelxmarquez
