### PR TITLE
Add support for COM Port black list in Device Explorer

### DIFF
--- a/source/VisualStudio.Extension-2019/NanoFrameworkPackage.cs
+++ b/source/VisualStudio.Extension-2019/NanoFrameworkPackage.cs
@@ -110,6 +110,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
         private const string SETTINGS_GENERATE_DEPLOYMENT_IMAGE_KEY = "GenerateDeploymentImage";
         private const string SETTINGS_INCLUDE_CONFIG_BLOCK_IN_DEPLOYMENT_IMAGE_KEY = "IncludeConfigBlockInDeploymentImage";
         private const string SETTINGS_PATH_OF_FLASH_DUMP_CACHE_IMAGE_KEY = "PathOfFlashDumpCache";
+        private const string SETTINGS_PORT_BLACK_LIST_KEY = "PortBlackList";
 
         private static bool? s_OptionShowInternalErrors;
         /// <summary>
@@ -243,6 +244,33 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 s_instance.UserRegistryRoot.OpenSubKey(EXTENSION_SUBKEY, true).Flush();
 
                 s_SettingPathOfFlashDumpCache = value;
+            }
+        }
+
+        private static string s_SettingPortBlackList = null;
+        /// <summary>
+        /// Setting to store COM port black list.
+        /// The value is persisted per user.
+        /// Default is empty.
+        /// </summary>
+        public static string SettingPortBlackList
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(s_SettingPortBlackList))
+                {
+                    s_SettingPortBlackList = (string)s_instance.UserRegistryRoot.OpenSubKey(EXTENSION_SUBKEY).GetValue(SETTINGS_PORT_BLACK_LIST_KEY);
+                }
+
+                return s_SettingPortBlackList;
+            }
+
+            set
+            {
+                s_instance.UserRegistryRoot.OpenSubKey(EXTENSION_SUBKEY, true).SetValue(SETTINGS_PORT_BLACK_LIST_KEY, value);
+                s_instance.UserRegistryRoot.OpenSubKey(EXTENSION_SUBKEY, true).Flush();
+
+                s_SettingPortBlackList = value;
             }
         }
 

--- a/source/VisualStudio.Extension-2019/ToolWindow.DeviceExplorer/SettingsDialog.xaml
+++ b/source/VisualStudio.Extension-2019/ToolWindow.DeviceExplorer/SettingsDialog.xaml
@@ -73,8 +73,28 @@
                 </Grid>
             </TabItem>
 
-            <TabItem Header="General" IsEnabled="False">
-                <Grid/>
+            <TabItem Header="General" IsEnabled="True">
+                <Grid Margin="10,10,10,10">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+
+                    <Grid Margin="8,10,10,10" Grid.Row="0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+
+                        <Label Grid.Row="0" HorizontalAlignment="Left" Content="COM port black list:" ToolTip="Semicolon separated list of COM ports to exclude when searching for nanoDevices." Margin="-7,0,0,0" />
+                        <TextBox x:Name="PortBlackList" Grid.Row="1" Margin="0,0,0,0" HorizontalAlignment="Stretch" LostFocus="PortBlackList_LostFocus" />
+                    </Grid>
+                </Grid>
             </TabItem>
 
         </TabControl>

--- a/source/VisualStudio.Extension-2019/ToolWindow.DeviceExplorer/SettingsDialog.xaml.cs
+++ b/source/VisualStudio.Extension-2019/ToolWindow.DeviceExplorer/SettingsDialog.xaml.cs
@@ -6,6 +6,7 @@
 namespace nanoFramework.Tools.VisualStudio.Extension
 {
     using Microsoft.VisualStudio.PlatformUI;
+    using System.Collections.Generic;
     using System.Net;
     using System.Windows.Controls.Primitives;
     using System.Windows.Forms;
@@ -50,6 +51,8 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 StoreCacheToUserPath.IsChecked = true;
                 PathOfFlashDumpCache.Text = NanoFrameworkPackage.SettingPathOfFlashDumpCache;
             }
+
+            PortBlackList.Text = NanoFrameworkPackage.SettingPortBlackList;
 
             // OK to add event handlers to controls now
             StoreCacheToUserPath.Checked += StoreCacheLocationChanged_Checked;
