### PR TITLE
Improve pipeline to build VS2019 and VS2022 in separate jobs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,8 @@ jobs:
       $commit.files | % {$_.filename}
 
       # default values 
-      echo "##vso[task.setvariable variable=BUILD_VS2019_2022;isOutput=true]false"  
+      echo "##vso[task.setvariable variable=BUILD_VS2019;isOutput=true]false"  
+      echo "##vso[task.setvariable variable=BUILD_VS2022;isOutput=true]false"  
 
       if( ($commit.files.filename -like "*CSharp.AssemblyInfoTemplate*") -Or
           ($commit.files.filename -like "*CSharp.BlankApplication*") -Or
@@ -55,29 +56,32 @@ jobs:
         )
       {
           # global changes, build both
-          echo "##vso[task.setvariable variable=BUILD_VS2019_2022;isOutput=true]true"  
+          echo "##vso[task.setvariable variable=BUILD_VS2019;isOutput=true]true"
+          echo "##vso[task.setvariable variable=BUILD_VS2022;isOutput=true]true"
       }
       else
       {
         if( $commit.files.filename -like "*nanoFramework.Tools.VisualStudio.sln")
         {
           # changes here impact VS2022 and VS2019
-          echo "##vso[task.setvariable variable=BUILD_VS2019_2022;isOutput=true]true"  
+          echo "##vso[task.setvariable variable=BUILD_VS2019;isOutput=true]true"
+          echo "##vso[task.setvariable variable=BUILD_VS2022;isOutput=true]true"
         }
         if( $commit.files.filename -like "*VisualStudio.Extension-2019/*" )
         {
           # changes here only impact VS2022 and VS2019
-          echo "##vso[task.setvariable variable=BUILD_VS2019_2022;isOutput=true]true"
+          echo "##vso[task.setvariable variable=BUILD_VS2019;isOutput=true]true"
+          echo "##vso[task.setvariable variable=BUILD_VS2022;isOutput=true]true"
         }
         if( $commit.files.filename -like "*VisualStudio.Extension-2022/*" )
         {
           # changes here only impact VS2022
-          echo "##vso[task.setvariable variable=BUILD_VS2019_2022;isOutput=true]true"
+          echo "##vso[task.setvariable variable=BUILD_VS2022;isOutput=true]true"
         }
       }
 
     name: BuildOptions
-    displayName: get list of changed paths
+    displayName: Get what to build
 
   - powershell: |
       # read VS2019 manifest file
@@ -106,21 +110,20 @@ jobs:
     displayName: Check proper version format
 
 ######################
-- job: VS2019_2022
+- job: VS2019
   condition: >-
     or(
-      eq(dependencies.Get_Build_Options.outputs['BuildOptions.BUILD_VS2019_2022'], true),
-      eq(variables['BUILD_VS2019'], 'true'),
-      eq(variables['BUILD_VS2022'], 'true')
+      eq(dependencies.Get_Build_Options.outputs['BuildOptions.BUILD_VS2019'], true),
+      eq(variables['BUILD_VS2019'], 'true')
     )
   dependsOn:
   - Get_Build_Options
 
   pool:
-    vmImage: 'windows-2022'
+    vmImage: 'windows-2019'
 
   variables:
-    solution: '**/nanoFramework.Tools.VisualStudio.sln'
+    solution: 'VisualStudio.Extension-2019\VisualStudio.Extension-vs2019.csproj'
     buildConfiguration: 'Release'
 
   steps:
@@ -159,13 +162,13 @@ jobs:
     inputs:
         targetType: 'inline'
         script: |
-            Write-Host "VS2019+2022 build version $env:NBGV_AssemblyVersion"
+            Write-Host "VS2019 build version $env:NBGV_AssemblyVersion"
             
             echo "##vso[task.setvariable variable=BUILD_VERSION;isOutput=true]$env:NBGV_AssemblyVersion"  
 
     condition: succeeded()
-    name: VS2019_2022_Build
-    displayName: Store VS2019+2022 build version
+    name: VS2019_Build
+    displayName: Store VS2019 build version
 
   - task: CopyFiles@1
     inputs:
@@ -180,20 +183,6 @@ jobs:
       flattenFolders: true
     condition: succeeded()
     displayName: Collecting VS2019 deployable artifacts
