### PR TITLE
Fix output dir in MDP targets file

### DIFF
--- a/VisualStudio.Extension-2019/Targets/NFProjectSystem.MDP.targets
+++ b/VisualStudio.Extension-2019/Targets/NFProjectSystem.MDP.targets
@@ -33,7 +33,7 @@
   <PropertyGroup>
     <NanoFramework_StartProgram Condition=" '$(StartAction)'== 'Program' ">$(StartProgram)</NanoFramework_StartProgram>
     <NanoFramework_IntermediateAssembly>$(ProjectDir)$(IntermediateOutputPath)$(TargetName)</NanoFramework_IntermediateAssembly>
-    <NanoFramework_Assembly>$(ProjectDir)$(OutDir)$(TargetName)</NanoFramework_Assembly>
+    <NanoFramework_Assembly>$(OutDir)$(TargetName)</NanoFramework_Assembly>
   </PropertyGroup>
 
   <!-- 
@@ -106,8 +106,8 @@
 
   <!-- Clean pe/pdbx files -->
   <Target Name="NanoFrameworkClean">
-    <Delete Condition="EXISTS('$(ProjectDir)$(OutDir)$(TargetName).pe')"   Files="$(ProjectDir)$(OutDir)$(TargetName).pe" />
-    <Delete Condition="EXISTS('$(ProjectDir)$(OutDir)$(TargetName).pdbx')" Files="$(ProjectDir)$(OutDir)$(TargetName).pdbx" />
+    <Delete Condition="EXISTS('$(OutDir)$(TargetName).pe')"   Files="$(OutDir)$(TargetName).pe" />
+    <Delete Condition="EXISTS('$(OutDir)$(TargetName).pdbx')" Files="$(OutDir)$(TargetName).pdbx" />
   </Target>
 
   <Target Name="CopyToOutDir">
@@ -115,28 +115,28 @@
     <Copy
         Condition="Exists('$(ProjectDir)$(IntermediateOutputPath)$(TargetName).exe')"
         SourceFiles="$(ProjectDir)$(IntermediateOutputPath)$(TargetName).exe"
-        DestinationFolder="$(ProjectDir)$(OutDir)\" >
+        DestinationFolder="$(OutDir)" >
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
     </Copy>
 
     <Copy
         Condition="Exists('$(ProjectDir)$(IntermediateOutputPath)$(TargetName).dll')"
         SourceFiles="$(ProjectDir)$(IntermediateOutputPath)$(TargetName).dll"
-        DestinationFolder="$(ProjectDir)$(OutDir)\" >
+        DestinationFolder="$(OutDir)" >
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
     </Copy>
 
     <Copy
         Condition="Exists('$(ProjectDir)$(IntermediateOutputPath)$(TargetName).pdbx')"
         SourceFiles="$(ProjectDir)$(IntermediateOutputPath)$(TargetName).pdbx"
-        DestinationFolder="$(ProjectDir)$(OutDir)" >
+        DestinationFolder="$(OutDir)" >
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
     </Copy>
 
     <Copy
         Condition="Exists('$(ProjectDir)$(IntermediateOutputPath)$(TargetName).bin')"
         SourceFiles="$(ProjectDir)$(IntermediateOutputPath)$(TargetName).bin"
-        DestinationFolder="$(ProjectDir)$(OutDir)" >
+        DestinationFolder="$(OutDir)" >
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
     </Copy>
 
@@ -170,14 +170,14 @@
         -->
     <Copy
         SourceFiles="@(ReferenceCopyLocalPaths->'%(RootDir)%(Directory)%(Filename).pe')"
-        DestinationFiles="@(ReferenceCopyLocalPaths->'$(OutDir)%(DestinationSubDirectory)%(Filename).pe')"
+        DestinationFiles="@(ReferenceCopyLocalPaths->'$(OutDir)%(Filename).pe')"
         SkipUnchangedFiles="true" ContinueOnError="true" >
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
     </Copy>
 
     <Copy
         SourceFiles="@(ReferenceCopyLocalPaths->'%(RootDir)%(Directory)%(Filename).pdbx')"
-        DestinationFiles="@(ReferenceCopyLocalPaths->'$(OutDir)%(DestinationSubDirectory)%(Filename).pdbx')"
+        DestinationFiles="@(ReferenceCopyLocalPaths->'$(OutDir)%(Filename).pdbx')"
         SkipUnchangedFiles="true" ContinueOnError="true">
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
     </Copy>
@@ -396,7 +396,7 @@
 
     <PropertyGroup>
       <!-- correct path for stubs output if set -->
-      <NFMDP_STUB_GenerateSkeletonFile Condition="'$(NFMDP_GENERATE_STUBS)' == 'true' AND '$(NFMDP_STUB_GenerateSkeletonFile)'!=''">$(ProjectDir)$(OutDir)$(NFMDP_STUB_GenerateSkeletonFile)</NFMDP_STUB_GenerateSkeletonFile>
+      <NFMDP_STUB_GenerateSkeletonFile Condition="'$(NFMDP_GENERATE_STUBS)' == 'true' AND '$(NFMDP_STUB_GenerateSkeletonFile)'!=''">$(OutDir)$(NFMDP_STUB_GenerateSkeletonFile)</NFMDP_STUB_GenerateSkeletonFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/VisualStudio.Extension/Targets/NFProjectSystem.MDP.targets
+++ b/VisualStudio.Extension/Targets/NFProjectSystem.MDP.targets
@@ -33,7 +33,7 @@
   <PropertyGroup>
     <NanoFramework_StartProgram Condition=" '$(StartAction)'== 'Program' ">$(StartProgram)</NanoFramework_StartProgram>
     <NanoFramework_IntermediateAssembly>$(ProjectDir)$(IntermediateOutputPath)$(TargetName)</NanoFramework_IntermediateAssembly>
