### PR TITLE
Fix error with auto selection of device

### DIFF
--- a/VisualStudio.Extension/ToolWindow.DeviceExplorer/DeviceExplorerCommand.cs
+++ b/VisualStudio.Extension/ToolWindow.DeviceExplorer/DeviceExplorerCommand.cs
@@ -284,7 +284,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                     await UpdateDeviceDependentToolbarButtonsAsync(false);
 
                     // make sure this device is showing as selected in Device Explorer tree view
-                    await ViewModelLocator.DeviceExplorer.ForceNanoDeviceSelectionAsync();
+                    ViewModelLocator.DeviceExplorer.ForceNanoDeviceSelection();
 
                     // check if debugger engine exists
                     if (NanoDeviceCommService.Device.DebugEngine == null)
@@ -358,7 +358,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                     await UpdateDeviceDependentToolbarButtonsAsync(false);
 
                     // make sure this device is showing as selected in Device Explorer tree view
-                    await ViewModelLocator.DeviceExplorer.ForceNanoDeviceSelectionAsync();
+                    ViewModelLocator.DeviceExplorer.ForceNanoDeviceSelection();
 
                     // only query device if it's different 
                     if (descriptionBackup.GetHashCode() != ViewModelLocator.DeviceExplorer.LastDeviceConnectedHash)
@@ -548,7 +548,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                     await UpdateDeviceDependentToolbarButtonsAsync(false);
 
                     // make sure this device is showing as selected in Device Explorer tree view
-                    await ViewModelLocator.DeviceExplorer.ForceNanoDeviceSelectionAsync();
+                    ViewModelLocator.DeviceExplorer.ForceNanoDeviceSelection();
 
                     // check if debugger engine exists
                     if (NanoDeviceCommService.Device.DebugEngine == null)
@@ -639,7 +639,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                     await UpdateDeviceDependentToolbarButtonsAsync(false);
 
                     // make sure this device is showing as selected in Device Explorer tree view
-                    await ViewModelLocator.DeviceExplorer.ForceNanoDeviceSelectionAsync();
+                    ViewModelLocator.DeviceExplorer.ForceNanoDeviceSelection();
 
                     // check if debugger engine exists
                     if (NanoDeviceCommService.Device.DebugEngine == null)
@@ -744,7 +744,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                     await UpdateDeviceDependentToolbarButtonsAsync(false);
 
                     // make sure this device is showing as selected in Device Explorer tree view
-                    await ViewModelLocator.DeviceExplorer.ForceNanoDeviceSelectionAsync();
+                    ViewModelLocator.DeviceExplorer.ForceNanoDeviceSelection();
 
                     // check if debugger engine exists
                     if (NanoDeviceCommService.Device.DebugEngine == null)

--- a/VisualStudio.Extension/ToolWindow.DeviceExplorer/DeviceExplorerControl.xaml.cs
+++ b/VisualStudio.Extension/ToolWindow.DeviceExplorer/DeviceExplorerControl.xaml.cs
@@ -10,6 +10,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
     using nanoFramework.Tools.Debugger;
     using nanoFramework.Tools.VisualStudio.Extension.ToolWindow.ViewModel;
     using System;
+    using System.Threading;
     using System.Windows.Controls;
 
     /// <summary>
@@ -77,6 +78,8 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
         private async System.Threading.Tasks.Task ForceSelectionOfNanoDeviceHandlerAsync()
         {
+            int tryCount = 2;
+
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             // make sure the item in the treeview is selected, in case the selected device was changed in the view model
@@ -90,20 +93,32 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 return;
             }
 
-            // select the device
-            if (DevicesHeaderItem.ItemContainerGenerator.ContainerFromItem((DataContext as DeviceExplorerViewModel).SelectedDevice) is TreeViewItem deviceItem)
+
+            do
             {
-                // switch to UI main thread
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                // select the device
+                if (DevicesHeaderItem.ItemContainerGenerator.ContainerFromItem((DataContext as DeviceExplorerViewModel).SelectedDevice) is TreeViewItem deviceItem)
+                {
+                    // switch to UI main thread
+                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-                // need to disable the event handler otherwise it will mess the selection
-                deviceTreeView.SelectedItemChanged -= DevicesTreeView_SelectedItemChanged;
+                    // need to disable the event handler otherwise it will mess the selection
+                    deviceTreeView.SelectedItemChanged -= DevicesTreeView_SelectedItemChanged;
 
-                deviceItem.IsSelected = true;
+                    deviceItem.IsSelected = true;
 
-                // enabled it back
-                deviceTreeView.SelectedItemChanged += DevicesTreeView_SelectedItemChanged;
+                    // enabled it back
+                    deviceTreeView.SelectedItemChanged += DevicesTreeView_SelectedItemChanged;
+                }
+                else
+                {
+                    // needs some time to allow the collection to be populated
+                    await System.Threading.Tasks.Task.Delay(10).ConfigureAwait(true);
+                }
             }
