### PR TITLE
Fix icon resources

### DIFF
--- a/VisualStudio.Extension-2019/NanoFrameworkMoniker.cs
+++ b/VisualStudio.Extension-2019/NanoFrameworkMoniker.cs
@@ -8,19 +8,14 @@ using Microsoft.VisualStudio.Imaging.Interop;
 
 namespace nanoFramework.Tools.VisualStudio.Extension
 {
-    public static class NanoFrameworkMonikers
+    public static class NanoFrameworkMoniker
     {
         // GUID matching the NanoFrameworkCatalog
 
         ////////////////////////////////////////////////////////
         // this GUID is coming from NanoFrameworkMoniker.vsct //
         ////////////////////////////////////////////////////////
-#if DEV17
-        private static readonly Guid ManifestGuid = new Guid("23cf437f-5e0e-4b0c-8aa4-ceec5b5f8679");
-#elif DEV16
         private static readonly Guid ManifestGuid = new Guid("6CBBCC35-4BB4-4110-AFFF-9BAEF4DAA4A7");
-#else
-#endif
 
         public static ImageMoniker NanoFramework
         {

--- a/VisualStudio.Extension-2019/NanoFrameworkMoniker.imagemanifest
+++ b/VisualStudio.Extension-2019/NanoFrameworkMoniker.imagemanifest
@@ -4,7 +4,7 @@
                            xmlns="http://schemas.microsoft.com/VisualStudio/ImageManifestSchema/2014">
   <Symbols>
     <String Name="Resources" Value="/nanoFramework.Tools.VS2019.Extension;Component/Resources" />
-    <Guid Name="NanoFrameworkCatalog" Value="6CBBCC35-4BB4-4110-AFFF-9BAEF4DAA4A7" />
+    <Guid Name="NanoFrameworkCatalog" Value="{6CBBCC35-4BB4-4110-AFFF-9BAEF4DAA4A7}" />
     <ID Name="DeviceConnected" Value="20" />
     <ID Name="DeviceDisconnected" Value="30" />
     <ID Name="NanoFramework" Value="40" />

--- a/VisualStudio.Extension-2019/ToolWindow.DeviceExplorer/DeviceExplorerControl.xaml
+++ b/VisualStudio.Extension-2019/ToolWindow.DeviceExplorer/DeviceExplorerControl.xaml
@@ -109,7 +109,7 @@
                         </Grid.ColumnDefinitions>
 
                         <imaging:CrispImage Grid.Row="0" Grid.Column="0" Width="32" Height="32" HorizontalAlignment="Left" Margin="0" Focusable="False" 
-                                            Moniker="{x:Static nfCatalog:NanoFrameworkMonikers.NanoFramework}" 
+                                            Moniker="{x:Static nfCatalog:NanoFrameworkMoniker.NanoFramework}" 
                                             theming:ImageThemingUtilities.ImageBackgroundColor="{Binding Background, ElementName=BackgroundInvert, Converter={StaticResource BrushToColorConverter}}" />
 
                         <StackPanel Grid.Row="0" Grid.Column="1"  HorizontalAlignment="Left" Orientation="Vertical">

--- a/VisualStudio.Extension-2019/VisualStudio.Extension-vs2019.csproj
+++ b/VisualStudio.Extension-2019/VisualStudio.Extension-vs2019.csproj
@@ -69,6 +69,11 @@
     <Compile Include="..\Tools.BuildTasks-2017\ProcessResourceFiles.cs">
       <Link>ResXFileCodeGenerator\ProcessResourceFiles.cs</Link>
     </Compile>
+    <Compile Include="NanoFrameworkMoniker.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>NanoFrameworkMoniker.vsct</DependentUpon>
+    </Compile>
     <Compile Include="NanoFrameworkPackage.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Resources\ResourceStrings.Designer.cs">

--- a/VisualStudio.Extension-2019/version.json
+++ b/VisualStudio.Extension-2019/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2019.9.2",
+  "version": "2019.10.0",
   "release": {
     "branchName" : "release-v{version}",
     "versionIncrement" : "minor",

--- a/VisualStudio.Extension-2022/NanoFrameworkMoniker.cs
+++ b/VisualStudio.Extension-2022/NanoFrameworkMoniker.cs
@@ -1,0 +1,124 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using System;
+using Microsoft.VisualStudio.Imaging.Interop;
+
+namespace nanoFramework.Tools.VisualStudio.Extension
+{
+    public static class NanoFrameworkMoniker
+    {
+        // GUID matching the NanoFrameworkCatalog
+
+        ////////////////////////////////////////////////////////
+        // this GUID is coming from NanoFrameworkMoniker.vsct //
+        ////////////////////////////////////////////////////////
+        private static readonly Guid ManifestGuid = new Guid("23cf437f-5e0e-4b0c-8aa4-ceec5b5f8679");
+
+        public static ImageMoniker NanoFramework
+        {
+            get
+            {
+                return new ImageMoniker { Guid = ManifestGuid, Id = 40 };
+            }
+        }
+
+        public static ImageMoniker DeviceConnected
+        {
+            get
+            {
+                return new ImageMoniker { Guid = ManifestGuid, Id = 20 };
+            }
+        }
+
+        public static ImageMoniker DeviceDisconnected
+        {
+            get
+            {
+                return new ImageMoniker { Guid = ManifestGuid, Id = 30 };
+            }
+        }
+
+        public static ImageMoniker Ping
+        {
+            get
+            {
+                return new ImageMoniker { Guid = ManifestGuid, Id = 50 };
+            }
+        }
+
+        public static ImageMoniker DeviceCapabilities
+        {
+            get
+            {
+                return new ImageMoniker { Guid = ManifestGuid, Id = 70 };
+            }
+        }
+
+        public static ImageMoniker NanoFrameworkProject
+        {
+            get
+            {
+                return new ImageMoniker { Guid = ManifestGuid, Id = 80 };
+            }
+        }
+
+        public static ImageMoniker ShowInternalErrors
+        {
+            get
+            {
+                return new ImageMoniker { Guid = ManifestGuid, Id = 90 };
+            }
+        }
+
+        public static ImageMoniker DeviceErase
+        {
+            get
+            {
+                return new ImageMoniker { Guid = ManifestGuid, Id = 100 };
+            }
+        }
+
+        public static ImageMoniker NetworkConfig
+        {
+            get
+            {
+                return new ImageMoniker { Guid = ManifestGuid, Id = 110 };
+            }
+        }
+
+        public static ImageMoniker Reboot
+        {
+            get
+            {
+                return new ImageMoniker { Guid = ManifestGuid, Id = 120 };
+            }
+        }
+
+        public static ImageMoniker DisableDeviceWatchers
+        {
+            get
+            {
+                return new ImageMoniker { Guid = ManifestGuid, Id = 130 };
+            }
+        }
+
+        public static ImageMoniker RescanDevices
+        {
+            get
+            {
+                return new ImageMoniker { Guid = ManifestGuid, Id = 140 };
+            }
+        }
+
+        public static ImageMoniker SettingsID
+        {
+            get
+            {
+                return new ImageMoniker { Guid = ManifestGuid, Id = 150 };
+            }
+        }
+    }
+}

--- a/VisualStudio.Extension-2022/NanoFrameworkMoniker.imagemanifest
+++ b/VisualStudio.Extension-2022/NanoFrameworkMoniker.imagemanifest
@@ -4,7 +4,7 @@
                            xmlns="http://schemas.microsoft.com/VisualStudio/ImageManifestSchema/2014">
   <Symbols>
     <String Name="Resources" Value="/nanoFramework.Tools.VS2022.Extension;Component/Resources" />
-    <Guid Name="NanoFrameworkCatalog" Value="23cf437f-5e0e-4b0c-8aa4-ceec5b5f8679" />
+    <Guid Name="NanoFrameworkCatalog" Value="{23cf437f-5e0e-4b0c-8aa4-ceec5b5f8679}" />
     <ID Name="DeviceConnected" Value="20" />
     <ID Name="DeviceDisconnected" Value="30" />
     <ID Name="NanoFramework" Value="40" />

--- a/VisualStudio.Extension-2022/NanoFrameworkPackage.cs
+++ b/VisualStudio.Extension-2022/NanoFrameworkPackage.cs
@@ -29,7 +29,7 @@ using Task = System.Threading.Tasks.Task;
                                 displayProjectFileExtensions: ".NET nanoFramework Project Files (*.nfproj);*.nfproj",
                                 defaultProjectExtension: NanoCSharpProjectUnconfigured.ProjectExtension,
                                 language: NanoCSharpProjectUnconfigured.Language,
-                                resourcePackageGuid: NanoFrameworkPackage.PackageGuid,
+                                resourcePackageGuid: NanoFrameworkPackage.PackageGuidString,
                                 PossibleProjectExtensions = NanoCSharpProjectUnconfigured.ProjectExtension,
                                 Capabilities = NanoCSharpProjectUnconfigured.UniqueCapability
                                 )]
@@ -62,7 +62,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
     [ProvideToolWindow(typeof(DeviceExplorer), Style = VsDockStyle.Tabbed, Window = "3ae79031-e1bc-11d0-8f78-00a0c9110057")]
     // register nanoDevice communication service
     [ProvideService((typeof(NanoDeviceCommService)), IsAsyncQueryable = true)]
-    [Guid(NanoFrameworkPackage.PackageGuid)]
+    [Guid(PackageGuidString)]
     [ProvideObject(typeof(CorDebug))]
     [ProvideDebugEngine("Managed", typeof(CorDebug), CorDebug.EngineId, setNextStatement: true, hitCountBp: true)]
     [ProvideDebugPortSupplier(".NET nanoFramework Port Supplier", typeof(DebugPortSupplier), DebugPortSupplier.PortSupplierId)]
@@ -83,7 +83,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
         ////////////////////////////////////////////////////////
         // this GUID is coming from NanoFrameworkPackage.vsct //
         ////////////////////////////////////////////////////////
-        public const string PackageGuid = "1b4aea27-9d6e-46a4-9868-f2d9a052c821";
+        public const string PackageGuidString = "1b4aea27-9d6e-46a4-9868-f2d9a052c821";
 
         /// <summary>
         /// Path for nanoFramework Extension directory

--- a/VisualStudio.Extension-2022/ToolWindow.DeviceExplorer/DeviceExplorerControl.xaml
+++ b/VisualStudio.Extension-2022/ToolWindow.DeviceExplorer/DeviceExplorerControl.xaml
@@ -109,7 +109,7 @@
                         </Grid.ColumnDefinitions>
 
                         <imaging:CrispImage Grid.Row="0" Grid.Column="0" Width="32" Height="32" HorizontalAlignment="Left" Margin="0" Focusable="False" 
-                                            Moniker="{x:Static nfCatalog:NanoFrameworkMonikers.NanoFramework}" 
+                                            Moniker="{x:Static nfCatalog:NanoFrameworkMoniker.NanoFramework}" 
                                             theming:ImageThemingUtilities.ImageBackgroundColor="{Binding Background, ElementName=BackgroundInvert, Converter={StaticResource BrushToColorConverter}}" />
 
                         <StackPanel Grid.Row="0" Grid.Column="1"  HorizontalAlignment="Left" Orientation="Vertical">

--- a/VisualStudio.Extension-2022/VisualStudio.Extension-vs2022.csproj
+++ b/VisualStudio.Extension-2022/VisualStudio.Extension-vs2022.csproj
@@ -85,6 +85,11 @@
     <Compile Include="..\Tools.BuildTasks-2017\ProcessResourceFiles.cs">
       <Link>ResXFileCodeGenerator\ProcessResourceFiles.cs</Link>
     </Compile>
+    <Compile Include="NanoFrameworkMoniker.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>NanoFrameworkMoniker.vsct</DependentUpon>
+    </Compile>
     <Compile Include="NanoFrameworkPackage.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Resources\ResourceStrings.Designer.cs">

--- a/VisualStudio.Extension-2022/version.json
+++ b/VisualStudio.Extension-2022/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2022.0.3",
+  "version": "2022.1.0",
   "release": {
     "branchName" : "release-v{version}",
     "versionIncrement" : "minor",

--- a/vs-extension.shared/ProjectSystem/ProjectTreePropertiesProvider.cs
+++ b/vs-extension.shared/ProjectSystem/ProjectTreePropertiesProvider.cs
@@ -36,8 +36,8 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                     return;
                 }
 
-                propertyValues.Icon = NanoFrameworkMonikers.NanoFrameworkProject.ToProjectSystemType();
-                propertyValues.ExpandedIcon = NanoFrameworkMonikers.NanoFrameworkProject.ToProjectSystemType();
+                propertyValues.Icon = NanoFrameworkMoniker.NanoFrameworkProject.ToProjectSystemType();
+                propertyValues.ExpandedIcon = NanoFrameworkMoniker.NanoFrameworkProject.ToProjectSystemType();
             }
         }
     }

