### PR TITLE
Fix generator for binary resources

### DIFF
--- a/Tools.BuildTasks-2017/ProcessResourceFiles.cs
+++ b/Tools.BuildTasks-2017/ProcessResourceFiles.cs
@@ -944,32 +944,10 @@ namespace nanoFramework.Tools
 
                     if (entry == null)
                     {
-                        // Try to create a bitmap from byte[]
-                        // If it doesn't contain a BMP format (will throw an exception) then create BinaryEntry
+                        // Create BinaryEntry
                         using (var ms = new MemoryStream(rawValue))
                         {
-                            try
-                            {
-                                Bitmap bmp = new Bitmap(ms);
-
-                                // validate supported formats
-                                if (
-                                    bmp.RawFormat.Equals(ImageFormat.Jpeg) ||
-                                    bmp.RawFormat.Equals(ImageFormat.Gif) ||
-                                    bmp.RawFormat.Equals(ImageFormat.Bmp))
-                                {
-                                    entry = new BitmapEntry(name, bmp);
-                                }
-                                else
-                                {
-                                    // bitmap image format not supported 
-                                    throw new NotSupportedException();
-                                }
-                            }
-                            catch(Exception) 
-                            {
-                                entry = new BinaryEntry(name, rawValue);
-                            }
+                            entry = new BinaryEntry(name, rawValue);
                         }
                     }
                 }


### PR DESCRIPTION
## Description
- Binary resources do not default to Bitmap anymore.

## Motivation and Context
- With the current approach all binary resources where first attempted to be parsed as Bitmap which, on success, would prevent the resource from being added as a simple binary resource. This defeats the intent of adding a file as binary resource even if it's a bitmap. Typical use case is to store bitmap files to use it's binary data without requiring to reference the UI nuget.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- VS experimental instance: adding a bitmap file without extension which was successfully added as a binary resource.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
