### PR TITLE
Add resource support for Bitmaps and correct Font namespace

### DIFF
--- a/source/Tools.BuildTasks/ProcessResourceFiles.cs
+++ b/source/Tools.BuildTasks/ProcessResourceFiles.cs
@@ -874,9 +874,9 @@ namespace nanoFramework.Tools
                 {
                     null, //RESOURCE_Invalid
                     // TODO not supported, see issue https://github.com/nanoframework/Home/issues/120
-                    new ResourceTypeDescription(NanoResourceFile.ResourceHeader.RESOURCE_Bitmap, "GetBitmap", "Microsoft.SPOT.Bitmap", "BitmapResources"),
+                    new ResourceTypeDescription(NanoResourceFile.ResourceHeader.RESOURCE_Bitmap, "GetBitmap", "nanoFramework.UI.Bitmap", "BitmapResources"),
                     // TODO not supported, see issue https://github.com/nanoframework/Home/issues/121
-                    new ResourceTypeDescription(NanoResourceFile.ResourceHeader.RESOURCE_Font, "GetFont", "Microsoft.SPOT.Font", "FontResources"),
+                    new ResourceTypeDescription(NanoResourceFile.ResourceHeader.RESOURCE_Font, "GetFont", "nanoFramework.UI.Font", "FontResources"),
                     new ResourceTypeDescription(NanoResourceFile.ResourceHeader.RESOURCE_String, "GetString", "System.String", "StringResources"),
                     new ResourceTypeDescription(NanoResourceFile.ResourceHeader.RESOURCE_Binary, "GetBytes", "System.Byte[]", "BinaryResources"),
                     };
@@ -909,10 +909,22 @@ namespace nanoFramework.Tools
                 if (rawValue != null)
                 {
                     entry = NanoResourcesEntry.TryCreateNanoResourcesEntry(name, rawValue);
-
                     if (entry == null)
                     {
-                        entry = new BinaryEntry(name, rawValue);
+                        // Try to create a bitmap from byte[]
+                        // If it doesn't contain a bmp format(exception) then create BinaryEntry
+                        using (var ms = new MemoryStream(rawValue))
+                        {
+                            try
+                            {
+                                Bitmap bmp = new Bitmap(ms);
+                                entry = new BitmapEntry(name, bmp);
+                            }
+                            catch(Exception) 
+                            {
+                                entry = new BinaryEntry(name, rawValue);
+                            }
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Description
Adds support for Bitmap type in resources and fixes namespace for fonts

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template bellow (mind the link as all issues are open in the Home repository, not in this one) -->
- Resolves nanoFramework/Home#120
- Resolves nanoFramework/Home#121


## How Has This Been Tested?<!-- (if applicable) -->
Tested under debug VS extension

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: adriansoundy <adriansoundy@gmail.com>