--- a/vs-extension.shared/ToolWindow.DeviceExplorer/DeviceExplorer.cs
+++ b/vs-extension.shared/ToolWindow.DeviceExplorer/DeviceExplorer.cs
@@ -45,7 +45,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
             control = new DeviceExplorerControl();
             base.Content = control;
 
-            BitmapImageMoniker = NanoFrameworkMonikers.NanoFramework;
+            BitmapImageMoniker = NanoFrameworkMoniker.NanoFramework;
 
             // set the toolbar for this control
             ToolBar = new CommandID(new Guid(DeviceExplorerCommand.guidDeviceExplorerCmdSet), DeviceExplorerCommand.DeviceExplorerToolbarID);

--- a/vs-extension.shared/ToolWindow.DeviceExplorer/DeviceExplorerCommand.cs
+++ b/vs-extension.shared/ToolWindow.DeviceExplorer/DeviceExplorerCommand.cs
@@ -85,7 +85,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
         OleMenuCommandService MenuCommandService;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="DisableDeviceWatchersHandler"/> class.
+        /// Initializes a new instance of the <see cref="DeviceExplorerCommand"/> class.
         /// Adds our command handlers for menu (commands must exist in the command table file)
         /// </summary>
         /// <param name="package">Owner package, not null.</param>

--- a/vs-extension.shared/vs-extension.shared.projitems
+++ b/vs-extension.shared/vs-extension.shared.projitems
@@ -67,7 +67,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)NanoDeviceCommService\INanoDeviceCommService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NanoDeviceCommService\NanoDeviceCommService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NanoDeviceCommService\SNanoDeviceCommService.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)NanoFrameworkMonikers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ProjectSystem\GlobalPropertiesProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ProjectSystem\NanoCSharpProjectConfigured.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ProjectSystem\NanoCSharpProjectUnconfigured.cs" />


### PR DESCRIPTION
## Description
- Rework declaration of package GUID for VS2022.
- Move NanoFrameworkMonikers to each extension project (because of compilation).
- Rename for consistency.
- Update code and xaml controls accordingly.
- Fix guid in imagemanifest.
- Bump versions.

## Motivation and Context
- Another stab on fixing the missing icons in VS2022.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
