### PR TITLE
Improvement in LoadHints for MDP targets

### DIFF
--- a/VisualStudio.Extension-2019/Targets/NFProjectSystem.MDP.targets
+++ b/VisualStudio.Extension-2019/Targets/NFProjectSystem.MDP.targets
@@ -436,7 +436,7 @@
         GenerateDependency="$(NFMDP_PE_GenerateDependency)"
         CreateDatabase="@(NFMDP_PE_CreateDatabase)"
         CreateDatabaseFile="$(NFMDP_PE_CreateDatabaseFile)"
-        LoadHints="@(NFMDP_PE_LoadHints)"
+        LoadHints="@(ReferencePath);@(ReferenceDependencyPaths);@(ReferenceSatellitePaths)"
         IgnoreAssembly="@(NFMDP_PE_IgnoreAssembly)"
         ExcludeClassByName="@(NFMDP_PE_ExcludeClassByName)"
         Condition="'$(NFMDP_GENERATE_STUBS)' == 'false'">
@@ -469,7 +469,7 @@
         GenerateDependency="$(NFMDP_STUB_GenerateDependency)"
         CreateDatabase="@(NFMDP_STUB_CreateDatabase)"
         CreateDatabaseFile="$(NFMDP_STUB_CreateDatabaseFile)"
-        LoadHints="@(NFMDP_PE_LoadHints)"
+        LoadHints="@(ReferencePath);@(ReferenceDependencyPaths);@(ReferenceSatellitePaths)"
         IgnoreAssembly="@(NFMDP_STUB_IgnoreAssembly)"
         ExcludeClassByName="@(NFMDP_PE_ExcludeClassByName)"
         Condition="'$(NFMDP_GENERATE_STUBS)' == 'true'">

--- a/VisualStudio.Extension/Targets/NFProjectSystem.MDP.targets
+++ b/VisualStudio.Extension/Targets/NFProjectSystem.MDP.targets
@@ -436,7 +436,7 @@
         GenerateDependency="$(NFMDP_PE_GenerateDependency)"
         CreateDatabase="@(NFMDP_PE_CreateDatabase)"
         CreateDatabaseFile="$(NFMDP_PE_CreateDatabaseFile)"
-        LoadHints="@(NFMDP_PE_LoadHints)"
+        LoadHints="@(ReferencePath);@(ReferenceDependencyPaths);@(ReferenceSatellitePaths)"
         IgnoreAssembly="@(NFMDP_PE_IgnoreAssembly)"
         ExcludeClassByName="@(NFMDP_PE_ExcludeClassByName)"
         Condition="'$(NFMDP_GENERATE_STUBS)' == 'false'">
@@ -469,7 +469,7 @@
         GenerateDependency="$(NFMDP_STUB_GenerateDependency)"
         CreateDatabase="@(NFMDP_STUB_CreateDatabase)"
         CreateDatabaseFile="$(NFMDP_STUB_CreateDatabaseFile)"
-        LoadHints="@(NFMDP_PE_LoadHints)"
+        LoadHints="@(ReferencePath);@(ReferenceDependencyPaths);@(ReferenceSatellitePaths)"
         IgnoreAssembly="@(NFMDP_STUB_IgnoreAssembly)"
         ExcludeClassByName="@(NFMDP_PE_ExcludeClassByName)"
         Condition="'$(NFMDP_GENERATE_STUBS)' == 'true'">


### PR DESCRIPTION
## Description
- LoadHints aren't required anymore in nfproj files. 
- Bump versions to 2017.7.0 and 2019.7.0.

Note: it's OK to keep having NFMDP_PE_LoadHints in nfproj, but those won't be used anymore from now on.

## Motivation and Context
- msbuild is perfectly capable to determine paths to all referenced assemblies.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