@@ -119,6 +122,31 @@ namespace nanoFramework.Tools.VisualStudio.Extension
             {
                 // any other outcome from folder browser dialog doesn't require processing
             }
+        }
+
+        private void PortBlackList_LostFocus(object sender, System.Windows.RoutedEventArgs e)
+        {
+            // store updated setting
+            NanoFrameworkPackage.SettingPortBlackList = PortBlackList.Text;
+
+            // update debug client
+            List<string> PortList = new List<string>();
+
+            // need to wrap the processing in a try/catch to deal with bad user input/format
+            try
+            {
+                // grab and parse COM port list
+                if (!string.IsNullOrEmpty(PortBlackList.Text))
+                {
+                    PortList.AddRange(PortBlackList.Text.Split(';'));
+                }
+            }
+            catch
+            {
+                // don't care about bad user input/format/etc 
+            }
+
+            NanoFrameworkPackage.NanoDeviceCommService.DebugClient.PortBlackList = PortList;
         }
     }
 }

--- a/source/VisualStudio.Extension-2019/version.json
+++ b/source/VisualStudio.Extension-2019/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2019.2.1",
+  "version": "2019.2.2",
   "release": {
     "branchName" : "release-v{version}",
     "versionIncrement" : "minor",

--- a/source/VisualStudio.Extension/NanoDeviceCommService/NanoDeviceCommService.cs
+++ b/source/VisualStudio.Extension/NanoDeviceCommService/NanoDeviceCommService.cs
@@ -5,6 +5,7 @@
 
 using nanoFramework.Tools.Debugger;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
@@ -25,9 +26,26 @@ namespace nanoFramework.Tools.VisualStudio.Extension
             {
                 if (_debugClient == null)
                 {
+                    // grab and parse COM port list
+                    List<string> PortList = new List<string>();
+                    
+                    // need to wrap the processing in a try/catch to deal with bad user input/format
+                    try
+                    {
+                        // grab and parse COM port list
+                        if (!string.IsNullOrEmpty(NanoFrameworkPackage.SettingPortBlackList))
+                        {
+                            PortList.AddRange(NanoFrameworkPackage.SettingPortBlackList.Split(';'));
+                        }
+                    }
+                    catch
+                    {
+                        // don't care about bad user input/format/etc 
+                    }
+
                     // create serial instance WITHOUT app associated because we don't care of app life cycle in VS extension
                     // pass the user preference about starting the device watchers, or not
-                    _debugClient = PortBase.CreateInstanceForSerial("", null, !NanoFrameworkPackage.OptionDisableDeviceWatchers, 1000);
+                    _debugClient = PortBase.CreateInstanceForSerial("", null, !NanoFrameworkPackage.OptionDisableDeviceWatchers, PortList);
                 }
 
                 return _debugClient;

--- a/source/VisualStudio.Extension/NanoFrameworkPackage.cs
+++ b/source/VisualStudio.Extension/NanoFrameworkPackage.cs
@@ -87,6 +87,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
         private const string SETTINGS_GENERATE_DEPLOYMENT_IMAGE_KEY = "GenerateDeploymentImage";
         private const string SETTINGS_INCLUDE_CONFIG_BLOCK_IN_DEPLOYMENT_IMAGE_KEY = "IncludeConfigBlockInDeploymentImage";
         private const string SETTINGS_PATH_OF_FLASH_DUMP_CACHE_IMAGE_KEY = "PathOfFlashDumpCache";
+        private const string SETTINGS_PORT_BLACK_LIST_KEY = "PortBlackList";
 
         private static bool? s_OptionShowInternalErrors;
         /// <summary>
@@ -220,6 +221,33 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 s_instance.UserRegistryRoot.OpenSubKey(EXTENSION_SUBKEY, true).Flush();
 
                 s_SettingPathOfFlashDumpCache = value;
+            }
+        }
+
+        private static string s_SettingPortBlackList = null;
+        /// <summary>
+        /// Setting to store COM port black list.
+        /// The value is persisted per user.
+        /// Default is empty.
+        /// </summary>
+        public static string SettingPortBlackList
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(s_SettingPortBlackList))
+                {
+                    s_SettingPortBlackList = (string)s_instance.UserRegistryRoot.OpenSubKey(EXTENSION_SUBKEY).GetValue(SETTINGS_PORT_BLACK_LIST_KEY);
+                }
+
+                return s_SettingPortBlackList;
+            }
+
+            set
+            {
+                s_instance.UserRegistryRoot.OpenSubKey(EXTENSION_SUBKEY, true).SetValue(SETTINGS_PORT_BLACK_LIST_KEY, value);
+                s_instance.UserRegistryRoot.OpenSubKey(EXTENSION_SUBKEY, true).Flush();
+
+                s_SettingPortBlackList = value;
             }
         }
 