-
-  - task: CopyFiles@1
-    inputs:
-      sourceFolder: $(Build.SourcesDirectory)
-      Contents: |
-        **\*VS2022.Extension.vsix
-        **\vs2022-extension-manifest.json
-        **\vs2022-marketplace-overview.md
-        **\vs2022\debug-session.png
-        **\vs2022\starting-new-project.png
-      TargetFolder: '$(Build.ArtifactStagingDirectory)\vs2022'
-      flattenFolders: true
-    condition: succeeded()
-    displayName: Collecting VS2022 deployable artifacts
 
   - task: DotNetCoreCLI@2
     displayName: Install SignTool tool
@@ -216,7 +205,191 @@ jobs:
       --descriptionUrl "https://github.com/$env:Build_Repository_Name"
     displayName: Sign VS2019 packages
     condition: and( succeeded(), eq(variables['System.PullRequest.PullRequestId'], '') )
-  
+
+  # publish artifacts (only possible if this is not a PR originated on a fork)
+  - task: PublishBuildArtifacts@1
+    inputs:
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      ArtifactName: deployables
+      ArtifactType: Container
+    condition: and( succeeded(), ne(variables['system.pullrequest.isfork'], true) )
+    displayName: Publish deployables artifacts
+
+  # upload extension to Open VSIX Gallery (only possible if this is not a PR from a fork)
+  - task: PowerShell@2
+    inputs:
+        targetType: 'inline'
+        script: |
+
+          $artifactsCollection = @("./*VS2019.Extension.vsix") | %{ Get-ChildItem -File . -Filter $_ -Recurse}
+
+          (new-object Net.WebClient).DownloadString("https://raw.github.com/madskristensen/ExtensionScripts/master/AppVeyor/vsix.ps1") | iex
+
+          foreach($file in $artifactsCollection)
+          {
+              "Uploading VSIX package to Open VSIX Gallery..." | Write-Host
+
+              Vsix-PublishToGallery $file
+          }
+    condition: >-
+      and(
+        succeeded(),
+        ne(variables['system.pullrequest.isfork'], true),
+        eq(variables['System.PullRequest.PullRequestId'], '')
+      )
+    displayName: Upload vsix to Open VSIX Gallery
+
+  - powershell: |
+      # get subject and commit message for commit
+      $commitMessage = git log --format='%B' -1
+
+      # need to flatten message by removing new lines
+      $commitMessage = $commitMessage -replace "`r`n", " "
+
+      if($commitMessage -like "*PUBLISH_RELEASE*")
+      {
+        # set variable
+        Write-Host "$("##vso[task.setvariable variable=RELEASE_DRAFT]")false"
+        Write-Host "Release draft: FALSE"
+      }
+      else
+      {
+        # set variable
+        Write-Host "$("##vso[task.setvariable variable=RELEASE_DRAFT]")true"
+        Write-Host "Release draft: TRUE"
+      }
+
+    displayName: set release draft var
+
+  # create or update GitHub release
+  - task: GithubRelease@1
+    condition: >-
+      and(
+        succeeded(),
+        eq(variables['System.PullRequest.PullRequestId'], ''),
+        not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
+      )
+    displayName: Create/Update GitHub release
+    inputs:
+      gitHubConnection: 'github.com_nano-$(System.TeamProject)'
+      tagSource: userSpecifiedTag
+      tag: v$(NBGV_AssemblyVersion)
+      title: '.NET nanoFramework VS Extension v$(NBGV_AssemblyVersion)'
+      releaseNotesSource: inline
+      releaseNotesInline: 'Check the [changelog](https://github.com/nanoframework/nf-Visual-Studio-extension/blob/$(Build.SourceBranchName)/CHANGELOG-VS2019.md).<br><br><h4>Install from nanoFramework Open VSIX Gallery development feed</h4><br>The following Visual Studio Extensions are available for install from this release<br><br>:package: [nanoFramework VS2019 Extension](https://marketplace.visualstudio.com/items?itemName=nanoframework.nanoFramework-VS2019-Extension)'
+      assets: '$(Build.ArtifactStagingDirectory)/*.vsix'
+      assetUploadMode: replace
+      isPreRelease: true
+      addChangeLog: false
+
+  # create or update GitHub release ON tags from release or main branches
+  - task: GithubRelease@1
+    condition: >-
+      and(
+        succeeded(),
+        startsWith(variables['Build.SourceBranch'], 'refs/tags/v'),
+        contains(variables['Build.SourceBranch'], 'vs2019'),
+        or(
+          eq(variables['Build.SourceBranchName'], 'main'),
+          contains(variables['Build.SourceBranchName'], 'release')
+        )
+      )
+    displayName: Create/Update GitHub stable release
+    inputs:
+      action: edit
+      gitHubConnection: 'github.com_nano-$(System.TeamProject)'
+      tagSource: userSpecifiedTag
+      tag: v$(NBGV_AssemblyVersion)
+      title: '.NET nanoFramework Visual Studio Extension v$(NBGV_AssemblyVersion)'
+      releaseNotesSource: inline
+      releaseNotesInline: 'Check the [changelog](https://github.com/nanoframework/nf-Visual-Studio-extension/blob/$(Build.SourceBranchName)/CHANGELOG-VS2019.md).<br><br><h4>Install from nanoFramework Open VSIX Gallery development feed</h4><br>The following Visual Studio Extensions are available for install from this release<br><br>:package: [nanoFramework VS2019 Extension](http://vsixgallery.com/extension/455f2be5-bb07-451e-b351-a9faf3018dc9)'
+      assets: '$(Build.ArtifactStagingDirectory)/*.vsix'
+      assetUploadMode: replace
+      isPreRelease: false
+      addChangeLog: false
+
+######################
+- job: VS2022
+  condition: >-
+    or(
+      eq(dependencies.Get_Build_Options.outputs['BuildOptions.BUILD_VS2022'], true),
+      eq(variables['BUILD_VS2022'], 'true')
+    )
+  dependsOn:
+  - Get_Build_Options
+
+  pool:
+    vmImage: 'windows-2022'
+
+  variables:
+    solution: 'VisualStudio.Extension-2022/VisualStudio.Extension-vs2022.csproj'
+    buildConfiguration: 'Release'
+
+  steps:
+
+  # need this here in order to persist GitHub credentials AND init submodules
+  - checkout: self
+    submodules: true
+
+  - script: |
+      git config --global user.email 'nanoframework@outlook.com'
+      git config --global user.name 'nfbot'
+    displayName: Setup git identity
+
+  - template: azure-pipelines-templates/install-nuget.yml@templates
+
+  - task: NuGetCommand@2
+    inputs:
+      restoreSolution: '$(solution)'
+      feedsToUse: config
+      nugetConfigPath: NuGet.config
+      verbosityRestore: quiet
+
+  - task: VSBuild@1
+    inputs:
+      solution: '$(solution)'
+      msbuildArgs: '/p:PublicRelease=true'
+      configuration: '$(buildConfiguration)'
+
+  # we don't have tests (yet)
+  # - task: VSTest@2
+  #   inputs:
+  #     platform: '$(buildPlatform)'
+  #     configuration: '$(buildConfiguration)'
+
+  - task: PowerShell@2
+    inputs:
+        targetType: 'inline'
+        script: |
+            Write-Host "VS2022 build version $env:NBGV_AssemblyVersion"
+            
+            echo "##vso[task.setvariable variable=BUILD_VERSION;isOutput=true]$env:NBGV_AssemblyVersion"  
+
+    condition: succeeded()
+    name: VS2022_Build
+    displayName: Store VS2022 build version
+
+  - task: CopyFiles@1
+    inputs:
+      sourceFolder: $(Build.SourcesDirectory)
+      Contents: |
+        **\*VS2022.Extension.vsix
+        **\vs2022-extension-manifest.json
+        **\vs2022-marketplace-overview.md
+        **\vs2022\debug-session.png
+        **\vs2022\starting-new-project.png
+      TargetFolder: '$(Build.ArtifactStagingDirectory)\vs2022'
+      flattenFolders: true
+    condition: succeeded()
+    displayName: Collecting VS2022 deployable artifacts
+
+  - task: DotNetCoreCLI@2
+    displayName: Install SignTool tool
+    condition: and( succeeded(), eq(variables['System.PullRequest.PullRequestId'], '') )
+    inputs:
+      command: custom
+      custom: tool
+      arguments: install --tool-path . SignClient
   - pwsh: |
       .\SignClient "Sign" `
       --baseDirectory "$(Build.ArtifactStagingDirectory)\vs2022" `
