### PR TITLE
MAC address field editability fixed

### DIFF
--- a/VisualStudio.Extension-2019/ToolWindow.DeviceExplorer/NetworkConfigurationDialog.xaml
+++ b/VisualStudio.Extension-2019/ToolWindow.DeviceExplorer/NetworkConfigurationDialog.xaml
@@ -123,7 +123,7 @@
                     <!--MAC address-->
                     <Label Grid.Row="0" Grid.Column="0" HorizontalAlignment="Left" Content="MAC address:" Margin="-6,0,0,0" />
                     <xctk:MaskedTextBox Grid.Row="0" Grid.Column="1" HorizontalAlignment="Left" Height="23" Mask="AA\:AA\:AA\:AA\:AA\:AA" VerticalAlignment="Center" VerticalContentAlignment="Center" Width="120" Margin="0,3,0,0" x:Name="MACAddress"
-                                         Text="{Binding DeviceNetworkConfiguration.MacAddress, Converter={StaticResource MacAddressConverter}, ValidatesOnNotifyDataErrors=False}"/>
+                                         Text="{Binding DeviceNetworkConfiguration.MacAddress, Converter={StaticResource MacAddressConverter}, ValidatesOnNotifyDataErrors=False}" IsEnabled="{Binding CanChangeMacAddress}"/>
 
                     <!--Interface type-->
                     <Label Grid.Row="1" Grid.Column="0" HorizontalAlignment="Left" Content="Interface type:" Margin="-6,6,0,0" />

--- a/VisualStudio.Extension-2022/ToolWindow.DeviceExplorer/NetworkConfigurationDialog.xaml
+++ b/VisualStudio.Extension-2022/ToolWindow.DeviceExplorer/NetworkConfigurationDialog.xaml
@@ -123,7 +123,7 @@
                     <!--MAC address-->
                     <Label Grid.Row="0" Grid.Column="0" HorizontalAlignment="Left" Content="MAC address:" Margin="-6,0,0,0" />
                     <xctk:MaskedTextBox Grid.Row="0" Grid.Column="1" HorizontalAlignment="Left" Height="23" Mask="AA\:AA\:AA\:AA\:AA\:AA" VerticalAlignment="Center" VerticalContentAlignment="Center" Width="120" Margin="0,3,0,0" x:Name="MACAddress"
-                                         Text="{Binding DeviceNetworkConfiguration.MacAddress, Converter={StaticResource MacAddressConverter}, ValidatesOnNotifyDataErrors=False}"/>
+                                         Text="{Binding DeviceNetworkConfiguration.MacAddress, Converter={StaticResource MacAddressConverter}, ValidatesOnNotifyDataErrors=False}" IsEnabled="{Binding CanChangeMacAddress}"/>
 
                     <!--Interface type-->
                     <Label Grid.Row="1" Grid.Column="0" HorizontalAlignment="Left" Content="Interface type:" Margin="-6,6,0,0" />

--- a/vs-extension.shared/ToolWindow.DeviceExplorer/ViewModel/DeviceExplorerViewModel.cs
+++ b/vs-extension.shared/ToolWindow.DeviceExplorer/ViewModel/DeviceExplorerViewModel.cs
@@ -340,6 +340,30 @@ namespace nanoFramework.Tools.VisualStudio.Extension.ToolWindow.ViewModel
         public DeviceConfiguration.X509CaRootBundleProperties CaCertificateBundle { get; set; }
         public DeviceConfiguration.X509DeviceCertificatesProperties DeviceCertificate { get; internal set; }
 
+        public bool CanChangeMacAddress
+        {
+
+            get
+            {
+                if (SelectedDevice is null)
+                {
+                    return false;
+                }
+                else
+                {
+                    if (SelectedDevice.DebugEngine != null &&
+                        !SelectedDevice.DebugEngine.Capabilities.IsUnknown)
+                    {
+                        return SelectedDevice.DebugEngine.Capabilities.CanChangeMacAddress;
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                }
+            }
+        }
+
         #endregion
 
         #region messaging tokens


### PR DESCRIPTION
## Description
- Add new property to view model exposing this capability.
- Bind MAC address field in network config dialog to this.

## Motivation and Context
- MAC address is now editable only when the target allows it.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
