### PR TITLE
Improve debug session start sequence

### DIFF
--- a/source/VisualStudio.Extension-2019/version.json
+++ b/source/VisualStudio.Extension-2019/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2019.1.8",
+  "version": "2019.2.0",
   "release": {
     "branchName" : "release-v{version}",
     "versionIncrement" : "minor",

--- a/source/VisualStudio.Extension/CorDebug/CorDebugProcess.cs
+++ b/source/VisualStudio.Extension/CorDebug/CorDebugProcess.cs
@@ -626,24 +626,6 @@ namespace nanoFramework.Tools.VisualStudio.Extension
     
                     MessageCentre.DebugMessage(Resources.ResourceStrings.WaitingDeviceInitialization);
                     EnsureProcessIsInInitializedState();
-
-                    MessageCentre.DebugMessage("Updating nanoDevice debugger engine.");
-
-                    // need to update the debugger engine flags on the device after ensuring that the device is properly initialized
-                    // this is needed to make sure that all engine flags are properly set
-                    if (_engine.UpdateDebugFlags())
-                    {
-                        // forced update device info in order to get deployed assemblies
-                        Device.GetDeviceInfo(true);
-
-                        // need to update the assemblies right here or the collection won't be populated when we need it ahead
-                        UpdateAssemblies();
-                    }
-                    else
-                    {
-                        // couldn't update debug engine flags
-                        MessageCentre.DebugMessage("Error trying to update the device debugger engine.");
-                    }
                 }
                 else
                 {
@@ -1531,7 +1513,6 @@ namespace nanoFramework.Tools.VisualStudio.Extension
             {
                 MessageCentre.DebugMessage(text);
             }
-
         }
 
         [MethodImpl(MethodImplOptions.Synchronized)]

--- a/source/VisualStudio.Extension/MessageCentre/MessageCentre.cs
+++ b/source/VisualStudio.Extension/MessageCentre/MessageCentre.cs
@@ -133,6 +133,14 @@ namespace nanoFramework.Tools.VisualStudio.Extension
             {
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
+                // if the message already ends with a return & new line, strip it
+                // this is the case with some messages from the target
+                // in case the message has more than one and intends to output an empty line this will occur anyway as we are adding it bellow
+                if(message.EndsWith("\r\n"))
+                {
+                    message = message.Substring(0, message.Length - 2);
+                }
+
                 pane.Activate();
                 pane.OutputStringThreadSafe(message + "\r\n");
             });

--- a/source/VisualStudio.Extension/version.json
+++ b/source/VisualStudio.Extension/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2017.1.8",
+  "version": "2017.2.0",
   "release": {
     "branchName" : "release-v{version}",
     "versionIncrement" : "minor",


### PR DESCRIPTION
## Description
- Remove call to update assemblies, now occurs at the correct step.
- Remove duplicate end of line when outputting message to output console.
- Bump version to 2019.2.0 and 2017.2.0.

## ⚠️ WORKS WITH FW >= 1.4.0-preview.182 ⚠️ ##

## Motivation and Context
- Follows nanoframework/nf-interpreter#1624.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [#] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [#] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>