@@ -225,8 +398,8 @@ jobs:
       --filelist "$(Build.Repository.LocalPath)\config\filelist.txt" `
       --user "$(SignClientUser)" `
       --secret '$(SignClientSecret)' `
-      --name ".NET nanoFramework VS2019 Extension" `
-      --description ".NET nanoFramework VS2019 Extension" `
+      --name ".NET nanoFramework VS2022 Extension" `
+      --description ".NET nanoFramework VS2022 Extension" `
       --descriptionUrl "https://github.com/$env:Build_Repository_Name"
     displayName: Sign VS2022 packages
     condition: and( succeeded(), eq(variables['System.PullRequest.PullRequestId'], '') )
@@ -246,7 +419,7 @@ jobs:
         targetType: 'inline'
         script: |
 
-          $artifactsCollection = @("./*VS2019.Extension.vsix", "./*VS2022.Extension.vsix") | %{ Get-ChildItem -File . -Filter $_ -Recurse}
+          $artifactsCollection = @("./*VS2022.Extension.vsix") | %{ Get-ChildItem -File . -Filter $_ -Recurse}
 
           (new-object Net.WebClient).DownloadString("https://raw.github.com/madskristensen/ExtensionScripts/master/AppVeyor/vsix.ps1") | iex
 
@@ -301,7 +474,7 @@ jobs:
       tag: v$(NBGV_AssemblyVersion)
       title: '.NET nanoFramework Visual Studio Extension v$(NBGV_AssemblyVersion)'
       releaseNotesSource: inline
-      releaseNotesInline: 'Check the [changelog](https://github.com/nanoframework/nf-Visual-Studio-extension/blob/$(Build.SourceBranchName)/CHANGELOG-VS2019.md).<br><br><h4>Install from nanoFramework Open VSIX Gallery development feed</h4><br>The following Visual Studio Extensions are available for install from this release<br><br>:package: [nanoFramework VS2022 Extension](https://marketplace.visualstudio.com/items?itemName=nanoframework.nanoFramework-VS2022-Extension)<br>:package: [nanoFramework VS2019 Extension](https://marketplace.visualstudio.com/items?itemName=nanoframework.nanoFramework-VS2019-Extension)'
+      releaseNotesInline: 'Check the [changelog](https://github.com/nanoframework/nf-Visual-Studio-extension/blob/$(Build.SourceBranchName)/CHANGELOG-VS2022.md).<br><br><h4>Install from nanoFramework Open VSIX Gallery development feed</h4><br>The following Visual Studio Extensions are available for install from this release<br><br>:package: [nanoFramework VS2022 Extension](https://marketplace.visualstudio.com/items?itemName=nanoframework.nanoFramework-VS2022-Extension)'
       assets: '$(Build.ArtifactStagingDirectory)/*.vsix'
       assetUploadMode: replace
       isPreRelease: true
@@ -327,7 +500,7 @@ jobs:
       tag: v$(NBGV_AssemblyVersion)
       title: '.NET nanoFramework Visual Studio Extension v$(NBGV_AssemblyVersion)'
       releaseNotesSource: inline
-      releaseNotesInline: 'Check the [changelog](https://github.com/nanoframework/nf-Visual-Studio-extension/blob/$(Build.SourceBranchName)/CHANGELOG-VS2019.md).<br><br><h4>Install from nanoFramework Open VSIX Gallery development feed</h4><br>The following Visual Studio Extensions are available for install from this release<br><br>:package: [nanoFramework VS2022 Extension](http://vsixgallery.com/extension/432ef961-ea3b-4099-ada9-b720ff3a566b)<br>:package: [nanoFramework VS2019 Extension](http://vsixgallery.com/extension/455f2be5-bb07-451e-b351-a9faf3018dc9)'
+      releaseNotesInline: 'Check the [changelog](https://github.com/nanoframework/nf-Visual-Studio-extension/blob/$(Build.SourceBranchName)/CHANGELOG-VS2022.md).<br><br><h4>Install from nanoFramework Open VSIX Gallery development feed</h4><br>The following Visual Studio Extensions are available for install from this release<br><br>:package: [nanoFramework VS2022 Extension](http://vsixgallery.com/extension/432ef961-ea3b-4099-ada9-b720ff3a566b)'
       assets: '$(Build.ArtifactStagingDirectory)/*.vsix'
       assetUploadMode: replace
       isPreRelease: false
@@ -337,19 +510,21 @@ jobs:
 - job: Generate_Changelog
   dependsOn:
   - Get_Build_Options
-  - VS2019_2022
+  - VS2019
+  - VS2022
   condition: >-
     and(
       succeeded('Get_Build_Options'),
-      succeeded('VS2019_2022'),
+      succeeded('VS2019'),
+      succeeded('VS2022'),
       eq(variables['System.PullRequest.PullRequestId'], '')
     )
 
   variables:
-    myBuildVS2019: $[ dependencies.Get_Build_Options.outputs['BuildOptions.BUILD_VS2019_2022'] ]
+    myBuildVS2019: $[ dependencies.Get_Build_Options.outputs['BuildOptions.BUILD_VS2019'] ]
     MY_VS2019_VERSION: $[ dependencies.VS2019_2022.outputs['VS2019Build.BUILD_VERSION'] ]
-    myBuildVS2022: $[ dependencies.Get_Build_Options.outputs['BuildOptions.BUILD_VS2019_2022'] ]
-    MY_VS2022_VERSION: $[ dependencies.VS2019_2022.outputs['VS2019Build.BUILD_VERSION'] ]
+    myBuildVS2022: $[ dependencies.Get_Build_Options.outputs['BuildOptions.BUILD_VS2022'] ]
+    MY_VS2022_VERSION: $[ dependencies.VS2019_2022.outputs['VS2022Build.BUILD_VERSION'] ]
 
   pool:
     vmImage: 'windows-latest'
@@ -395,7 +570,7 @@ jobs:
         ),
         or(
           eq(variables['myBuildVS2019'], true),
-          eq(variables['BUILD_VS2019_2022'], 'true')
+          eq(variables['BUILD_VS2019'], 'true')
         )
       )
     displayName: Generate VS2019 change log
@@ -415,7 +590,7 @@ jobs:
         ),
         or(
           eq(variables['myBuildVS2022'], true),
-          eq(variables['BUILD_VS2019_2022'], 'true')
+          eq(variables['BUILD_VS2022'], 'true')
         )
       )
     displayName: Generate VS2022 change log
@@ -437,7 +612,7 @@ jobs:
         ),
         or(
           eq(variables['myBuildVS2019'], true),
-          eq(variables['BUILD_VS2019_2022'], 'true')
+          eq(variables['BUILD_VS2019'], 'true')
         )
       )
     displayName: Generate VS2019 change log
@@ -459,12 +634,12 @@ jobs:
         ),
         or(
           eq(variables['myBuildVS2022'], true),
-          eq(variables['BUILD_VS2019_2022'], 'true')
+          eq(variables['BUILD_VS2022'], 'true')
         )
       )
     displayName: Generate VS2022 change log
 
-  # copy VS2019 change log to artifacts directory
+  # copy change logs to artifacts directory
   - task: CopyFiles@2
     inputs:
       SourceFolder: '$(System.DefaultWorkingDirectory)'
@@ -472,17 +647,8 @@ jobs:
         'CHANGELOG-VS2019.md'
         'CHANGELOG-VS2022.md'
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
-    condition: >-
-      and(
-        succeeded(),
-        eq(variables['System.PullRequest.PullRequestId'], ''),
-        not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')),
-        or(
-          eq(variables['myBuildVS2019'], true),
-          eq(variables['BUILD_VS2019_2022'], 'true')
-        )
-      )
-    displayName: Copy Changelog
+    condition: succeeded()
+    displayName: Copy Changelogs
 
   - task: CopyFiles@1
     inputs:
@@ -492,14 +658,7 @@ jobs:
         **\CHANGELOG-VS2022.md
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
       flattenFolders: true
-    condition: >-
-      and(
-        succeeded(),
-        or(
-          eq(variables['myBuildVS2019'], true),
-          eq(variables['BUILD_VS2019_2022'], 'true')
-        )
-      )
+    condition: succeeded()
     displayName: Collecting deployable artifacts
 
   # publish artifacts (only possible if this is not a PR originated on a fork)
@@ -526,7 +685,7 @@ jobs:
         not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')),
         or(
           eq(variables['myBuildVS2019'], true),
-          eq(variables['BUILD_VS2019_2022'], 'true')
+          eq(variables['BUILD_VS2019'], 'true')
         )
       )
     displayName: Commit VS2019 changelog
@@ -546,7 +705,7 @@ jobs:
         not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')),
         or(
           eq(variables['myBuildVS2022'], true),
-          eq(variables['BUILD_VS2019_2022'], 'true')
+          eq(variables['BUILD_VS2022'], 'true')
         )
       )
     displayName: Commit VS2022 changelog


### PR DESCRIPTION
## Description
- Improve pipeline to build VS2019 and VS2022 in separate jobs.

## Motivation and Context
- Need to be able to build one or the other version.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
