### PR TITLE
Improvements in device operations

### DIFF
--- a/VisualStudio.Extension/CorDebug/CorDebugProcess.cs
+++ b/VisualStudio.Extension/CorDebug/CorDebugProcess.cs
@@ -290,6 +290,9 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                     // need to reset flag
                     _engine.StopDebuggerOnConnect = false;
 
+                    // stop processing engine so it disconnects from device
+                    _engine.Stop(true);
+
                     // better do this inside a try/catch for unexpected side effects from the dispose and finalizer
                     try
                     {

--- a/VisualStudio.Extension/ToolWindow.DeviceExplorer/DeviceExplorerCommand.cs
+++ b/VisualStudio.Extension/ToolWindow.DeviceExplorer/DeviceExplorerCommand.cs
@@ -292,15 +292,12 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                         NanoDeviceCommService.Device.CreateDebugEngine();
                     }
 
-                    // connect to the device, if needed
-                    if (!NanoDeviceCommService.Device.DebugEngine.IsConnected)
+                    // connect to the device
+                    if (!NanoDeviceCommService.Device.DebugEngine.Connect())
                     {
-                        if (!NanoDeviceCommService.Device.DebugEngine.Connect())
-                        {
-                            MessageCentre.OutputMessage($"{descriptionBackup} is not responding, please reboot the device.");
+                        MessageCentre.OutputMessage($"{descriptionBackup} is not responding, please reboot the device.");
 
-                            return;
-                        }
+                        return;
                     }
 
                     // ping device
@@ -325,6 +322,9 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 }
                 finally
                 {
+                    // disconnect device
+                    NanoDeviceCommService.Device?.DebugEngine?.Stop(true);
+
                     // enable buttons
                     await UpdateDeviceDependentToolbarButtonsAsync(true);
 
@@ -508,6 +508,9 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 }
                 finally
                 {
+                    // disconnect device
+                    NanoDeviceCommService.Device?.DebugEngine?.Stop(true);
+
                     // enable buttons
                     await UpdateDeviceDependentToolbarButtonsAsync(true);
 
@@ -601,6 +604,9 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 }
                 finally
                 {
+                    // disconnect device
+                    NanoDeviceCommService.Device?.DebugEngine?.Stop(true);
+
                     // enable buttons
                     await UpdateDeviceDependentToolbarButtonsAsync(true);
 
@@ -705,6 +711,9 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 }
                 finally
                 {
+                    // disconnect device
+                    NanoDeviceCommService.Device?.DebugEngine?.Stop(true);
+
                     // enable buttons
                     await UpdateDeviceDependentToolbarButtonsAsync(true);
 
@@ -749,7 +758,9 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                     var previousSelectedDeviceDescription = NanoDeviceCommService.Device.Description;
 
                     // connect to the device
-                    if (NanoDeviceCommService.Device.DebugEngine.Connect(5000))
+                    if (NanoDeviceCommService.Device.DebugEngine.Connect(
+                        false,
+                        true))
                     {
                         try
                         {
@@ -820,6 +831,9 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 }
                 finally
                 {
+                    // disconnect device
+                    NanoDeviceCommService.Device?.DebugEngine?.Stop(true);
+
                     // enable buttons
                     await UpdateDeviceDependentToolbarButtonsAsync(true);
                 }


### PR DESCRIPTION
## Description
- Device is now disconnected when debug is stopped.
- Now all operations in Device Explorer menu open device if needed and close connection to it before leaving.
- Debug Launch now requests for device capabilities.

## Motivation and Context
- Fixes issues with starting a debug session in ESP32 devices.
- Allow connecting to devices that are not being used in other instances of VS and other applications.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
