### PR TITLE
Remove output of deployment exception

### DIFF
--- a/source/VisualStudio.Extension/DeployProvider/DeployProvider.cs
+++ b/source/VisualStudio.Extension/DeployProvider/DeployProvider.cs
@@ -430,13 +430,9 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                     throw new DeploymentException($"{_viewModelLocator.DeviceExplorer.SelectedDevice.Description} is not responding. Please retry the deployment. If the situation persists reboot the device.");
                 }
             }
-            catch (DeploymentException ex)
+            catch (DeploymentException)
             {
-                MessageCentre.InternalErrorMessage($"Exception occurred during deployment." +
-                    $"{Environment.NewLine} {ex.Message} " +
-                    $"{Environment.NewLine} {ex.InnerException} " +
-                    $"{Environment.NewLine} {ex.StackTrace}");
-
+                // this exception is used to flag a failed deployment to VS, no need to show anything about the exception here
                 throw;
             }
             catch (Exception ex)


### PR DESCRIPTION
## Description
- Remove output of `DeploymentException`.

## Motivation and Context
- No need to output details about this expected exception that's used to signal VS of a deployment error.

## How Has This Been Tested?<!-- (if applicable) -->
- VS experimental instance.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>