### PR TITLE
Fix issue with device capabilities output after 1st output

### DIFF
--- a/vs-extension.shared/ToolWindow.DeviceExplorer/DeviceExplorerCommand.cs
+++ b/vs-extension.shared/ToolWindow.DeviceExplorer/DeviceExplorerCommand.cs
@@ -384,21 +384,22 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                     // only query device if it's different 
                     if (descriptionBackup.GetHashCode() != ViewModelLocator.DeviceExplorer.LastDeviceConnectedHash)
                     {
-                        // keep device description hash code to avoid get info twice
-                        ViewModelLocator.DeviceExplorer.LastDeviceConnectedHash = descriptionBackup.GetHashCode();
-
                         // check if debugger engine exists
                         if (NanoDeviceCommService.Device.DebugEngine == null)
                         {
                             NanoDeviceCommService.Device.CreateDebugEngine();
                         }
 
-
                         // connect to the device
                         if (NanoDeviceCommService.Device.DebugEngine.Connect(
                             false,
                             true))
                         {
+                            // keep device description hash code to avoid get info twice
+                            ViewModelLocator.DeviceExplorer.LastDeviceConnectedHash = descriptionBackup.GetHashCode();
+                            // also store connection source
+                            ViewModelLocator.DeviceExplorer.LastDeviceConnectionSource = NanoDeviceCommService.Device.DebugEngine.ConnectionSource;
+
                             // check that we are in CLR
                             if (NanoDeviceCommService.Device.DebugEngine.IsConnectedTonanoCLR)
                             {
@@ -490,8 +491,12 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                             return;
                         }
                     }
+                    else
+                    {
 
-                    if (NanoDeviceCommService.Device.DebugEngine.IsConnectedTonanoCLR)
+                    }
+
+                    if (ViewModelLocator.DeviceExplorer.LastDeviceConnectionSource == ConnectionSource.nanoCLR)
                     {
                         // CLR, output full details
                         MessageCentre.OutputMessage(string.Empty);
@@ -513,7 +518,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                         MessageCentre.OutputMessage(ViewModelLocator.DeviceExplorer.DeviceDeploymentMap.ToString());
                         MessageCentre.OutputMessage(string.Empty);
                     }
-                    else
+                    else if (ViewModelLocator.DeviceExplorer.LastDeviceConnectionSource == ConnectionSource.nanoBooter)
                     {
                         // booter, can only output minimal details
 
@@ -521,6 +526,10 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                         MessageCentre.OutputMessage(string.Empty);
                         MessageCentre.OutputMessage("Target Information");
                         MessageCentre.OutputMessage(ViewModelLocator.DeviceExplorer.TargetInfo.ToString());
+                    }
+                    else
+                    {
+                        // shouldn't get here...
                     }
                 }
                 catch

--- a/vs-extension.shared/ToolWindow.DeviceExplorer/ViewModel/DeviceExplorerViewModel.cs
+++ b/vs-extension.shared/ToolWindow.DeviceExplorer/ViewModel/DeviceExplorerViewModel.cs
@@ -42,6 +42,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension.ToolWindow.ViewModel
 
         // for serial devices we wait 10 seconds for the device to be available again
         private const int SerialDeviceReconnectMaximumAttempts = 4 * 10;
+        private ConnectionSource _lastDeviceConnectionSource;
 
         // keep this here otherwise Fody won't be able to properly implement INotifyPropertyChanging
 #pragma warning disable 67
@@ -304,6 +305,29 @@ namespace nanoFramework.Tools.VisualStudio.Extension.ToolWindow.ViewModel
         /// used to prevent repeated retrieval of device capabilities after connection
         /// </summary>
         public int LastDeviceConnectedHash { get; set; }
+
+        /// <summary>
+        /// used to store connection information about a previously connect device
+        /// </summary>
+        public ConnectionSource LastDeviceConnectionSource 
+        { 
+            get
+            {
+                if (LastDeviceConnectedHash != 0)
+                {
+                    return _lastDeviceConnectionSource;
+                }
+                else
+                {
+                    return ConnectionSource.Unknown;
+                }
+            }
+
+            set
+            {
+                _lastDeviceConnectionSource = value;
+            }
+        }
 
         #endregion
 


### PR DESCRIPTION
## Description
- Add code to store/update connection source of a device.
- Improve code that outputs dev caps.

## Motivation and Context
- Output of dev caps wasn't working on subsequent clicks after the 1st one.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
