### PR TITLE
Expose native assembly checksum in Azure Pipelines

### DIFF
--- a/Tools.BuildTasks/MetaDataProcessorTask.cs
+++ b/Tools.BuildTasks/MetaDataProcessorTask.cs
@@ -100,6 +100,9 @@ namespace nanoFramework.Tools
         [Output]
         public ITaskItem[] FilesWritten { get { return _filesWritten.ToArray(); } }
 
+        [Output]
+        public ITaskItem NativeChecksum { get { return new TaskItem(_nativeChecksum); } }
+
         #endregion
 
         #region internal fields for MetadataProcessor
@@ -109,6 +112,7 @@ namespace nanoFramework.Tools
         private readonly IDictionary<string, string> _loadHints =
             new Dictionary<string, string>(StringComparer.Ordinal);
         private readonly List<string> _classNamesToExclude = new List<string>();
+        private string _nativeChecksum = "";
 
         #endregion
 
@@ -355,6 +359,9 @@ namespace nanoFramework.Tools
 
                 // set environment variable with assembly native checksum
                 Environment.SetEnvironmentVariable("AssemblyNativeChecksum", _assemblyBuilder.GetNativeChecksum(), EnvironmentVariableTarget.Process);
+
+                // store assembly native checksum
+                _nativeChecksum = _assemblyBuilder.GetNativeChecksum();
             }
             catch (ArgumentException ex)
             {

--- a/VisualStudio.Extension-2019/Targets/NFProjectSystem.MDP.targets
+++ b/VisualStudio.Extension-2019/Targets/NFProjectSystem.MDP.targets
@@ -238,9 +238,13 @@
         SkeletonWithoutInterop="$(NFMDP_STUB_SkeletonWithoutInterop)"
         ImportResources="@(NanoFramework_Resources)">
       <Output TaskParameter="FilesWritten" ItemName="FileWrites" />
+      <Output TaskParameter="NativeChecksum" PropertyName="NativeChecksum" />
     </MetaDataProcessorTask>
 
     <CallTarget Targets="NanoGenerateBinaryOutput"/>
+
+    <!--Output native checksum to Azure Pipelines var (only usefull on Azure)-->
+    <Message Importance="high" Text="##vso[task.setvariable variable=NativeAssemblyChecksum]$(NativeChecksum)" Condition="'$(SYSTEM_TEAMPROJECTID)' != ''" />
 
   </Target>
 
@@ -431,7 +435,11 @@
         ExcludeClassByName="@(NFMDP_PE_ExcludeClassByName)"
         Condition="'$(NFMDP_GENERATE_STUBS)' == 'false'">
       <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
+      <Output TaskParameter="NativeChecksum" PropertyName="NativeChecksum" />
     </MetaDataProcessorTask>
+
+    <!--Output native checksum to Azure Pipelines var (only usefull on Azure)-->
+    <Message Importance="high" Text="##vso[task.setvariable variable=NativeAssemblyChecksum]$(NativeChecksum)" Condition="'$(NFMDP_GENERATE_STUBS)' == 'false' AND '$(SYSTEM_TEAMPROJECTID)' != ''" />
 
     <Message Text="Distilling assemblies to nanoCLR PE files along with stubs and skeleton files..." Condition="'$(NFMDP_GENERATE_STUBS)' == 'true'"/>
     <!-- Create STUB file -->
@@ -460,7 +468,11 @@
         ExcludeClassByName="@(NFMDP_PE_ExcludeClassByName)"
         Condition="'$(NFMDP_GENERATE_STUBS)' == 'true'">
       <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
+      <Output TaskParameter="NativeChecksum" PropertyName="NativeChecksum" />
     </MetaDataProcessorTask>
+
+    <!--Output native checksum to Azure Pipelines var (only usefull on Azure)-->
+    <Message Importance="high" Text="##vso[task.setvariable variable=NativeAssemblyChecksum]$(NativeChecksum)" Condition="'$(NFMDP_GENERATE_STUBS)' == 'true' AND '$(SYSTEM_TEAMPROJECTID)' != ''"/>
 
     <!-- Copy files (dll, pe, pdb and pdbx) to ouput directory -->
     <CallTarget Targets="CopyFilesToOutputDirectory" />
@@ -530,7 +542,11 @@
         LoadDatabase="@(NFMDP_DAT_LoadDatabase)"
         ExcludeClassByName="@(NFMDP_DAT_ExcludeClassByName)">
       <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
+      <Output TaskParameter="NativeChecksum" PropertyName="NativeChecksum" />
     </MetaDataProcessorTask>
+
+    <!--Output native checksum to Azure Pipelines var (only usefull on Azure)-->
+    <Message Importance="high" Text="##vso[task.setvariable variable=NativeAssemblyChecksum]$(NativeChecksum)" Condition="'$(SYSTEM_TEAMPROJECTID)' != ''" />
 
   </Target>
 

--- a/VisualStudio.Extension/Targets/NFProjectSystem.MDP.targets
+++ b/VisualStudio.Extension/Targets/NFProjectSystem.MDP.targets
@@ -238,9 +238,13 @@
         SkeletonWithoutInterop="$(NFMDP_STUB_SkeletonWithoutInterop)"
         ImportResources="@(NanoFramework_Resources)">
       <Output TaskParameter="FilesWritten" ItemName="FileWrites" />
+      <Output TaskParameter="NativeChecksum" PropertyName="NativeChecksum" />
     </MetaDataProcessorTask>
 
     <CallTarget Targets="NanoGenerateBinaryOutput"/>
+
+    <!--Output native checksum to Azure Pipelines var (only usefull on Azure)-->
+    <Message Importance="high" Text="##vso[task.setvariable variable=NativeAssemblyChecksum]$(NativeChecksum)" Condition="'$(SYSTEM_TEAMPROJECTID)' != ''" />
 
   </Target>
 
@@ -431,7 +435,11 @@
         ExcludeClassByName="@(NFMDP_PE_ExcludeClassByName)"
         Condition="'$(NFMDP_GENERATE_STUBS)' == 'false'">
       <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
+      <Output TaskParameter="NativeChecksum" PropertyName="NativeChecksum" />
     </MetaDataProcessorTask>
+
+    <!--Output native checksum to Azure Pipelines var (only usefull on Azure)-->
+    <Message Importance="high" Text="##vso[task.setvariable variable=NativeAssemblyChecksum]$(NativeChecksum)" Condition="'$(NFMDP_GENERATE_STUBS)' == 'false' AND '$(SYSTEM_TEAMPROJECTID)' != ''" />
 
     <Message Text="Distilling assemblies to nanoCLR PE files along with stubs and skeleton files..." Condition="'$(NFMDP_GENERATE_STUBS)' == 'true'"/>
     <!-- Create STUB file -->
@@ -460,7 +468,11 @@
         ExcludeClassByName="@(NFMDP_PE_ExcludeClassByName)"
         Condition="'$(NFMDP_GENERATE_STUBS)' == 'true'">
       <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
+      <Output TaskParameter="NativeChecksum" PropertyName="NativeChecksum" />
     </MetaDataProcessorTask>
+
+    <!--Output native checksum to Azure Pipelines var (only usefull on Azure)-->
+    <Message Importance="high" Text="##vso[task.setvariable variable=NativeAssemblyChecksum]$(NativeChecksum)" Condition="'$(NFMDP_GENERATE_STUBS)' == 'true' AND '$(SYSTEM_TEAMPROJECTID)' != ''"/>
 
     <!-- Copy files (dll, pe, pdb and pdbx) to ouput directory -->
     <CallTarget Targets="CopyFilesToOutputDirectory" />
@@ -530,7 +542,11 @@
         LoadDatabase="@(NFMDP_DAT_LoadDatabase)"
         ExcludeClassByName="@(NFMDP_DAT_ExcludeClassByName)">
       <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
+      <Output TaskParameter="NativeChecksum" PropertyName="NativeChecksum" />
     </MetaDataProcessorTask>
+
+    <!--Output native checksum to Azure Pipelines var (only usefull on Azure)-->
+    <Message Importance="high" Text="##vso[task.setvariable variable=NativeAssemblyChecksum]$(NativeChecksum)" Condition="'$(SYSTEM_TEAMPROJECTID)' != ''" />
 
   </Target>
 


### PR DESCRIPTION
##  Description
- Add output variable to MDP task to output native assembly checksum.
- Add code to MDP targets file to set Azure Pipeline variable with native assembly checksum.

## Motivation and Context
- This is now exposed as a build variable making it easier to be used in the pipeline.

## How Has This Been Tested?<!-- (if applicable) -->
- Experimental instance.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
