### PR TITLE
Fix debug start

### DIFF
--- a/VisualStudio.Extension/CorDebug/CorDebugProcess.cs
+++ b/VisualStudio.Extension/CorDebug/CorDebugProcess.cs
@@ -360,6 +360,8 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                             MessageCentre.InternalErrorWriteLine($"Device is running CLR, requesting reboot and pause for debugger ({retries + 1}/{ maxOperationRetries }).");
 
                             _engine.RebootDevice(RebootOptions.ClrOnly | RebootOptions.WaitForDebugger);
+
+                            Thread.Sleep(500);
                         }
                     }
                     else if (_engine.IsConnectedTonanoBooter)


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
- Add thread sleep after device reboot to allow communication flow and device changing state.
- Update debugger sub-module @ 8e59558.

## Motivation and Context
- Improves debug start on ESP32 device.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
