### PR TITLE
Fix loading of assembly without debug symbols

### DIFF
--- a/VisualStudio.Extension/CorDebug/CorDebugAppDomain.cs
+++ b/VisualStudio.Extension/CorDebug/CorDebugAppDomain.cs
@@ -119,18 +119,28 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                     
                     Debug.Assert( assembly != null );
 
-                    //create a new CorDebugAssemblyInstance
-                    assembly = assembly.CreateAssemblyInstance( this );
+                    if (assembly.HasSymbols)
+                    {
+                        //create a new CorDebugAssemblyInstance
+                        assembly = assembly.CreateAssemblyInstance(this);
 
-                    Debug.Assert(assembly != null);
+                        Debug.Assert(assembly != null);
 
-                    m_assemblies.Add( assembly );
+                        m_assemblies.Add(assembly);
 
-                    //cpde expects mscorlib to be the first assembly it hears about
-                    int index = (assembly.Name == "mscorlib") ? 0 : callbacks.Count;
+                        //cpde expects mscorlib to be the first assembly it hears about
+                        int index = (assembly.Name == "mscorlib") ? 0 : callbacks.Count;
 
-                    callbacks.Insert(index, new ManagedCallbacks.ManagedCallbackAssembly(assembly, ManagedCallbacks.ManagedCallbackAssembly.EventType.LoadAssembly));
-                    callbacks.Insert(index+1, new ManagedCallbacks.ManagedCallbackAssembly(assembly, ManagedCallbacks.ManagedCallbackAssembly.EventType.LoadModule));
+                        callbacks.Insert(index, new ManagedCallbacks.ManagedCallbackAssembly(assembly, ManagedCallbacks.ManagedCallbackAssembly.EventType.LoadAssembly));
+                        callbacks.Insert(index + 1, new ManagedCallbacks.ManagedCallbackAssembly(assembly, ManagedCallbacks.ManagedCallbackAssembly.EventType.LoadModule));
+                    }
+                    else
+                    {
+                        // no debug symbols available, so can't call the LoadModule event
+                        // this is probably an assembly that was loaded inside the application running using reflection
+                        MessageCentre.DebugMessage($"*** No debugging symbols available for '{assembly.Name}'. This assembly won't be loaded in the current debug session. ***");
+                        MessageCentre.InternalErrorMessage($"*** No debugging symbols available for '{assembly.Name}'. This assembly won't be loaded in the current debug session. ***");
+                    }
                 }
             }
 

--- a/VisualStudio.Extension/CorDebug/CorDebugProcess.cs
+++ b/VisualStudio.Extension/CorDebug/CorDebugProcess.cs
@@ -1430,6 +1430,8 @@ namespace nanoFramework.Tools.VisualStudio.Extension
             MessageCentre.InternalErrorMessage(Resources.ResourceStrings.LoadedAssembliesInformation);
             lock (_appDomains)
             {
+                _assemblies = new ArrayList();
+
                 LoadAssemblies();
 
                 uint[] appDomains = new uint[] { CorDebugAppDomain.c_AppDomainId_ForNoAppDomainSupport };

--- a/VisualStudio.Extension/CorDebug/MetaDataImport.cs
+++ b/VisualStudio.Extension/CorDebug/MetaDataImport.cs
@@ -660,8 +660,9 @@ namespace nanoFramework.Tools.VisualStudio.Extension.MetaData
         }
 
         public int GetAssemblyFromScope (IntPtr ptkAssembly)
-        {            
+        {
             //Only one assembly per MetaDataImport, doesn't matter what token we give them back            
+            NotImpl();
             return COM_HResults.E_NOTIMPL;
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
- Add check for debug symbols existing so the assembly and module loading only occur if those are available.
- Add missing assert from not implemented call.

## Motivation and Context
- This would happen when an assembly is loaded with reflection using `Assembly.Load()`. Without this check the debugger would try to load the assembly and the respective module. That would fail miserably because the debug symbols are not available and we don't have any way to find out that. The call to `GetAssemblyFromScope()` is not implemented on purpose because we are allowing only one assembly for each MetadataImport.
- Resolves nanoFramework/Home#732.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
