### PR TITLE
Now checking for null ref before trying to select device

### DIFF
--- a/VisualStudio.Extension-2019/ToolWindow.DeviceExplorer/DeviceExplorerControl.xaml.cs
+++ b/VisualStudio.Extension-2019/ToolWindow.DeviceExplorer/DeviceExplorerControl.xaml.cs
@@ -10,7 +10,6 @@ namespace nanoFramework.Tools.VisualStudio.Extension
     using nanoFramework.Tools.Debugger;
     using nanoFramework.Tools.VisualStudio.Extension.ToolWindow.ViewModel;
     using System;
-    using System.Threading;
     using System.Windows.Controls;
 
     /// <summary>
@@ -104,7 +103,11 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                     // need to disable the event handler otherwise it will mess the selection
                     deviceTreeView.SelectedItemChanged -= DevicesTreeView_SelectedItemChanged;
 
-                    deviceItem.IsSelected = true;
+
+                    if (deviceItem != null)
+                    {
+                        deviceItem.IsSelected = true;
+                    }
 
                     // enabled it back
                     deviceTreeView.SelectedItemChanged += DevicesTreeView_SelectedItemChanged;

--- a/VisualStudio.Extension-2022/ToolWindow.DeviceExplorer/DeviceExplorerControl.xaml.cs
+++ b/VisualStudio.Extension-2022/ToolWindow.DeviceExplorer/DeviceExplorerControl.xaml.cs
@@ -10,7 +10,6 @@ namespace nanoFramework.Tools.VisualStudio.Extension
     using nanoFramework.Tools.Debugger;
     using nanoFramework.Tools.VisualStudio.Extension.ToolWindow.ViewModel;
     using System;
-    using System.Threading;
     using System.Windows.Controls;
 
     /// <summary>
@@ -104,7 +103,10 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                     // need to disable the event handler otherwise it will mess the selection
                     deviceTreeView.SelectedItemChanged -= DevicesTreeView_SelectedItemChanged;
 
-                    deviceItem.IsSelected = true;
+                    if (deviceItem != null)
+                    {
+                        deviceItem.IsSelected = true;
+                    }
 
                     // enabled it back
                     deviceTreeView.SelectedItemChanged += DevicesTreeView_SelectedItemChanged;


### PR DESCRIPTION
## Description
- Add null check before accessing the property.

## Motivation and Context
- Fixes potential issue in transitory situations where there could be no device.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
