### PR TITLE
Fix start-up issue with Device Explorer Tool Window

### DIFF
--- a/VisualStudio.Extension-2019/NanoFrameworkPackage.vsct
+++ b/VisualStudio.Extension-2019/NanoFrameworkPackage.vsct
@@ -1,36 +1,36 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CommandTable xmlns="http://schemas.microsoft.com/VisualStudio/2005-10-18/CommandTable" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
-  <!--  This is the file that defines the actual layout and type of the commands.
+	<!--  This is the file that defines the actual layout and type of the commands.
         It is divided in different sections (e.g. command definition, command
         placement, ...), with each defining a specific set of properties.
         See the comment before each section for more details about how to
         use it. -->
 
-  <!--  The VSCT compiler (the tool that translates this file into the binary 
+	<!--  The VSCT compiler (the tool that translates this file into the binary 
         format that VisualStudio will consume) has the ability to run a preprocessor 
         on the vsct file; this preprocessor is (usually) the C++ preprocessor, so 
         it is possible to define includes and macros with the same syntax used 
         in C++ files. Using this ability of the compiler here, we include some files 
         defining some of the constants that we will use inside the file. -->
 
-  <!--This is the file that defines the IDs for all the commands exposed by VisualStudio. -->
-  <Extern href="stdidcmd.h"/>
+	<!--This is the file that defines the IDs for all the commands exposed by VisualStudio. -->
+	<Extern href="stdidcmd.h"/>
 
-  <!--This header contains the command ids for the menus provided by the shell. -->
-  <Extern href="vsshlids.h"/>
+	<!--This header contains the command ids for the menus provided by the shell. -->
+	<Extern href="vsshlids.h"/>
 
-  <!--This header contains the image monikers for various images-->
-  <Include href="KnownImageIds.vsct"/>
+	<!--This header contains the image monikers for various images-->
+	<Include href="KnownImageIds.vsct"/>
 
-  <!--This header contains data for the nanoFramework image moniker-->
-  <Include href="NanoFrameworkMoniker.vsct"/>
+	<!--This header contains data for the nanoFramework image moniker-->
+	<Include href="NanoFrameworkMoniker.vsct"/>
 
 
-  <!--The Commands section is where we the commands, menus and menu groups are defined.
+	<!--The Commands section is where we the commands, menus and menu groups are defined.
       This section uses a Guid to identify the package that provides the command defined inside it. -->
-  <Commands package="guidNanoFrameworkPackage">
-    <!-- Inside this section we have different sub-sections: one for the menus, another  
+	<Commands package="guidNanoFrameworkPackage">
+		<!-- Inside this section we have different sub-sections: one for the menus, another  
     for the menu groups, one for the buttons (the actual commands), one for the combos 
     and the last one for the bitmaps used. Each element is identified by a command id that  
     is a unique pair of guid and numeric identifier; the guid part of the identifier is usually  
@@ -38,263 +38,263 @@
     group; your package should define its own command set in order to avoid collisions  
     with command ids defined by other packages. -->
 
-    <Menus>
-      <!-- this is the menu for Device Explorer Window -->
-      <Menu guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarID" priority="0x0000" type="ToolWindowToolbar">
-        <Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarID" />
-        <Strings>
-          <ButtonText>Tool Window Toolbar</ButtonText>
-          <CommandName>Tool Window Toolbar</CommandName>
-        </Strings>
-      </Menu>
+		<Menus>
+			<!-- this is the menu for Device Explorer Window -->
+			<Menu guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarID" priority="0x0000" type="ToolWindowToolbar">
+				<Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarID" />
+				<Strings>
+					<ButtonText>Tool Window Toolbar</ButtonText>
+					<CommandName>Tool Window Toolbar</CommandName>
+				</Strings>
+			</Menu>
 
-      <!-- this is the menu controller for the reboot command menu -->
-      <Menu guid="guidDeviceExplorerCmdSet" id="RebootMenuControllerID" type="MenuController" priority="0x0101" toolbarPriorityInBand="0x0001">
-        <Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroupID" />
-        <CommandFlag>NotInTBList</CommandFlag>
-        <Strings>
-          <ButtonText></ButtonText>
-          <CommandName>RebootMenuController</CommandName>
-        </Strings>
-      </Menu>
-      
-    </Menus>
+			<!-- this is the menu controller for the reboot command menu -->
+			<Menu guid="guidDeviceExplorerCmdSet" id="RebootMenuControllerID" type="MenuController" priority="0x0101" toolbarPriorityInBand="0x0001">
+				<Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroupID" />
+				<CommandFlag>NotInTBList</CommandFlag>
+				<Strings>
+					<ButtonText></ButtonText>
+					<CommandName>RebootMenuController</CommandName>
+				</Strings>
+			</Menu>
 
-    <Groups>
-      <!-- this is the 1st group for the Device Explorer Toolbar -->
-      <Group guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroupID" priority="0x0000">
-        <Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarID" />
-      </Group>
+		</Menus>
 
-      <!-- this is the 2nd group for the Device Explorer Toolbar -->
-      <Group guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroup2ID" priority="0x0001">
-        <Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarID" />
-      </Group>
+		<Groups>
+			<!-- this is the 1st group for the Device Explorer Toolbar -->
+			<Group guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroupID" priority="0x0000">
+				<Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarID" />
+			</Group>
 
-      <!-- this is the 3rd group for the Device Explorer Toolbar -->
-      <Group guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroup3ID" priority="0x0002">
-        <Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarID" />
-      </Group>
+			<!-- this is the 2nd group for the Device Explorer Toolbar -->
+			<Group guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroup2ID" priority="0x0001">
+				<Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarID" />
+			</Group>
 
-      <!-- this is the menu group for the reboot command button -->
-      <Group guid="guidDeviceExplorerCmdSet" id="RebootMenuGroupID" priority="0x0000">
-        <Parent guid="guidDeviceExplorerCmdSet" id="RebootMenuControllerID" />
-      </Group>
+			<!-- this is the 3rd group for the Device Explorer Toolbar -->
+			<Group guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroup3ID" priority="0x0002">
+				<Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarID" />
+			</Group>
 
-    </Groups>
+			<!-- this is the menu group for the reboot command button -->
+			<Group guid="guidDeviceExplorerCmdSet" id="RebootMenuGroupID" priority="0x0000">
+				<Parent guid="guidDeviceExplorerCmdSet" id="RebootMenuControllerID" />
+			</Group>
 
-    <!--Buttons section. -->
-    <!--This section defines the elements the user can interact with, like a menu command or a button 
+		</Groups>
+
+		<!--Buttons section. -->
+		<!--This section defines the elements the user can interact with, like a menu command or a button 
         or combo box in a toolbar. -->
-    <Buttons>
+		<Buttons>
 
-      <!-- commands for command line-->
-      <Button guid="guidNanoDebugPackageCmdSet" id="cmdidLaunchNanoDebug" priority="0x0100" type="Button">
-        <CommandFlag>AllowParams</CommandFlag>
-        <Strings>
-          <ButtonText>NanoDebug Launch</ButtonText>
-          <!--NOTE: 'Debug.' (or some other prefix) is required - the command window doesn't like commands which aren't prefixed.'-->
-          <CanonicalName>Debug.NanoDebugLaunch</CanonicalName>
-          <LocCanonicalName>Debug.NanoDebugLaunch</LocCanonicalName>
-        </Strings>
-      </Button>
+			<!-- commands for command line-->
+			<Button guid="guidNanoDebugPackageCmdSet" id="cmdidLaunchNanoDebug" priority="0x0100" type="Button">
+				<CommandFlag>AllowParams</CommandFlag>
+				<Strings>
+					<ButtonText>NanoDebug Launch</ButtonText>
+					<!--NOTE: 'Debug.' (or some other prefix) is required - the command window doesn't like commands which aren't prefixed.'-->
+					<CanonicalName>Debug.NanoDebugLaunch</CanonicalName>
+					<LocCanonicalName>Debug.NanoDebugLaunch</LocCanonicalName>
+				</Strings>
+			</Button>
 
-      <!--To define a menu group you have to specify its ID, the parent menu and its display priority.
+			<!--To define a menu group you have to specify its ID, the parent menu and its display priority.
           The command is visible and enabled by default. If you need to change the visibility, status, etc, you can use
           the CommandFlag node.
           You can add more than one CommandFlag node e.g.:
               <CommandFlag>DefaultInvisible</CommandFlag>
               <CommandFlag>DynamicVisibility</CommandFlag>
           If you do not want an image next to your command, remove the Icon node /> -->
-      <Button guid="guidNanoFrameworkPackageCmdSet" id="DeviceExplorerCommandId" priority="0x0100" type="Button">
-        <Parent guid="guidSHLMainMenu" id="IDG_VS_WNDO_OTRWNDWS1"/>
-        <Icon guid="NanoFrameworkCatalog" id="NanoFramework" />
-        <CommandFlag>IconIsMoniker</CommandFlag>
-        <Strings>
-          <ButtonText>Device Explorer</ButtonText>
-        </Strings>
-      </Button>
+			<Button guid="guidNanoFrameworkPackageCmdSet" id="DeviceExplorerCommandId" priority="0x0100" type="Button">
+				<Parent guid="guidSHLMainMenu" id="IDG_VS_WNDO_OTRWNDWS1"/>
+				<Icon guid="NanoFrameworkCatalog" id="NanoFramework" />
+				<CommandFlag>IconIsMoniker</CommandFlag>
+				<Strings>
+					<ButtonText>Device Explorer</ButtonText>
+				</Strings>
+			</Button>
 
-      <!-- Ping for Device Explorer toolbar -->
-      <Button guid="guidDeviceExplorerCmdSet" id="idPingDeviceCommand" priority="0x0101" type="Button">
-        <Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroupID"/>
-        <Icon guid="NanoFrameworkCatalog" id="Ping" />
-        <CommandFlag>IconIsMoniker</CommandFlag>
-        <CommandFlag>DefaultDisabled</CommandFlag>
-        <Strings>
-          <CommandName>PingDeviceCommand</CommandName>
-          <ButtonText>Ping Device</ButtonText>
-        </Strings>
-      </Button>
+			<!-- Ping for Device Explorer toolbar -->
+			<Button guid="guidDeviceExplorerCmdSet" id="idPingDeviceCommand" priority="0x0101" type="Button">
+				<Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroupID"/>
+				<Icon guid="NanoFrameworkCatalog" id="Ping" />
+				<CommandFlag>IconIsMoniker</CommandFlag>
+				<CommandFlag>DefaultDisabled</CommandFlag>
+				<Strings>
+					<CommandName>PingDeviceCommand</CommandName>
+					<ButtonText>Ping Device</ButtonText>
+				</Strings>
+			</Button>
 
-      <!-- DeviceCapabilities for Device Explorer toolbar -->
-      <Button guid="guidDeviceExplorerCmdSet" id="idDeviceCapabilitiesCommand" priority="0x0101" type="Button">
-        <Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroupID"/>
-        <Icon guid="NanoFrameworkCatalog" id="DeviceCapabilities" />
-        <CommandFlag>IconIsMoniker</CommandFlag>
-        <CommandFlag>DefaultDisabled</CommandFlag>
-        <Strings>
-          <CommandName>DeviceCapabilitiesCommand</CommandName>
-          <ButtonText>Device Capabilities</ButtonText>
-        </Strings>
-      </Button>
+			<!-- DeviceCapabilities for Device Explorer toolbar -->
+			<Button guid="guidDeviceExplorerCmdSet" id="idDeviceCapabilitiesCommand" priority="0x0101" type="Button">
+				<Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroupID"/>
+				<Icon guid="NanoFrameworkCatalog" id="DeviceCapabilities" />
+				<CommandFlag>IconIsMoniker</CommandFlag>
+				<CommandFlag>DefaultDisabled</CommandFlag>
+				<Strings>
+					<CommandName>DeviceCapabilitiesCommand</CommandName>
+					<ButtonText>Device Capabilities</ButtonText>
+				</Strings>
+			</Button>
 
-      <!-- DeviceErase for Device Explorer toolbar -->
-      <Button guid="guidDeviceExplorerCmdSet" id="idDeviceEraseCommand" priority="0x0101" type="Button">
-        <Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroupID"/>
-        <Icon guid="NanoFrameworkCatalog" id="DeviceErase" />
-        <CommandFlag>IconIsMoniker</CommandFlag>
-        <CommandFlag>DefaultDisabled</CommandFlag>
-        <Strings>
-          <CommandName>DeviceEraseCommand</CommandName>
-          <ButtonText>Erase Device Deployment Area</ButtonText>
-        </Strings>
-      </Button>
+			<!-- DeviceErase for Device Explorer toolbar -->
+			<Button guid="guidDeviceExplorerCmdSet" id="idDeviceEraseCommand" priority="0x0101" type="Button">
+				<Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroupID"/>
+				<Icon guid="NanoFrameworkCatalog" id="DeviceErase" />
+				<CommandFlag>IconIsMoniker</CommandFlag>
+				<CommandFlag>DefaultDisabled</CommandFlag>
+				<Strings>
+					<CommandName>DeviceEraseCommand</CommandName>
+					<ButtonText>Erase Device Deployment Area</ButtonText>
+				</Strings>
+			</Button>
 
-      <!-- Reboot for Device Explorer toolbar -->
-      <Button guid="guidDeviceExplorerCmdSet" id="idRebootCommand" priority="0x0101" type="Button">
-        <Parent guid="guidDeviceExplorerCmdSet" id="RebootMenuGroupID"/>
-        <Icon guid="NanoFrameworkCatalog" id="Reboot" />
-        <CommandFlag>IconIsMoniker</CommandFlag>
-        <CommandFlag>DefaultDisabled</CommandFlag>
-        <CommandFlag>NoShowOnMenuController</CommandFlag>
-        <CommandFlag>FixMenuController</CommandFlag>
-        <Strings>
-          <CommandName>RebootCommand</CommandName>
-          <ButtonText>Reboot target device</ButtonText>
-        </Strings>
-      </Button>
+			<!-- Reboot for Device Explorer toolbar -->
+			<Button guid="guidDeviceExplorerCmdSet" id="idRebootCommand" priority="0x0101" type="Button">
+				<Parent guid="guidDeviceExplorerCmdSet" id="RebootMenuGroupID"/>
+				<Icon guid="NanoFrameworkCatalog" id="Reboot" />
+				<CommandFlag>IconIsMoniker</CommandFlag>
+				<CommandFlag>DefaultDisabled</CommandFlag>
+				<CommandFlag>NoShowOnMenuController</CommandFlag>
+				<CommandFlag>FixMenuController</CommandFlag>
+				<Strings>
+					<CommandName>RebootCommand</CommandName>
+					<ButtonText>Reboot target device</ButtonText>
+				</Strings>
+			</Button>
 
-      <Button guid="guidDeviceExplorerCmdSet" id="idRebootClrCommand" priority="0x0101" type="Button">
-        <Parent guid="guidDeviceExplorerCmdSet" id="RebootMenuGroupID"/>
-        <CommandFlag>TextOnly</CommandFlag>
-        <Strings>
-          <CommandName>RebootClrCommand</CommandName>
-          <ButtonText>Reboot CLR</ButtonText>
-        </Strings>
-      </Button>
-      
-      <Button guid="guidDeviceExplorerCmdSet" id="idRebootNanoBooterCommand" priority="0x0101" type="Button">
-        <Parent guid="guidDeviceExplorerCmdSet" id="RebootMenuGroupID"/>
-        <CommandFlag>TextOnly</CommandFlag>
-        <CommandFlag>DynamicVisibility</CommandFlag>
-        <Strings>
-          <CommandName>RebootNanoBooterCommand</CommandName>
-          <ButtonText>Reboot to nanoBooter</ButtonText>
-        </Strings>
-      </Button>
-      
-      <Button guid="guidDeviceExplorerCmdSet" id="idRebootBootloaderCommand" priority="0x0101" type="Button">
-        <Parent guid="guidDeviceExplorerCmdSet" id="RebootMenuGroupID"/>
-        <CommandFlag>TextOnly</CommandFlag>
-        <CommandFlag>TextChanges</CommandFlag>
-        <CommandFlag>DynamicVisibility</CommandFlag>
-        <Strings>
-          <CommandName>RebootToBootloaderCommand</CommandName>
-          <ButtonText>Reboot to bootloader</ButtonText>
-        </Strings>
-      </Button>
-      
-      <!-- NetworkConfig for Device Explorer toolbar -->
-      <Button guid="guidDeviceExplorerCmdSet" id="idNetworkConfigCommand" priority="0x0101" type="Button">
-        <Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroupID"/>
-        <Icon guid="NanoFrameworkCatalog" id="NetworkConfig" />
-        <CommandFlag>IconIsMoniker</CommandFlag>
-        <CommandFlag>DefaultDisabled</CommandFlag>
-        <Strings>
-          <CommandName>NetworkConfigCommand</CommandName>
-          <ButtonText>Edit Network Configuration</ButtonText>
-        </Strings>
-      </Button>
+			<Button guid="guidDeviceExplorerCmdSet" id="idRebootClrCommand" priority="0x0101" type="Button">
+				<Parent guid="guidDeviceExplorerCmdSet" id="RebootMenuGroupID"/>
+				<CommandFlag>TextOnly</CommandFlag>
+				<Strings>
+					<CommandName>RebootClrCommand</CommandName>
+					<ButtonText>Reboot CLR</ButtonText>
+				</Strings>
+			</Button>
 
-      <!-- buttons for the 2nd menu -->
+			<Button guid="guidDeviceExplorerCmdSet" id="idRebootNanoBooterCommand" priority="0x0101" type="Button">
+				<Parent guid="guidDeviceExplorerCmdSet" id="RebootMenuGroupID"/>
+				<CommandFlag>TextOnly</CommandFlag>
+				<CommandFlag>DynamicVisibility</CommandFlag>
+				<Strings>
+					<CommandName>RebootNanoBooterCommand</CommandName>
+					<ButtonText>Reboot to nanoBooter</ButtonText>
+				</Strings>
+			</Button>
 
-      <!-- Disable device watchers -->
-      <Button guid="guidDeviceExplorerCmdSet" id="idDisableDeviceWatchersCommand" priority="0x0101" type="Button">
-        <Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroup2ID"/>
-        <Icon guid="NanoFrameworkCatalog" id="DisableDeviceWatchers" />
-        <CommandFlag>IconIsMoniker</CommandFlag>
-        <Strings>
-          <CommandName>DisableDeviceWatchersCommand</CommandName>
-          <ButtonText>Disable Device Watchers</ButtonText>
-        </Strings>
-      </Button>
+			<Button guid="guidDeviceExplorerCmdSet" id="idRebootBootloaderCommand" priority="0x0101" type="Button">
+				<Parent guid="guidDeviceExplorerCmdSet" id="RebootMenuGroupID"/>
+				<CommandFlag>TextOnly</CommandFlag>
+				<CommandFlag>TextChanges</CommandFlag>
+				<CommandFlag>DynamicVisibility</CommandFlag>
+				<Strings>
+					<CommandName>RebootToBootloaderCommand</CommandName>
+					<ButtonText>Reboot to bootloader</ButtonText>
+				</Strings>
+			</Button>
 
-      <!-- Rescan devices -->
-      <Button guid="guidDeviceExplorerCmdSet" id="idRescanDevicesCommand" priority="0x0101" type="Button">
-        <Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroup2ID"/>
-        <Icon guid="NanoFrameworkCatalog" id="RescanDevices" />
-        <CommandFlag>IconIsMoniker</CommandFlag>
-        <Strings>
-          <CommandName>RescanDevicesCommand</CommandName>
-          <ButtonText>Rescan nanoDevices</ButtonText>
-        </Strings>
-      </Button>
+			<!-- NetworkConfig for Device Explorer toolbar -->
+			<Button guid="guidDeviceExplorerCmdSet" id="idNetworkConfigCommand" priority="0x0101" type="Button">
+				<Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroupID"/>
+				<Icon guid="NanoFrameworkCatalog" id="NetworkConfig" />
+				<CommandFlag>IconIsMoniker</CommandFlag>
+				<CommandFlag>DefaultDisabled</CommandFlag>
+				<Strings>
+					<CommandName>NetworkConfigCommand</CommandName>
+					<ButtonText>Edit Network Configuration</ButtonText>
+				</Strings>
+			</Button>
 
-      <!-- buttons for the 3rd menu -->
+			<!-- buttons for the 2nd menu -->
 
-      <!-- Show internal errors for nF extension -->
-      <Button guid="guidDeviceExplorerCmdSet" id="idShowInternalErrorsCommand" priority="0x0101" type="Button">
-        <Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroup3ID"/>
-        <Icon guid="NanoFrameworkCatalog" id="ShowInternalErrors" />
-        <CommandFlag>IconIsMoniker</CommandFlag>
-        <Strings>
-          <CommandName>ShowInternalErrorsCommand</CommandName>
-          <ButtonText>Show Internal Errors</ButtonText>
-        </Strings>
-      </Button>
+			<!-- Disable device watchers -->
+			<Button guid="guidDeviceExplorerCmdSet" id="idDisableDeviceWatchersCommand" priority="0x0101" type="Button">
+				<Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroup2ID"/>
+				<Icon guid="NanoFrameworkCatalog" id="DisableDeviceWatchers" />
+				<CommandFlag>IconIsMoniker</CommandFlag>
+				<Strings>
+					<CommandName>DisableDeviceWatchersCommand</CommandName>
+					<ButtonText>Disable Device Watchers</ButtonText>
+				</Strings>
+			</Button>
 
-      <!-- show settings for Device Explorer toolbar -->
-      <Button guid="guidDeviceExplorerCmdSet" id="idShowSettingsCommand" priority="0x0101" type="Button">
-        <Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroup3ID"/>
-        <Icon guid="NanoFrameworkCatalog" id="SettingsID" />
-        <CommandFlag>IconIsMoniker</CommandFlag>
-        <Strings>
-          <CommandName>ShowSettingsCommand</CommandName>
-          <ButtonText>Show Settings</ButtonText>
-        </Strings>
-      </Button>
+			<!-- Rescan devices -->
+			<Button guid="guidDeviceExplorerCmdSet" id="idRescanDevicesCommand" priority="0x0101" type="Button">
+				<Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroup2ID"/>
+				<Icon guid="NanoFrameworkCatalog" id="RescanDevices" />
+				<CommandFlag>IconIsMoniker</CommandFlag>
+				<Strings>
+					<CommandName>RescanDevicesCommand</CommandName>
+					<ButtonText>Rescan nanoDevices</ButtonText>
+				</Strings>
+			</Button>
 
-    </Buttons>
-  </Commands>
+			<!-- buttons for the 3rd menu -->
 
-  <Symbols>
-    <!-- This is the package guid. -->
-    <GuidSymbol name="guidNanoFrameworkPackage" value="{046B40EB-1DE1-4D08-AF61-FDB7592B9BBD}" />
+			<!-- Show internal errors for nF extension -->
+			<Button guid="guidDeviceExplorerCmdSet" id="idShowInternalErrorsCommand" priority="0x0101" type="Button">
+				<Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroup3ID"/>
+				<Icon guid="NanoFrameworkCatalog" id="ShowInternalErrors" />
+				<CommandFlag>IconIsMoniker</CommandFlag>
+				<Strings>
+					<CommandName>ShowInternalErrorsCommand</CommandName>
+					<ButtonText>Show Internal Errors</ButtonText>
+				</Strings>
+			</Button>
 
-    <!-- This is the guid used to group the commands together -->
-    <GuidSymbol name="guidNanoDebugPackageCmdSet" value="{6A0F19B1-00EF-4215-BD7B-29DEB4425F7C}">
-      <IDSymbol name="MyMenuGroup" value="0x1020" />
-      <IDSymbol name="cmdidLaunchNanoDebug" value="0x0300" />
-    </GuidSymbol>
+			<!-- show settings for Device Explorer toolbar -->
+			<Button guid="guidDeviceExplorerCmdSet" id="idShowSettingsCommand" priority="0x0101" type="Button">
+				<Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroup3ID"/>
+				<Icon guid="NanoFrameworkCatalog" id="SettingsID" />
+				<CommandFlag>IconIsMoniker</CommandFlag>
+				<Strings>
+					<CommandName>ShowSettingsCommand</CommandName>
+					<ButtonText>Show Settings</ButtonText>
+				</Strings>
+			</Button>
 
-    <!-- This is the guid used to group the menu commands together -->
-    <GuidSymbol name="guidNanoFrameworkPackageCmdSet" value="{c975c4ec-f229-45dd-b681-e42815641675}">
-      <IDSymbol name="DeviceExplorerCommandId" value="0x0100" />
-    </GuidSymbol>
+		</Buttons>
+	</Commands>
 
-    <!-- This is the guid used to group the Device Explorer Toolwindow menu commands together -->
-    <GuidSymbol name="guidDeviceExplorerCmdSet" value="{DF641D51-1E8C-48E4-B549-CC6BCA9BDE19}">
-      <IDSymbol name="DeviceExplorerToolbarID" value="0x1000" />
-      <IDSymbol name="DeviceExplorerToolbarGroupID" value="0x1001" />
-      <IDSymbol name="DeviceExplorerToolbarGroup2ID" value="0x1002" />
-      <IDSymbol name="DeviceExplorerToolbarGroup3ID" value="0x1003" />
-      <IDSymbol name="RebootMenuGroupID" value="0x1004" />
-      <IDSymbol name="RebootMenuControllerID" value="0x1005" />
-      <IDSymbol name="idPingDeviceCommand" value="0x0210" />
-      <IDSymbol name="idDeviceCapabilitiesCommand" value="0x0220" />
-      <IDSymbol name="idDeviceEraseCommand" value="0x0230" />
-      <IDSymbol name="idRebootCommand" value="0x0240" />
-      <IDSymbol name="idRebootClrCommand" value="0x0242" />
-      <IDSymbol name="idRebootNanoBooterCommand" value="0x0244" />
-      <IDSymbol name="idRebootBootloaderCommand" value="0x0246" />
-      <IDSymbol name="idNetworkConfigCommand" value="0x0250" />
-      <IDSymbol name="idDisableDeviceWatchersCommand" value="0x0400" />
-      <IDSymbol name="idRescanDevicesCommand" value="0x0410" />
-      <IDSymbol name="idShowInternalErrorsCommand" value="0x0300" />
-      <IDSymbol name="idShowSettingsCommand" value="0x0420" />
-    </GuidSymbol>
+	<Symbols>
+		<!-- This is the package guid. -->
+		<GuidSymbol name="guidNanoFrameworkPackage" value="{046B40EB-1DE1-4D08-AF61-FDB7592B9BBD}" />
 
-  </Symbols>
+		<!-- This is the guid used to group the commands together -->
+		<GuidSymbol name="guidNanoDebugPackageCmdSet" value="{6A0F19B1-00EF-4215-BD7B-29DEB4425F7C}">
+			<IDSymbol name="MyMenuGroup" value="0x1020" />
+			<IDSymbol name="cmdidLaunchNanoDebug" value="0x0300" />
+		</GuidSymbol>
+
+		<!-- This is the guid used to group the menu commands together -->
+		<GuidSymbol name="guidNanoFrameworkPackageCmdSet" value="{c975c4ec-f229-45dd-b681-e42815641675}">
+			<IDSymbol name="DeviceExplorerCommandId" value="0x0100" />
+		</GuidSymbol>
+
+		<!-- This is the guid used to group the Device Explorer Toolwindow menu commands together -->
+		<GuidSymbol name="guidDeviceExplorerCmdSet" value="{DF641D51-1E8C-48E4-B549-CC6BCA9BDE19}">
+			<IDSymbol name="DeviceExplorerToolbarID" value="0x1000" />
+			<IDSymbol name="DeviceExplorerToolbarGroupID" value="0x1001" />
+			<IDSymbol name="DeviceExplorerToolbarGroup2ID" value="0x1002" />
+			<IDSymbol name="DeviceExplorerToolbarGroup3ID" value="0x1003" />
+			<IDSymbol name="RebootMenuGroupID" value="0x1004" />
+			<IDSymbol name="RebootMenuControllerID" value="0x1005" />
+			<IDSymbol name="idPingDeviceCommand" value="0x0210" />
+			<IDSymbol name="idDeviceCapabilitiesCommand" value="0x0220" />
+			<IDSymbol name="idDeviceEraseCommand" value="0x0230" />
+			<IDSymbol name="idRebootCommand" value="0x0240" />
+			<IDSymbol name="idRebootClrCommand" value="0x0242" />
+			<IDSymbol name="idRebootNanoBooterCommand" value="0x0244" />
+			<IDSymbol name="idRebootBootloaderCommand" value="0x0246" />
+			<IDSymbol name="idNetworkConfigCommand" value="0x0250" />
+			<IDSymbol name="idDisableDeviceWatchersCommand" value="0x0400" />
+			<IDSymbol name="idRescanDevicesCommand" value="0x0410" />
+			<IDSymbol name="idShowInternalErrorsCommand" value="0x0300" />
+			<IDSymbol name="idShowSettingsCommand" value="0x0420" />
+		</GuidSymbol>
+
+	</Symbols>
 
 </CommandTable>

--- a/VisualStudio.Extension-2019/VisualStudio.Extension-vs2019.csproj
+++ b/VisualStudio.Extension-2019/VisualStudio.Extension-vs2019.csproj
@@ -471,9 +471,6 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="EnvDTE80">
-      <Version>16.9.31023.347</Version>
-    </PackageReference>
     <PackageReference Include="Extended.Wpf.Toolkit">
       <Version>4.0.2</Version>
     </PackageReference>

--- a/VisualStudio.Extension-2019/app.config
+++ b/VisualStudio.Extension-2019/app.config
@@ -8,11 +8,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.VisualStudio.Validation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-15.3.0.0" newVersion="15.3.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-15.3.0.0" newVersion="16.9.32.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.VisualStudio.Threading" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-16.4.0.0" newVersion="16.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-16.4.0.0" newVersion="16.10.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
@@ -28,7 +28,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks.Dataflow" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.6.5.0" newVersion="4.6.5.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.6.5.0" newVersion="5.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.InteropServices.RuntimeInformation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -36,7 +36,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Composition.AttributedModel" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.0.35.0" newVersion="1.0.35.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.0.35.0" newVersion="5.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -44,11 +44,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Composition.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.0.35.0" newVersion="1.0.35.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.0.35.0" newVersion="5.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="StreamJsonRpc" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.7.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.VisualStudio.Shell.Framework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -56,7 +56,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.VisualStudio.Composition" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-16.4.0.0" newVersion="16.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-16.4.0.0" newVersion="16.9.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.VisualStudio.Shell.15.0" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -92,7 +92,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="5.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.IO.Pipelines" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/VisualStudio.Extension-2019/packages.lock.json
+++ b/VisualStudio.Extension-2019/packages.lock.json
@@ -2,16 +2,6 @@
   "version": 1,
   "dependencies": {
     ".NETFramework,Version=v4.7.2": {
-      "EnvDTE80": {
-        "type": "Direct",
-        "requested": "[16.9.31023.347, )",
-        "resolved": "16.9.31023.347",
-        "contentHash": "hVP+82Z42DlxSdIK9CWYFpfIru7RRp1hfUnRTdGEBYTPc8dARIs7oaR5DIMCxj2XZ1ko7vZCwZmoc3sBrziQ+w==",
-        "dependencies": {
-          "EnvDTE": "16.9.31023.347",
-          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.34"
-        }
-      },
       "Extended.Wpf.Toolkit": {
         "type": "Direct",
         "requested": "[4.0.2, )",
@@ -583,6 +573,15 @@
         "contentHash": "EmBssxuTgoTm0svUDfS1uQvH0azDxotoRdgBuvw9/s/terTD8O/Wxcmmn8PBFkWiA9hjvfgcXKCkro/TiVs8gg==",
         "dependencies": {
           "EnvDTE90a": "16.10.31320.204",
+          "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.34"
+        }
+      },
+      "EnvDTE80": {
+        "type": "Transitive",
+        "resolved": "16.10.31320.204",
+        "contentHash": "co2tF7mfkpi2le77Bte5rI56oojl/8GPNcqbIbUJdBcEux6yex8K29gA/1GqVbbkM07QQX7lr6vo5Z/f/ATojg==",
+        "dependencies": {
+          "EnvDTE": "16.10.31320.204",
           "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "15.0.34"
         }
       },
@@ -2381,7 +2380,7 @@
       "csharp.testapplication-vs2019": {
         "type": "Project"
       },
-      "tools.buildtasks": {
+      "nanoFramework.Tools.BuildTasks": {
         "type": "Project",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "4.7.0"

--- a/VisualStudio.Extension-2019/version.json
+++ b/VisualStudio.Extension-2019/version.json
@@ -16,7 +16,7 @@
     "^refs/tags/$"
   ],
   "cloudBuild": {
-    "setVersionVariables": true,
-    "setAllVariables": true
+    "setVersionVariables": false,
+    "setAllVariables": false
   }
 }

--- a/VisualStudio.Extension-2022/NanoFrameworkPackage.vsct
+++ b/VisualStudio.Extension-2022/NanoFrameworkPackage.vsct
@@ -1,36 +1,36 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CommandTable xmlns="http://schemas.microsoft.com/VisualStudio/2005-10-18/CommandTable" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
-  <!--  This is the file that defines the actual layout and type of the commands.
+	<!--  This is the file that defines the actual layout and type of the commands.
         It is divided in different sections (e.g. command definition, command
         placement, ...), with each defining a specific set of properties.
         See the comment before each section for more details about how to
         use it. -->
 
-  <!--  The VSCT compiler (the tool that translates this file into the binary 
+	<!--  The VSCT compiler (the tool that translates this file into the binary 
         format that VisualStudio will consume) has the ability to run a preprocessor 
         on the vsct file; this preprocessor is (usually) the C++ preprocessor, so 
         it is possible to define includes and macros with the same syntax used 
         in C++ files. Using this ability of the compiler here, we include some files 
         defining some of the constants that we will use inside the file. -->
 
-  <!--This is the file that defines the IDs for all the commands exposed by VisualStudio. -->
-  <Extern href="stdidcmd.h"/>
+	<!--This is the file that defines the IDs for all the commands exposed by VisualStudio. -->
+	<Extern href="stdidcmd.h" />
 
-  <!--This header contains the command ids for the menus provided by the shell. -->
-  <Extern href="vsshlids.h"/>
+	<!--This header contains the command ids for the menus provided by the shell. -->
+	<Extern href="vsshlids.h" />
 
-  <!--This header contains the image monikers for various images-->
-  <Include href="KnownImageIds.vsct"/>
+	<!--This header contains the image monikers for various images-->
+	<Include href="KnownImageIds.vsct" />
 
-  <!--This header contains data for the nanoFramework image moniker-->
-  <Include href="NanoFrameworkMoniker.vsct"/>
+	<!--This header contains data for the nanoFramework image moniker-->
+	<Include href="NanoFrameworkMoniker.vsct" />
 
 
-  <!--The Commands section is where we the commands, menus and menu groups are defined.
+	<!--The Commands section is where we the commands, menus and menu groups are defined.
       This section uses a Guid to identify the package that provides the command defined inside it. -->
-  <Commands package="guidNanoFrameworkPackage">
-    <!-- Inside this section we have different sub-sections: one for the menus, another  
+	<Commands package="guidNanoFrameworkPackage">
+		<!-- Inside this section we have different sub-sections: one for the menus, another  
     for the menu groups, one for the buttons (the actual commands), one for the combos 
     and the last one for the bitmaps used. Each element is identified by a command id that  
     is a unique pair of guid and numeric identifier; the guid part of the identifier is usually  
@@ -38,263 +38,263 @@
     group; your package should define its own command set in order to avoid collisions  
     with command ids defined by other packages. -->
 
-    <Menus>
-      <!-- this is the menu for Device Explorer Window -->
-      <Menu guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarID" priority="0x0000" type="ToolWindowToolbar">
-        <Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarID" />
-        <Strings>
-          <ButtonText>Tool Window Toolbar</ButtonText>
-          <CommandName>Tool Window Toolbar</CommandName>
-        </Strings>
-      </Menu>
+		<Menus>
+			<!-- this is the menu for Device Explorer Window -->
+			<Menu guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarID" priority="0x0000" type="ToolWindowToolbar">
+				<Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarID" />
+				<Strings>
+					<ButtonText>Tool Window Toolbar</ButtonText>
+					<CommandName>Tool Window Toolbar</CommandName>
+				</Strings>
+			</Menu>
 
-      <!-- this is the menu controller for the reboot command menu -->
-      <Menu guid="guidDeviceExplorerCmdSet" id="RebootMenuControllerID" type="MenuController" priority="0x0101" toolbarPriorityInBand="0x0001">
-        <Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroupID" />
-        <CommandFlag>NotInTBList</CommandFlag>
-        <Strings>
-          <ButtonText></ButtonText>
-          <CommandName>RebootMenuController</CommandName>
-        </Strings>
-      </Menu>
-      
-    </Menus>
+			<!-- this is the menu controller for the reboot command menu -->
+			<Menu guid="guidDeviceExplorerCmdSet" id="RebootMenuControllerID" type="MenuController" priority="0x0101" toolbarPriorityInBand="0x0001">
+				<Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroupID" />
+				<CommandFlag>NotInTBList</CommandFlag>
+				<Strings>
+					<ButtonText></ButtonText>
+					<CommandName>RebootMenuController</CommandName>
+				</Strings>
+			</Menu>
 
-    <Groups>
-      <!-- this is the 1st group for the Device Explorer Toolbar -->
-      <Group guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroupID" priority="0x0000">
-        <Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarID" />
-      </Group>
+		</Menus>
 
-      <!-- this is the 2nd group for the Device Explorer Toolbar -->
-      <Group guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroup2ID" priority="0x0001">
-        <Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarID" />
-      </Group>
+		<Groups>
+			<!-- this is the 1st group for the Device Explorer Toolbar -->
+			<Group guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroupID" priority="0x0000">
+				<Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarID" />
+			</Group>
 
-      <!-- this is the 3rd group for the Device Explorer Toolbar -->
-      <Group guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroup3ID" priority="0x0002">
-        <Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarID" />
-      </Group>
+			<!-- this is the 2nd group for the Device Explorer Toolbar -->
+			<Group guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroup2ID" priority="0x0001">
+				<Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarID" />
+			</Group>
 
-      <!-- this is the menu group for the reboot command button -->
-      <Group guid="guidDeviceExplorerCmdSet" id="RebootMenuGroupID" priority="0x0000">
-        <Parent guid="guidDeviceExplorerCmdSet" id="RebootMenuControllerID" />
-      </Group>
+			<!-- this is the 3rd group for the Device Explorer Toolbar -->
+			<Group guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroup3ID" priority="0x0002">
+				<Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarID" />
+			</Group>
 
-    </Groups>
+			<!-- this is the menu group for the reboot command button -->
+			<Group guid="guidDeviceExplorerCmdSet" id="RebootMenuGroupID" priority="0x0000">
+				<Parent guid="guidDeviceExplorerCmdSet" id="RebootMenuControllerID" />
+			</Group>
 
-    <!--Buttons section. -->
-    <!--This section defines the elements the user can interact with, like a menu command or a button 
+		</Groups>
+
+		<!--Buttons section. -->
+		<!--This section defines the elements the user can interact with, like a menu command or a button 
         or combo box in a toolbar. -->
-    <Buttons>
+		<Buttons>
 
-      <!-- commands for command line-->
-      <Button guid="guidNanoDebugPackageCmdSet" id="cmdidLaunchNanoDebug" priority="0x0100" type="Button">
-        <CommandFlag>AllowParams</CommandFlag>
-        <Strings>
-          <ButtonText>NanoDebug Launch</ButtonText>
-          <!--NOTE: 'Debug.' (or some other prefix) is required - the command window doesn't like commands which aren't prefixed.'-->
-          <CanonicalName>Debug.NanoDebugLaunch</CanonicalName>
-          <LocCanonicalName>Debug.NanoDebugLaunch</LocCanonicalName>
-        </Strings>
-      </Button>
+			<!-- commands for command line-->
+			<Button guid="guidNanoDebugPackageCmdSet" id="cmdidLaunchNanoDebug" priority="0x0100" type="Button">
+				<CommandFlag>AllowParams</CommandFlag>
+				<Strings>
+					<ButtonText>NanoDebug Launch</ButtonText>
+					<!--NOTE: 'Debug.' (or some other prefix) is required - the command window doesn't like commands which aren't prefixed.'-->
+					<CanonicalName>Debug.NanoDebugLaunch</CanonicalName>
+					<LocCanonicalName>Debug.NanoDebugLaunch</LocCanonicalName>
+				</Strings>
+			</Button>
 
-      <!--To define a menu group you have to specify its ID, the parent menu and its display priority.
+			<!--To define a menu group you have to specify its ID, the parent menu and its display priority.
           The command is visible and enabled by default. If you need to change the visibility, status, etc, you can use
           the CommandFlag node.
           You can add more than one CommandFlag node e.g.:
               <CommandFlag>DefaultInvisible</CommandFlag>
               <CommandFlag>DynamicVisibility</CommandFlag>
           If you do not want an image next to your command, remove the Icon node /> -->
-      <Button guid="guidNanoFrameworkPackageCmdSet" id="DeviceExplorerCommandId" priority="0x0100" type="Button">
-        <Parent guid="guidSHLMainMenu" id="IDG_VS_WNDO_OTRWNDWS1"/>
-        <Icon guid="NanoFrameworkCatalog" id="NanoFramework" />
-        <CommandFlag>IconIsMoniker</CommandFlag>
-        <Strings>
-          <ButtonText>Device Explorer</ButtonText>
-        </Strings>
-      </Button>
+			<Button guid="guidNanoFrameworkPackageCmdSet" id="DeviceExplorerCommandId" priority="0x0100" type="Button">
+				<Parent guid="guidSHLMainMenu" id="IDG_VS_WNDO_OTRWNDWS1" />
+				<Icon guid="NanoFrameworkCatalog" id="NanoFramework" />
+				<CommandFlag>IconIsMoniker</CommandFlag>
+				<Strings>
+					<ButtonText>Device Explorer</ButtonText>
+				</Strings>
+			</Button>
 
-      <!-- Ping for Device Explorer toolbar -->
-      <Button guid="guidDeviceExplorerCmdSet" id="idPingDeviceCommand" priority="0x0101" type="Button">
-        <Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroupID"/>
-        <Icon guid="NanoFrameworkCatalog" id="Ping" />
-        <CommandFlag>IconIsMoniker</CommandFlag>
-        <CommandFlag>DefaultDisabled</CommandFlag>
-        <Strings>
-          <CommandName>PingDeviceCommand</CommandName>
-          <ButtonText>Ping Device</ButtonText>
-        </Strings>
-      </Button>
+			<!-- Ping for Device Explorer toolbar -->
+			<Button guid="guidDeviceExplorerCmdSet" id="idPingDeviceCommand" priority="0x0101" type="Button">
+				<Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroupID" />
+				<Icon guid="NanoFrameworkCatalog" id="Ping" />
+				<CommandFlag>IconIsMoniker</CommandFlag>
+				<CommandFlag>DefaultDisabled</CommandFlag>
+				<Strings>
+					<CommandName>PingDeviceCommand</CommandName>
+					<ButtonText>Ping Device</ButtonText>
+				</Strings>
+			</Button>
 
-      <!-- DeviceCapabilities for Device Explorer toolbar -->
-      <Button guid="guidDeviceExplorerCmdSet" id="idDeviceCapabilitiesCommand" priority="0x0101" type="Button">
-        <Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroupID"/>
-        <Icon guid="NanoFrameworkCatalog" id="DeviceCapabilities" />
-        <CommandFlag>IconIsMoniker</CommandFlag>
-        <CommandFlag>DefaultDisabled</CommandFlag>
-        <Strings>
-          <CommandName>DeviceCapabilitiesCommand</CommandName>
-          <ButtonText>Device Capabilities</ButtonText>
-        </Strings>
-      </Button>
+			<!-- DeviceCapabilities for Device Explorer toolbar -->
+			<Button guid="guidDeviceExplorerCmdSet" id="idDeviceCapabilitiesCommand" priority="0x0101" type="Button">
+				<Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroupID" />
+				<Icon guid="NanoFrameworkCatalog" id="DeviceCapabilities" />
+				<CommandFlag>IconIsMoniker</CommandFlag>
+				<CommandFlag>DefaultDisabled</CommandFlag>
+				<Strings>
+					<CommandName>DeviceCapabilitiesCommand</CommandName>
+					<ButtonText>Device Capabilities</ButtonText>
+				</Strings>
+			</Button>
 
-      <!-- DeviceErase for Device Explorer toolbar -->
-      <Button guid="guidDeviceExplorerCmdSet" id="idDeviceEraseCommand" priority="0x0101" type="Button">
-        <Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroupID"/>
-        <Icon guid="NanoFrameworkCatalog" id="DeviceErase" />
-        <CommandFlag>IconIsMoniker</CommandFlag>
-        <CommandFlag>DefaultDisabled</CommandFlag>
-        <Strings>
-          <CommandName>DeviceEraseCommand</CommandName>
-          <ButtonText>Erase Device Deployment Area</ButtonText>
-        </Strings>
-      </Button>
+			<!-- DeviceErase for Device Explorer toolbar -->
+			<Button guid="guidDeviceExplorerCmdSet" id="idDeviceEraseCommand" priority="0x0101" type="Button">
+				<Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroupID" />
+				<Icon guid="NanoFrameworkCatalog" id="DeviceErase" />
+				<CommandFlag>IconIsMoniker</CommandFlag>
+				<CommandFlag>DefaultDisabled</CommandFlag>
+				<Strings>
+					<CommandName>DeviceEraseCommand</CommandName>
+					<ButtonText>Erase Device Deployment Area</ButtonText>
+				</Strings>
+			</Button>
 
-      <!-- Reboot for Device Explorer toolbar -->
-      <Button guid="guidDeviceExplorerCmdSet" id="idRebootCommand" priority="0x0101" type="Button">
-        <Parent guid="guidDeviceExplorerCmdSet" id="RebootMenuGroupID"/>
-        <Icon guid="NanoFrameworkCatalog" id="Reboot" />
-        <CommandFlag>IconIsMoniker</CommandFlag>
-        <CommandFlag>DefaultDisabled</CommandFlag>
-        <CommandFlag>NoShowOnMenuController</CommandFlag>
-        <CommandFlag>FixMenuController</CommandFlag>
-        <Strings>
-          <CommandName>RebootCommand</CommandName>
-          <ButtonText>Reboot target device</ButtonText>
-        </Strings>
-      </Button>
+			<!-- Reboot for Device Explorer toolbar -->
+			<Button guid="guidDeviceExplorerCmdSet" id="idRebootCommand" priority="0x0101" type="Button">
+				<Parent guid="guidDeviceExplorerCmdSet" id="RebootMenuGroupID" />
+				<Icon guid="NanoFrameworkCatalog" id="Reboot" />
+				<CommandFlag>IconIsMoniker</CommandFlag>
+				<CommandFlag>DefaultDisabled</CommandFlag>
+				<CommandFlag>NoShowOnMenuController</CommandFlag>
+				<CommandFlag>FixMenuController</CommandFlag>
+				<Strings>
+					<CommandName>RebootCommand</CommandName>
+					<ButtonText>Reboot target device</ButtonText>
+				</Strings>
+			</Button>
 
-      <Button guid="guidDeviceExplorerCmdSet" id="idRebootClrCommand" priority="0x0101" type="Button">
-        <Parent guid="guidDeviceExplorerCmdSet" id="RebootMenuGroupID"/>
-        <CommandFlag>TextOnly</CommandFlag>
-        <Strings>
-          <CommandName>RebootClrCommand</CommandName>
-          <ButtonText>Reboot CLR</ButtonText>
-        </Strings>
-      </Button>
-      
-      <Button guid="guidDeviceExplorerCmdSet" id="idRebootNanoBooterCommand" priority="0x0101" type="Button">
-        <Parent guid="guidDeviceExplorerCmdSet" id="RebootMenuGroupID"/>
-        <CommandFlag>TextOnly</CommandFlag>
-        <CommandFlag>DynamicVisibility</CommandFlag>
-        <Strings>
-          <CommandName>RebootNanoBooterCommand</CommandName>
-          <ButtonText>Reboot to nanoBooter</ButtonText>
-        </Strings>
-      </Button>
-      
-      <Button guid="guidDeviceExplorerCmdSet" id="idRebootBootloaderCommand" priority="0x0101" type="Button">
-        <Parent guid="guidDeviceExplorerCmdSet" id="RebootMenuGroupID"/>
-        <CommandFlag>TextOnly</CommandFlag>
-        <CommandFlag>TextChanges</CommandFlag>
-        <CommandFlag>DynamicVisibility</CommandFlag>
-        <Strings>
-          <CommandName>RebootToBootloaderCommand</CommandName>
-          <ButtonText>Reboot to bootloader</ButtonText>
-        </Strings>
-      </Button>
-      
-      <!-- NetworkConfig for Device Explorer toolbar -->
-      <Button guid="guidDeviceExplorerCmdSet" id="idNetworkConfigCommand" priority="0x0101" type="Button">
-        <Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroupID"/>
-        <Icon guid="NanoFrameworkCatalog" id="NetworkConfig" />
-        <CommandFlag>IconIsMoniker</CommandFlag>
-        <CommandFlag>DefaultDisabled</CommandFlag>
-        <Strings>
-          <CommandName>NetworkConfigCommand</CommandName>
-          <ButtonText>Edit Network Configuration</ButtonText>
-        </Strings>
-      </Button>
+			<Button guid="guidDeviceExplorerCmdSet" id="idRebootClrCommand" priority="0x0101" type="Button">
+				<Parent guid="guidDeviceExplorerCmdSet" id="RebootMenuGroupID" />
+				<CommandFlag>TextOnly</CommandFlag>
+				<Strings>
+					<CommandName>RebootClrCommand</CommandName>
+					<ButtonText>Reboot CLR</ButtonText>
+				</Strings>
+			</Button>
 
-      <!-- buttons for the 2nd menu -->
+			<Button guid="guidDeviceExplorerCmdSet" id="idRebootNanoBooterCommand" priority="0x0101" type="Button">
+				<Parent guid="guidDeviceExplorerCmdSet" id="RebootMenuGroupID" />
+				<CommandFlag>TextOnly</CommandFlag>
+				<CommandFlag>DynamicVisibility</CommandFlag>
+				<Strings>
+					<CommandName>RebootNanoBooterCommand</CommandName>
+					<ButtonText>Reboot to nanoBooter</ButtonText>
+				</Strings>
+			</Button>
 
-      <!-- Disable device watchers -->
-      <Button guid="guidDeviceExplorerCmdSet" id="idDisableDeviceWatchersCommand" priority="0x0101" type="Button">
-        <Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroup2ID"/>
-        <Icon guid="NanoFrameworkCatalog" id="DisableDeviceWatchers" />
-        <CommandFlag>IconIsMoniker</CommandFlag>
-        <Strings>
-          <CommandName>DisableDeviceWatchersCommand</CommandName>
-          <ButtonText>Disable Device Watchers</ButtonText>
-        </Strings>
-      </Button>
+			<Button guid="guidDeviceExplorerCmdSet" id="idRebootBootloaderCommand" priority="0x0101" type="Button">
+				<Parent guid="guidDeviceExplorerCmdSet" id="RebootMenuGroupID" />
+				<CommandFlag>TextOnly</CommandFlag>
+				<CommandFlag>TextChanges</CommandFlag>
+				<CommandFlag>DynamicVisibility</CommandFlag>
+				<Strings>
+					<CommandName>RebootToBootloaderCommand</CommandName>
+					<ButtonText>Reboot to bootloader</ButtonText>
+				</Strings>
+			</Button>
 
-      <!-- Rescan devices -->
-      <Button guid="guidDeviceExplorerCmdSet" id="idRescanDevicesCommand" priority="0x0101" type="Button">
-        <Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroup2ID"/>
-        <Icon guid="NanoFrameworkCatalog" id="RescanDevices" />
-        <CommandFlag>IconIsMoniker</CommandFlag>
-        <Strings>
-          <CommandName>RescanDevicesCommand</CommandName>
-          <ButtonText>Rescan nanoDevices</ButtonText>
-        </Strings>
-      </Button>
+			<!-- NetworkConfig for Device Explorer toolbar -->
+			<Button guid="guidDeviceExplorerCmdSet" id="idNetworkConfigCommand" priority="0x0101" type="Button">
+				<Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroupID" />
+				<Icon guid="NanoFrameworkCatalog" id="NetworkConfig" />
+				<CommandFlag>IconIsMoniker</CommandFlag>
+				<CommandFlag>DefaultDisabled</CommandFlag>
+				<Strings>
+					<CommandName>NetworkConfigCommand</CommandName>
+					<ButtonText>Edit Network Configuration</ButtonText>
+				</Strings>
+			</Button>
 
-      <!-- buttons for the 3rd menu -->
+			<!-- buttons for the 2nd menu -->
 
-      <!-- Show internal errors for nF extension -->
-      <Button guid="guidDeviceExplorerCmdSet" id="idShowInternalErrorsCommand" priority="0x0101" type="Button">
-        <Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroup3ID"/>
-        <Icon guid="NanoFrameworkCatalog" id="ShowInternalErrors" />
-        <CommandFlag>IconIsMoniker</CommandFlag>
-        <Strings>
-          <CommandName>ShowInternalErrorsCommand</CommandName>
-          <ButtonText>Show Internal Errors</ButtonText>
-        </Strings>
-      </Button>
+			<!-- Disable device watchers -->
+			<Button guid="guidDeviceExplorerCmdSet" id="idDisableDeviceWatchersCommand" priority="0x0101" type="Button">
+				<Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroup2ID" />
+				<Icon guid="NanoFrameworkCatalog" id="DisableDeviceWatchers" />
+				<CommandFlag>IconIsMoniker</CommandFlag>
+				<Strings>
+					<CommandName>DisableDeviceWatchersCommand</CommandName>
+					<ButtonText>Disable Device Watchers</ButtonText>
+				</Strings>
+			</Button>
 
-      <!-- show settings for Device Explorer toolbar -->
-      <Button guid="guidDeviceExplorerCmdSet" id="idShowSettingsCommand" priority="0x0101" type="Button">
-        <Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroup3ID"/>
-        <Icon guid="NanoFrameworkCatalog" id="SettingsID" />
-        <CommandFlag>IconIsMoniker</CommandFlag>
-        <Strings>
-          <CommandName>ShowSettingsCommand</CommandName>
-          <ButtonText>Show Settings</ButtonText>
-        </Strings>
-      </Button>
+			<!-- Rescan devices -->
+			<Button guid="guidDeviceExplorerCmdSet" id="idRescanDevicesCommand" priority="0x0101" type="Button">
+				<Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroup2ID" />
+				<Icon guid="NanoFrameworkCatalog" id="RescanDevices" />
+				<CommandFlag>IconIsMoniker</CommandFlag>
+				<Strings>
+					<CommandName>RescanDevicesCommand</CommandName>
+					<ButtonText>Rescan nanoDevices</ButtonText>
+				</Strings>
+			</Button>
 
-    </Buttons>
-  </Commands>
+			<!-- buttons for the 3rd menu -->
 
-  <Symbols>
-    <!-- This is the package guid. -->
-    <GuidSymbol name="guidNanoFrameworkPackage" value="{c72d2e12-4593-421e-9ced-5ce21fe0aeb4}" />
+			<!-- Show internal errors for nF extension -->
+			<Button guid="guidDeviceExplorerCmdSet" id="idShowInternalErrorsCommand" priority="0x0101" type="Button">
+				<Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroup3ID" />
+				<Icon guid="NanoFrameworkCatalog" id="ShowInternalErrors" />
+				<CommandFlag>IconIsMoniker</CommandFlag>
+				<Strings>
+					<CommandName>ShowInternalErrorsCommand</CommandName>
+					<ButtonText>Show Internal Errors</ButtonText>
+				</Strings>
+			</Button>
 
-    <!-- This is the guid used to group the commands together -->
-    <GuidSymbol name="guidNanoDebugPackageCmdSet" value="{6A0F19B1-00EF-4215-BD7B-29DEB4425F7C}">
-      <IDSymbol name="MyMenuGroup" value="0x1020" />
-      <IDSymbol name="cmdidLaunchNanoDebug" value="0x0300" />
-    </GuidSymbol>
+			<!-- show settings for Device Explorer toolbar -->
+			<Button guid="guidDeviceExplorerCmdSet" id="idShowSettingsCommand" priority="0x0101" type="Button">
+				<Parent guid="guidDeviceExplorerCmdSet" id="DeviceExplorerToolbarGroup3ID" />
+				<Icon guid="NanoFrameworkCatalog" id="SettingsID" />
+				<CommandFlag>IconIsMoniker</CommandFlag>
+				<Strings>
+					<CommandName>ShowSettingsCommand</CommandName>
+					<ButtonText>Show Settings</ButtonText>
+				</Strings>
+			</Button>
 
-    <!-- This is the guid used to group the menu commands together -->
-    <GuidSymbol name="guidNanoFrameworkPackageCmdSet" value="{c975c4ec-f229-45dd-b681-e42815641675}">
-      <IDSymbol name="DeviceExplorerCommandId" value="0x0100" />
-    </GuidSymbol>
+		</Buttons>
+	</Commands>
 
-    <!-- This is the guid used to group the Device Explorer Toolwindow menu commands together -->
-    <GuidSymbol name="guidDeviceExplorerCmdSet" value="{DF641D51-1E8C-48E4-B549-CC6BCA9BDE19}">
-      <IDSymbol name="DeviceExplorerToolbarID" value="0x1000" />
-      <IDSymbol name="DeviceExplorerToolbarGroupID" value="0x1001" />
-      <IDSymbol name="DeviceExplorerToolbarGroup2ID" value="0x1002" />
-      <IDSymbol name="DeviceExplorerToolbarGroup3ID" value="0x1003" />
-      <IDSymbol name="RebootMenuGroupID" value="0x1004" />
-      <IDSymbol name="RebootMenuControllerID" value="0x1005" />
-      <IDSymbol name="idPingDeviceCommand" value="0x0210" />
-      <IDSymbol name="idDeviceCapabilitiesCommand" value="0x0220" />
-      <IDSymbol name="idDeviceEraseCommand" value="0x0230" />
-      <IDSymbol name="idRebootCommand" value="0x0240" />
-      <IDSymbol name="idRebootClrCommand" value="0x0242" />
-      <IDSymbol name="idRebootNanoBooterCommand" value="0x0244" />
-      <IDSymbol name="idRebootBootloaderCommand" value="0x0246" />
-      <IDSymbol name="idNetworkConfigCommand" value="0x0250" />
-      <IDSymbol name="idDisableDeviceWatchersCommand" value="0x0400" />
-      <IDSymbol name="idRescanDevicesCommand" value="0x0410" />
-      <IDSymbol name="idShowInternalErrorsCommand" value="0x0300" />
-      <IDSymbol name="idShowSettingsCommand" value="0x0420" />
-    </GuidSymbol>
+	<Symbols>
+		<!-- This is the package guid. -->
+		<GuidSymbol name="guidNanoFrameworkPackage" value="{c72d2e12-4593-421e-9ced-5ce21fe0aeb4}" />
 
-  </Symbols>
+		<!-- This is the guid used to group the commands together -->
+		<GuidSymbol name="guidNanoDebugPackageCmdSet" value="{6A0F19B1-00EF-4215-BD7B-29DEB4425F7C}">
+			<IDSymbol name="MyMenuGroup" value="0x1020" />
+			<IDSymbol name="cmdidLaunchNanoDebug" value="0x0300" />
+		</GuidSymbol>
+
+		<!-- This is the guid used to group the menu commands together -->
+		<GuidSymbol name="guidNanoFrameworkPackageCmdSet" value="{c975c4ec-f229-45dd-b681-e42815641675}">
+			<IDSymbol name="DeviceExplorerCommandId" value="0x0100" />
+		</GuidSymbol>
+
+		<!-- This is the guid used to group the Device Explorer Toolwindow menu commands together -->
+		<GuidSymbol name="guidDeviceExplorerCmdSet" value="{DF641D51-1E8C-48E4-B549-CC6BCA9BDE19}">
+			<IDSymbol name="DeviceExplorerToolbarID" value="0x1000" />
+			<IDSymbol name="DeviceExplorerToolbarGroupID" value="0x1001" />
+			<IDSymbol name="DeviceExplorerToolbarGroup2ID" value="0x1002" />
+			<IDSymbol name="DeviceExplorerToolbarGroup3ID" value="0x1003" />
+			<IDSymbol name="RebootMenuGroupID" value="0x1004" />
+			<IDSymbol name="RebootMenuControllerID" value="0x1005" />
+			<IDSymbol name="idPingDeviceCommand" value="0x0210" />
+			<IDSymbol name="idDeviceCapabilitiesCommand" value="0x0220" />
+			<IDSymbol name="idDeviceEraseCommand" value="0x0230" />
+			<IDSymbol name="idRebootCommand" value="0x0240" />
+			<IDSymbol name="idRebootClrCommand" value="0x0242" />
+			<IDSymbol name="idRebootNanoBooterCommand" value="0x0244" />
+			<IDSymbol name="idRebootBootloaderCommand" value="0x0246" />
+			<IDSymbol name="idNetworkConfigCommand" value="0x0250" />
+			<IDSymbol name="idDisableDeviceWatchersCommand" value="0x0400" />
+			<IDSymbol name="idRescanDevicesCommand" value="0x0410" />
+			<IDSymbol name="idShowInternalErrorsCommand" value="0x0300" />
+			<IDSymbol name="idShowSettingsCommand" value="0x0420" />
+		</GuidSymbol>
+
+	</Symbols>
 
 </CommandTable>

--- a/VisualStudio.Extension-2022/version.json
+++ b/VisualStudio.Extension-2022/version.json
@@ -16,7 +16,7 @@
     "^refs/tags/$"
   ],
   "cloudBuild": {
-    "setVersionVariables": true,
-    "setAllVariables": true
+    "setVersionVariables": false,
+    "setAllVariables": false
   }
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,9 +2,10 @@ trigger:
   branches:
     include: [main, develop, "release-*" ]
   paths:
-    exclude: [README.md, LICENSE.md, NuGet.Config, .github_changelog_generator, .gitignore]
+    exclude: [README.md, CHANGELOG-VS2017.md, CHANGELOG-VS2019.md, CHANGELOG-VS2022.md, LICENSE.md, NuGet.Config, .github_changelog_generator, .gitignore]
   tags:
-    include: ["v*"]
+    include:
+    - refs/tags/v*
 
 # PR always trigger build
 pr:
@@ -128,7 +129,8 @@ jobs:
     vmImage: 'windows-2019'
 
   variables:
-    solution: 'VisualStudio.Extension-2019\VisualStudio.Extension-vs2019.csproj'
+    DOTNET_NOLOGO: true
+    solution: 'nanoFramework.Tools.VisualStudio.sln'
     buildConfiguration: 'Release'
 
   steps:
@@ -142,6 +144,14 @@ jobs:
       git config --global user.name 'nfbot'
     displayName: Setup git identity
 
+  - task: DotNetCoreCLI@2  
+    displayName: Install NBGV tool
+    condition: succeeded()
+    inputs:
+      command: custom
+      custom: tool
+      arguments: install -g nbgv
+    
   - template: azure-pipelines-templates/install-nuget.yml@templates
 
   - task: NuGetCommand@2
@@ -165,12 +175,16 @@ jobs:
 
   - task: PowerShell@2
     inputs:
-        targetType: 'inline'
-        script: |
-            Write-Host "VS2019 build version $env:NBGV_AssemblyVersion"
-            
-            echo "##vso[task.setvariable variable=BUILD_VERSION;isOutput=true]$env:NBGV_AssemblyVersion"  
+      targetType: 'inline'
+      script: |
+        $versionData = & nbgv get-version -f json -p VisualStudio.Extension-2019
+        $versionData =$versionData | ConvertFrom-Json
+        
+        $version = $versionData.AssemblyVersion
 
+        Write-Host "VS2019 build version $version"
+          
+        echo "##vso[task.setvariable variable=BUILD_VERSION;isOutput=true]$version" 
     condition: succeeded()
     name: VS2019_Build
     displayName: Store VS2019 build version
@@ -285,6 +299,7 @@ jobs:
       assets: '$(Build.ArtifactStagingDirectory)\*.vsix'
       assetUploadMode: replace
       isPreRelease: true
+      isDraft: true
       addChangeLog: false
 
   # create or update GitHub release ON tags from release or main branches
@@ -328,7 +343,8 @@ jobs:
     vmImage: 'windows-2022'
 
   variables:
-    solution: 'VisualStudio.Extension-2022/VisualStudio.Extension-vs2022.csproj'
+    DOTNET_NOLOGO: true
+    solution: 'nanoFramework.Tools.VisualStudio.sln'
     buildConfiguration: 'Release'
 
   steps:
@@ -341,6 +357,14 @@ jobs:
       git config --global user.email 'nanoframework@outlook.com'
       git config --global user.name 'nfbot'
     displayName: Setup git identity
+
+  - task: DotNetCoreCLI@2  
+    displayName: Install NBGV tool
+    condition: succeeded()
+    inputs:
+      command: custom
+      custom: tool
+      arguments: install -g nbgv
 
   - template: azure-pipelines-templates/install-nuget.yml@templates
 
@@ -365,12 +389,16 @@ jobs:
 
   - task: PowerShell@2
     inputs:
-        targetType: 'inline'
-        script: |
-            Write-Host "VS2022 build version $env:NBGV_AssemblyVersion"
-            
-            echo "##vso[task.setvariable variable=BUILD_VERSION;isOutput=true]$env:NBGV_AssemblyVersion"  
+      targetType: 'inline'
+      script: |
+        $versionData = & nbgv get-version -f json -p VisualStudio.Extension-2022
+        $versionData =$versionData | ConvertFrom-Json
+        
+        $version = $versionData.AssemblyVersion
 
+        Write-Host "VS2022 build version $version"
+          
+        echo "##vso[task.setvariable variable=BUILD_VERSION;isOutput=true]$version"
     condition: succeeded()
     name: VS2022_Build
     displayName: Store VS2022 build version
@@ -483,6 +511,7 @@ jobs:
       releaseNotesInline: 'Check the [changelog](https://github.com/nanoframework/nf-Visual-Studio-extension/blob/$(Build.SourceBranchName)/CHANGELOG-VS2022.md).<br><br><h4>Install from nanoFramework Open VSIX Gallery development feed</h4><br>The following Visual Studio Extensions are available for install from this release<br><br>:package: [nanoFramework VS2022 Extension](https://marketplace.visualstudio.com/items?itemName=nanoframework.nanoFramework-VS2022-Extension)'
       assets: '$(Build.ArtifactStagingDirectory)\*.vsix'
       assetUploadMode: replace
+      isDraft: true
       isPreRelease: true
       addChangeLog: false
 
@@ -492,7 +521,7 @@ jobs:
       and(
         succeeded(),
         startsWith(variables['Build.SourceBranch'], 'refs/tags/v'),
-        contains(variables['Build.SourceBranch'], 'vs2019'),
+        contains(variables['Build.SourceBranch'], 'vs2022'),
         or(
           eq(variables['Build.SourceBranchName'], 'main'),
           contains(variables['Build.SourceBranchName'], 'release')
@@ -528,9 +557,9 @@ jobs:
 
   variables:
     GO_BuildVS2019: $[ dependencies.Get_Build_Options.outputs['BuildOptions.BUILD_VS2019'] ]
-    MY_VS2019_VERSION: $[ dependencies.VS2019_2022.outputs['VS2019Build.BUILD_VERSION'] ]
+    MY_VS2019_VERSION: $[ dependencies.VS2019.outputs['VS2019_Build.BUILD_VERSION'] ]
     GO_BuildVS202: $[ dependencies.Get_Build_Options.outputs['BuildOptions.BUILD_VS2022'] ]
-    MY_VS2022_VERSION: $[ dependencies.VS2019_2022.outputs['VS2022Build.BUILD_VERSION'] ]
+    MY_VS2022_VERSION: $[ dependencies.VS2022.outputs['VS2022_Build.BUILD_VERSION'] ]
 
   pool:
     vmImage: 'windows-latest'

--- a/vs-extension.shared/ToolWindow.DeviceExplorer/DeviceExplorer.cs
+++ b/vs-extension.shared/ToolWindow.DeviceExplorer/DeviceExplorer.cs
@@ -25,9 +25,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
     [Guid("65ff0124-880b-4bf4-9441-08a10b4e4c06")]
     public class DeviceExplorer : ToolWindowPane
     {
-
         internal DeviceExplorerControl control;
-
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DeviceExplorer"/> class.


### PR DESCRIPTION
## Description
- Device Explorer commands are now fully async.
- Rework package init code to solve performance issues with loading.
- Remove unnecessary check for running on Win10.
- Fix package ref in VS2019.
- Fix app.config for VS2019.
- Fix code style on some files.

## Motivation and Context
- Improves performance issues with loading.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
