### PR TITLE
Fix default values for Network Dialog

### DIFF
--- a/VisualStudio.Extension-2019/IPMaskedTextBox/IPMaskedTextBox.xaml.cs
+++ b/VisualStudio.Extension-2019/IPMaskedTextBox/IPMaskedTextBox.xaml.cs
@@ -21,6 +21,8 @@ namespace nanoFramework.Tools.VisualStudio.Extension
     /// </summary>
     public partial class IPMaskedTextBox : UserControl
     {
+        private static readonly IPAddress EmptyIPAddress = new IPAddress(0x0);
+
         #region class variables and properties
 
         #region public variables and properties
@@ -47,7 +49,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
         {
             address = value;
 
-            if (address != IPAddress.None)
+            if (address != EmptyIPAddress)
             {
                 var addressBytes = address.GetAddressBytes();
 

--- a/VisualStudio.Extension-2019/ToolWindow.DeviceExplorer/NetworkConfigurationDialog.xaml.cs
+++ b/VisualStudio.Extension-2019/ToolWindow.DeviceExplorer/NetworkConfigurationDialog.xaml.cs
@@ -19,7 +19,9 @@ namespace nanoFramework.Tools.VisualStudio.Extension
     /// </summary>
     public partial class NetworkConfigurationDialog : DialogWindow
     {
-        private static IPAddress _InvalidIPv4 = new IPAddress(0x0);
+        private static readonly IPAddress EmptyIPAddress = new IPAddress(0x0);
+        private static readonly IPAddress DefaultMaskIPv4 = new IPAddress(new byte[] { 255, 255, 255, 0 });
+
         private DeviceExplorerViewModel DeviceExplorerViewModel => DataContext as DeviceExplorerViewModel;
 
         public NetworkConfigurationDialog(string helpTopic) : base(helpTopic)
@@ -54,17 +56,17 @@ namespace nanoFramework.Tools.VisualStudio.Extension
             {
                 IPv4Automatic.IsChecked = true;
 
-                IPv4Address.SetAddress(IPAddress.None);
-                IPv4NetMask.SetAddress(IPAddress.None);
-                IPv4GatewayAddress.SetAddress(IPAddress.None);
+                IPv4Address.SetAddress(EmptyIPAddress);
+                IPv4NetMask.SetAddress(DefaultMaskIPv4);
+                IPv4GatewayAddress.SetAddress(EmptyIPAddress);
             }
             else
             {
                 IPv4Manual.IsChecked = true;
 
-                IPv4Address.SetAddress(networkConfiguration.IPv4Address ?? IPAddress.None);
-                IPv4NetMask.SetAddress(networkConfiguration.IPv4NetMask ?? IPAddress.None);
-                IPv4GatewayAddress.SetAddress(networkConfiguration.IPv4GatewayAddress ?? IPAddress.None);
+                IPv4Address.SetAddress(networkConfiguration.IPv4Address ?? EmptyIPAddress);
+                IPv4NetMask.SetAddress(networkConfiguration.IPv4NetMask ?? DefaultMaskIPv4);
+                IPv4GatewayAddress.SetAddress(networkConfiguration.IPv4GatewayAddress ?? EmptyIPAddress);
             }
 
             // DNS is automatic?
@@ -72,15 +74,15 @@ namespace nanoFramework.Tools.VisualStudio.Extension
             {
                 IPv4DnsAutomatic.IsChecked = true;
 
-                IPv4Dns1Address.SetAddress(IPAddress.None);
-                IPv4Dns2Address.SetAddress(IPAddress.None);
+                IPv4Dns1Address.SetAddress(EmptyIPAddress);
+                IPv4Dns2Address.SetAddress(EmptyIPAddress);
             }
             else
             {
                 IPv4DnsManual.IsChecked = true;
 
-                IPv4Dns1Address.SetAddress(networkConfiguration.IPv4DNSAddress1 ?? IPAddress.None);
-                IPv4Dns2Address.SetAddress(networkConfiguration.IPv4DNSAddress2 ?? IPAddress.None);
+                IPv4Dns1Address.SetAddress(networkConfiguration.IPv4DNSAddress1 ?? EmptyIPAddress);
+                IPv4Dns2Address.SetAddress(networkConfiguration.IPv4DNSAddress2 ?? EmptyIPAddress);
             }
 
             // wireless configuration/properties
@@ -123,9 +125,9 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 networkConfigurationToSave.StartupAddressMode = AddressMode.DHCP;
 
                 // clear remaining options
-                networkConfigurationToSave.IPv4Address = IPAddress.None;
-                networkConfigurationToSave.IPv4NetMask = IPAddress.None;
-                networkConfigurationToSave.IPv4GatewayAddress = IPAddress.None;
+                networkConfigurationToSave.IPv4Address = EmptyIPAddress;
+                networkConfigurationToSave.IPv4NetMask = DefaultMaskIPv4;
+                networkConfigurationToSave.IPv4GatewayAddress = EmptyIPAddress;
             }
             else
             {
@@ -145,8 +147,8 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 networkConfigurationToSave.AutomaticDNS = true;
 
                 // clear DNS addresses
-                networkConfigurationToSave.IPv4DNSAddress1 = IPAddress.None;
-                networkConfigurationToSave.IPv4DNSAddress2 = IPAddress.None;
+                networkConfigurationToSave.IPv4DNSAddress1 = EmptyIPAddress;
+                networkConfigurationToSave.IPv4DNSAddress2 = EmptyIPAddress;
             }
             else
             {
@@ -159,23 +161,27 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
             // IPv6 options are not being handled for now
             // FIXME
-            networkConfigurationToSave.IPv6Address = IPAddress.None;
-            networkConfigurationToSave.IPv6NetMask = IPAddress.None;
-            networkConfigurationToSave.IPv6GatewayAddress = IPAddress.None;
-            networkConfigurationToSave.IPv6DNSAddress1 = IPAddress.None;
-            networkConfigurationToSave.IPv6DNSAddress2 = IPAddress.None;
+            networkConfigurationToSave.IPv6Address = EmptyIPAddress;
+            networkConfigurationToSave.IPv6NetMask = EmptyIPAddress;
+            networkConfigurationToSave.IPv6GatewayAddress = EmptyIPAddress;
+            networkConfigurationToSave.IPv6DNSAddress1 = EmptyIPAddress;
+            networkConfigurationToSave.IPv6DNSAddress2 = EmptyIPAddress;
 
-            // check MAC address
-            try
+            // process MAC address, if that can be updated
+            if (DeviceExplorerViewModel.CanChangeMacAddress)
             {
-                var newMACAddress = MACAddress.Text;
-                var newMACAddressArray = newMACAddress.Split(':');
-                var dummyMacAddress = newMACAddressArray.Select(a => byte.Parse(a, System.Globalization.NumberStyles.HexNumber)).ToArray();
-            }
-            catch (Exception ex)
-            {
-                // error parsing MAC address field
-                throw new Exception("Invalid MAC address format. Check value.");
+                // check MAC address
+                try
+                {
+                    var newMACAddress = MACAddress.Text;
+                    var newMACAddressArray = newMACAddress.Split(':');
+                    var dummyMacAddress = newMACAddressArray.Select(a => byte.Parse(a, System.Globalization.NumberStyles.HexNumber)).ToArray();
+                }
+                catch (Exception ex)
+                {
+                    // error parsing MAC address field
+                    throw new Exception("Invalid MAC address format. Check value.");
+                }
             }
 
             // Wi-Fi config

--- a/VisualStudio.Extension-2022/IPMaskedTextBox/IPMaskedTextBox.xaml.cs
+++ b/VisualStudio.Extension-2022/IPMaskedTextBox/IPMaskedTextBox.xaml.cs
@@ -21,6 +21,8 @@ namespace nanoFramework.Tools.VisualStudio.Extension
     /// </summary>
     public partial class IPMaskedTextBox : UserControl
     {
+        private static readonly IPAddress EmptyIPAddress = new IPAddress(0x0);
+
         #region class variables and properties
 
         #region public variables and properties
@@ -47,7 +49,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
         {
             address = value;
 
-            if (address != IPAddress.None)
+            if (address != EmptyIPAddress)
             {
                 var addressBytes = address.GetAddressBytes();
 


### PR DESCRIPTION
## Description
- Empty IP address are now 0.0.0.0 and default mask is 255.255.255.0.

## Motivation and Context
- The defaults were wrongly using IPAddress.Empty which is 255.255.255.255.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