--- a/source/VisualStudio.Extension/ToolWindow.DeviceExplorer/SettingsDialog.xaml
+++ b/source/VisualStudio.Extension/ToolWindow.DeviceExplorer/SettingsDialog.xaml
@@ -74,8 +74,28 @@
                 </Grid>
             </TabItem>
 
-            <TabItem Header="General" IsEnabled="False">
-                <Grid/>
+            <TabItem Header="General" IsEnabled="True">
+                <Grid Margin="10,10,10,10">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+
+                    <Grid Margin="8,10,10,10" Grid.Row="0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+
+                        <Label Grid.Row="0" HorizontalAlignment="Left" Content="COM port black list:" ToolTip="Semicolon separated list of COM ports to exclude when searching for nanoDevices." Margin="-7,0,0,0" />
+                        <TextBox x:Name="PortBlackList" Grid.Row="1" Margin="0,0,0,0" HorizontalAlignment="Stretch" LostFocus="PortBlackList_LostFocus" />
+                    </Grid>
+                </Grid>
             </TabItem>
 
         </TabControl>

--- a/source/VisualStudio.Extension/ToolWindow.DeviceExplorer/SettingsDialog.xaml.cs
+++ b/source/VisualStudio.Extension/ToolWindow.DeviceExplorer/SettingsDialog.xaml.cs
@@ -6,6 +6,7 @@
 namespace nanoFramework.Tools.VisualStudio.Extension
 {
     using Microsoft.VisualStudio.PlatformUI;
+    using System.Collections.Generic;
     using System.Net;
     using System.Windows.Controls.Primitives;
     using System.Windows.Forms;
@@ -50,6 +51,8 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 StoreCacheToUserPath.IsChecked = true;
                 PathOfFlashDumpCache.Text = NanoFrameworkPackage.SettingPathOfFlashDumpCache;
             }
+
+            PortBlackList.Text = NanoFrameworkPackage.SettingPortBlackList;
 
             // OK to add event handlers to controls now
             StoreCacheToUserPath.Checked += StoreCacheLocationChanged_Checked;
@@ -119,6 +122,31 @@ namespace nanoFramework.Tools.VisualStudio.Extension
             {
                 // any other outcome from folder browser dialog doesn't require processing
             }
+        }
+
+        private void PortBlackList_LostFocus(object sender, System.Windows.RoutedEventArgs e)
+        {
+            // store updated setting
+            NanoFrameworkPackage.SettingPortBlackList = PortBlackList.Text;
+
+            // update debug client
+            List<string> comPortList = new List<string>();
+
+            // need to wrap the processing in a try/catch to deal with bad user input/format
+            try
+            {
+                // grab and parse COM port list
+                if (!string.IsNullOrEmpty(PortBlackList.Text))
+                {
+                    comPortList.AddRange(PortBlackList.Text.Split(';'));
+                }
+            }
+            catch
+            { 
+                // don't care about bad user input/format/etc 
+            }
+
+            NanoFrameworkPackage.NanoDeviceCommService.DebugClient.PortBlackList = comPortList;
         }
     }
 }

--- a/source/VisualStudio.Extension/version.json
+++ b/source/VisualStudio.Extension/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2017.2.1",
+  "version": "2017.2.2",
   "release": {
     "branchName" : "release-v{version}",
     "versionIncrement" : "minor",


### PR DESCRIPTION
## Description
- Add text box to enter list of ports to exclude from search.
- Add support for new property to retrieve/store this property in user preferences.

## Motivation and Context
- Closes nanoFramework/Home#635.

## How Has This Been Tested?<!-- (if applicable) -->
- VS experimental instance.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
