### PR TITLE
Fix exceptions when processing image resource files

### DIFF
--- a/Tools.BuildTasks/ProcessResourceFiles.cs
+++ b/Tools.BuildTasks/ProcessResourceFiles.cs
@@ -1371,7 +1371,12 @@ namespace nanoFramework.Tools
 
                 if (formatDst != bitmap.PixelFormat)
                 {
-                    bitmap = bitmap.Clone(rect, formatDst);
+                    // need to copy the Bitmap in order to access it, otherwise it will throw an exception
+                    using (Bitmap bmpCopy = new Bitmap(bitmap))
+                    using (Bitmap targetBmp = bmpCopy.Clone(rect, formatDst))
+                    {
+                        bitmap = new Bitmap(targetBmp);
+                    }
                 }
 
                 try
@@ -1423,7 +1428,12 @@ namespace nanoFramework.Tools
                 bitmapDescription = new NanoResourceFile.CLR_GFX_BitmapDescription((ushort)bitmap.Width, (ushort)bitmap.Height, 0, 1, type);
 
                 MemoryStream stream = new MemoryStream();
-                bitmap.Save(stream, bitmap.RawFormat);
+
+                // need to copy the Bitmap in order to access it, otherwise it will throw an exception
+                using (Bitmap bmpCopy = new Bitmap(bitmap))
+                {
+                    bmpCopy.Save(stream, bitmap.RawFormat);
+                }
 
                 stream.Capacity = (int)stream.Length;
                 return stream.GetBuffer();


### PR DESCRIPTION
## Description
- Copy Bitmaps before accessing their data, otherwise exceptions are thrown.

## Motivation and Context
- Fixes nanoFramework/Home#702.

## How Has This Been Tested?<!-- (if applicable) -->
- Test project with resource file and adding the two "offending" formats.

After the fix the build completes succesfully:
```
Rebuild started...
1>------ Rebuild All started: Project: NFApp4-Resx, Configuration: Debug Any CPU ------
1>NFApp4-Resx -> C:\Users\JoséSimões\source\repos\NFApp4-Resx\NFApp4-Resx\bin\Debug\NFApp4_Resx.exe
========== Rebuild All: 1 succeeded, 0 failed, 0 skipped ==========
```

## Screenshots<!-- (if appropriate): -->
![_Captura de ecrã 2021-03-23 130758](https://user-images.githubusercontent.com/1881520/112152056-c8ebe900-8bd9-11eb-84b1-3f754c8ff329.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
