### PR TITLE
Improvements in debug session start

### DIFF
--- a/VisualStudio.Extension/DebugLauncher/NanoDebuggerLaunchProvider.cs
+++ b/VisualStudio.Extension/DebugLauncher/NanoDebuggerLaunchProvider.cs
@@ -43,7 +43,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 // check for debug engine
                 if (device.DebugEngine == null)
                 {
-                    device.CreateDebugEngine(device.Transport == Debugger.WireProtocol.TransportType.Serial ? NanoSerialDevice.SafeDefaultTimeout : 5000);
+                    device.CreateDebugEngine();
                 }
 
                 // make sure that the device is connected

--- a/VisualStudio.Extension/NanoDeviceCommService/NanoDeviceCommService.cs
+++ b/VisualStudio.Extension/NanoDeviceCommService/NanoDeviceCommService.cs
@@ -74,15 +74,6 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
             Device = device;
 
-            // has we'll be needing the debugger engine anyway, create it if needed
-            if (device != null)
-            {
-                if (device.DebugEngine == null)
-                {
-                    device.CreateDebugEngine();
-                }
-            }
-
             return true;
         }
 


### PR DESCRIPTION
## Description
- Rework AttachToEngine to simplify workflow.
- Rework EnsureProcessIsInInitializedState to remove unnecessary reboot call and rename vars for consistency.
- Remove unnecessary debug engine creation in comm service.
- Remove unnecessary timeout setting in debug lunch provider.
- Update debugger sub-module @ 8e59558.

## Motivation and Context
- Improves device detection.
- Fixes random issues with debug session start.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