-    <NanoFramework_Assembly>$(ProjectDir)$(OutDir)$(TargetName)</NanoFramework_Assembly>
+    <NanoFramework_Assembly>$(OutDir)$(TargetName)</NanoFramework_Assembly>
   </PropertyGroup>
 
   <!-- 
@@ -106,8 +106,8 @@
 
   <!-- Clean pe/pdbx files -->
   <Target Name="NanoFrameworkClean">
-    <Delete Condition="EXISTS('$(ProjectDir)$(OutDir)$(TargetName).pe')"   Files="$(ProjectDir)$(OutDir)$(TargetName).pe" />
-    <Delete Condition="EXISTS('$(ProjectDir)$(OutDir)$(TargetName).pdbx')" Files="$(ProjectDir)$(OutDir)$(TargetName).pdbx" />
+    <Delete Condition="EXISTS('$(OutDir)$(TargetName).pe')"   Files="$(OutDir)$(TargetName).pe" />
+    <Delete Condition="EXISTS('$(OutDir)$(TargetName).pdbx')" Files="$(OutDir)$(TargetName).pdbx" />
   </Target>
 
   <Target Name="CopyToOutDir">
@@ -115,28 +115,28 @@
     <Copy
         Condition="Exists('$(ProjectDir)$(IntermediateOutputPath)$(TargetName).exe')"
         SourceFiles="$(ProjectDir)$(IntermediateOutputPath)$(TargetName).exe"
-        DestinationFolder="$(ProjectDir)$(OutDir)\" >
+        DestinationFolder="$(OutDir)" >
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
     </Copy>
 
     <Copy
         Condition="Exists('$(ProjectDir)$(IntermediateOutputPath)$(TargetName).dll')"
         SourceFiles="$(ProjectDir)$(IntermediateOutputPath)$(TargetName).dll"
-        DestinationFolder="$(ProjectDir)$(OutDir)\" >
+        DestinationFolder="$(OutDir)" >
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
     </Copy>
 
     <Copy
         Condition="Exists('$(ProjectDir)$(IntermediateOutputPath)$(TargetName).pdbx')"
         SourceFiles="$(ProjectDir)$(IntermediateOutputPath)$(TargetName).pdbx"
-        DestinationFolder="$(ProjectDir)$(OutDir)" >
+        DestinationFolder="$(OutDir)" >
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
     </Copy>
 
     <Copy
         Condition="Exists('$(ProjectDir)$(IntermediateOutputPath)$(TargetName).bin')"
         SourceFiles="$(ProjectDir)$(IntermediateOutputPath)$(TargetName).bin"
-        DestinationFolder="$(ProjectDir)$(OutDir)" >
+        DestinationFolder="$(OutDir)" >
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
     </Copy>
 
@@ -170,14 +170,14 @@
         -->
     <Copy
         SourceFiles="@(ReferenceCopyLocalPaths->'%(RootDir)%(Directory)%(Filename).pe')"
-        DestinationFiles="@(ReferenceCopyLocalPaths->'$(OutDir)%(DestinationSubDirectory)%(Filename).pe')"
+        DestinationFiles="@(ReferenceCopyLocalPaths->'$(OutDir)%(Filename).pe')"
         SkipUnchangedFiles="true" ContinueOnError="true" >
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
     </Copy>
 
     <Copy
         SourceFiles="@(ReferenceCopyLocalPaths->'%(RootDir)%(Directory)%(Filename).pdbx')"
-        DestinationFiles="@(ReferenceCopyLocalPaths->'$(OutDir)%(DestinationSubDirectory)%(Filename).pdbx')"
+        DestinationFiles="@(ReferenceCopyLocalPaths->'$(OutDir)%(Filename).pdbx')"
         SkipUnchangedFiles="true" ContinueOnError="true">
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
     </Copy>
@@ -396,7 +396,7 @@
 
     <PropertyGroup>
       <!-- correct path for stubs output if set -->
-      <NFMDP_STUB_GenerateSkeletonFile Condition="'$(NFMDP_GENERATE_STUBS)' == 'true' AND '$(NFMDP_STUB_GenerateSkeletonFile)'!=''">$(ProjectDir)$(OutDir)$(NFMDP_STUB_GenerateSkeletonFile)</NFMDP_STUB_GenerateSkeletonFile>
+      <NFMDP_STUB_GenerateSkeletonFile Condition="'$(NFMDP_GENERATE_STUBS)' == 'true' AND '$(NFMDP_STUB_GenerateSkeletonFile)'!=''">$(OutDir)$(NFMDP_STUB_GenerateSkeletonFile)</NFMDP_STUB_GenerateSkeletonFile>
     </PropertyGroup>
 
     <ItemGroup>
@@ -552,7 +552,7 @@
     </MetaDataProcessorTask>
 
     <!--Output native checksum to Azure Pipelines var (only usefull on Azure)-->
-    <Message Importance="high" Text="##vso[task.setvariable variable=NativeAssemblyChecksum]$(NativeChecksum)" Condition="'$(TF_BUILD)' == 'true'"/>
+    <Message Importance="high" Text="##vso[task.setvariable variable=NativeAssemblyChecksum]$(NativeChecksum)" Condition="'$(TF_BUILD)' == 'true'" />
     <Message Importance="high" Text="Metadata processor location overriden with: $(NF_MDP_MSBUILDTASK_PATH)" Condition="'$(NF_MDP_MSBUILDTASK_PATH)' != ''" />
 
   </Target>


### PR DESCRIPTION
## Description
- Update MDP targets file to allow output dir to be freely set.

## Motivation and Context
- Was wrongly forcing the output directory to be inside the project folder.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
