### PR TITLE
Remove advertising of PackageReferences

### DIFF
--- a/VisualStudio.Extension-2019/Targets/NFProjectSystem.targets
+++ b/VisualStudio.Extension-2019/Targets/NFProjectSystem.targets
@@ -17,7 +17,7 @@
   <ItemGroup>
     <ProjectCapability Include="NanoCSharpProject" />
     
-    <ProjectCapability Include="AssemblyReferences;ProjectReferences;PackageReferences;SharedProjectReferences" />
+    <ProjectCapability Include="AssemblyReferences;ProjectReferences;SharedProjectReferences" />
     <ProjectCapability Include="ProjectConfigurationsDeclaredAsItems" />
     <ProjectCapability Include="DeclaredSourceItems;UserSourceItems" />
     <ProjectCapability Include="CPS" />

--- a/VisualStudio.Extension/Targets/NFProjectSystem.targets
+++ b/VisualStudio.Extension/Targets/NFProjectSystem.targets
@@ -17,7 +17,7 @@
   <ItemGroup>
     <ProjectCapability Include="NanoCSharpProject" />
     
-    <ProjectCapability Include="AssemblyReferences;ProjectReferences;PackageReferences;SharedProjectReferences" />
+    <ProjectCapability Include="AssemblyReferences;ProjectReferences;SharedProjectReferences" />
     <ProjectCapability Include="ProjectConfigurationsDeclaredAsItems" />
     <ProjectCapability Include="DeclaredSourceItems;UserSourceItems" />
     <ProjectCapability Include="CPS" />


### PR DESCRIPTION
## Description
- Remove this from project capabilites.

## Motivation and Context
- Fixes nanoFramework/Home#712.

## How Has This Been Tested?<!-- (if applicable) -->
- Tested with VS 16.10 preview.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