+            while (tryCount-- > 0);
+
+            Messenger.Default.Send(new NotificationMessage(""), DeviceExplorerViewModel.MessagingTokens.SelectedNanoDeviceHasChanged);
 
             // force redrawing to show selection
             deviceTreeView.InvalidateVisual();

--- a/VisualStudio.Extension/ToolWindow.DeviceExplorer/ViewModel/DeviceExplorerViewModel.cs
+++ b/VisualStudio.Extension/ToolWindow.DeviceExplorer/ViewModel/DeviceExplorerViewModel.cs
@@ -162,7 +162,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension.ToolWindow.ViewModel
                     // is there a single device
                     if (AvailableDevices.Count == 1)
                     {
-                        ForceNanoDeviceSelectionAsync(AvailableDevices[0]).ConfigureAwait(true);
+                        ForceNanoDeviceSelection(AvailableDevices[0]);
                     }
                 }
 
@@ -222,7 +222,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension.ToolWindow.ViewModel
                     if (deviceToReSelect != null)
                     {
                         // device seems to be back online, select it
-                        ForceNanoDeviceSelectionAsync(deviceToReSelect).ConfigureAwait(true);
+                        ForceNanoDeviceSelection(deviceToReSelect);
 
                         // clear device to reselect
                         DeviceToReSelect = null;
@@ -234,7 +234,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension.ToolWindow.ViewModel
                     // is there a single device
                     if (AvailableDevices.Count == 1)
                     {
-                        ForceNanoDeviceSelectionAsync(AvailableDevices[0]).ConfigureAwait(true);
+                        ForceNanoDeviceSelection(AvailableDevices[0]);
                     }
                     else
                     {
@@ -242,26 +242,26 @@ namespace nanoFramework.Tools.VisualStudio.Extension.ToolWindow.ViewModel
                         if (SelectedDevice != null)
                         {
                             // maintain selection
-                            ForceNanoDeviceSelectionAsync(AvailableDevices.FirstOrDefault(d => d.Description == SelectedDevice.Description)).ConfigureAwait(false);
+                            ForceNanoDeviceSelection(AvailableDevices.FirstOrDefault(d => d.Description == SelectedDevice.Description));
                         }
                     }
                 }
             }
         }
 
-        private async Task ForceNanoDeviceSelectionAsync(NanoDeviceBase nanoDevice)
+        private void ForceNanoDeviceSelection(NanoDeviceBase nanoDevice)
         {
             // select the device
             SelectedDevice = nanoDevice;
 
             // request forced selection of device in UI
-            await Task.Run(() => { MessengerInstance.Send(new NotificationMessage(""), MessagingTokens.ForceSelectionOfNanoDevice); });
+            _ = Task.Run(() => { MessengerInstance.Send(new NotificationMessage(""), MessagingTokens.ForceSelectionOfNanoDevice); });
         }
 
-        public async Task ForceNanoDeviceSelectionAsync()
+        public void ForceNanoDeviceSelection()
         {
             // request forced selection of device in UI
-            await Task.Run(() => { MessengerInstance.Send(new NotificationMessage(""), MessagingTokens.ForceSelectionOfNanoDevice); });
+            _ = Task.Run(() => { MessengerInstance.Send(new NotificationMessage(""), MessagingTokens.ForceSelectionOfNanoDevice); });
         }
 
         public void OnSelectedDeviceChanged()


### PR DESCRIPTION
## Description
- Improve handler to allow enough time for collection to be populated and then perform the selection of the item.

## Motivation and Context
- Fixes issue with a single device not being automatically selected when the devices collection changes.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
