### PR TITLE
Fix category name of templates

### DIFF
--- a/CSharp.AssemblyInfoTemplate/CSharp.AssemblyInfoTemplate.vstemplate
+++ b/CSharp.AssemblyInfoTemplate/CSharp.AssemblyInfoTemplate.vstemplate
@@ -3,7 +3,7 @@
   <TemplateData>
     <!--<Name Package="{FAE04EC1-301F-11d3-BF4B-00C04F79EFBC}" ID="2405" />-->
     <!--<Description Package="{FAE04EC1-301F-11d3-BF4B-00C04F79EFBC}" ID="2406" />-->
-    <Name>Assembly Information File (nanoFramework)</Name>
+    <Name>Assembly Information File (.NET nanoFramework)</Name>
     <Description>A file containing general assembly information for a .NET nanoFramework project.</Description>
     <AppliesTo>CSharp</AppliesTo>
     <Icon>CSAssemblyInfoFile.ico</Icon>

--- a/CSharp.BlankApplication/CS.BlankApplication-vs2019.vstemplate
+++ b/CSharp.BlankApplication/CS.BlankApplication-vs2019.vstemplate
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VSTemplate Version="3.0.0" Type="Project" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
   <TemplateData>
-    <Name>Blank Application (nanoFramework)</Name>
+    <Name>Blank Application (.NET nanoFramework)</Name>
     <Description>A project for a .NET nanoFramework application to be deployed into a target board.</Description>
     <Icon>CSApplication.ico</Icon>
     <ProjectType>CSharp</ProjectType>

--- a/CSharp.BlankApplication/CS.BlankApplication-vs2022.vstemplate
+++ b/CSharp.BlankApplication/CS.BlankApplication-vs2022.vstemplate
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VSTemplate Version="3.0.0" Type="Project" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
   <TemplateData>
-    <Name>Blank Application (nanoFramework)</Name>
+    <Name>Blank Application (.NET nanoFramework)</Name>
     <Description>A project for a .NET nanoFramework application to be deployed into a target board.</Description>
     <Icon>CSApplication.ico</Icon>
     <ProjectType>CSharp</ProjectType>

--- a/CSharp.ClassLibrary/CS.ClassLibrary-vs2019.vstemplate
+++ b/CSharp.ClassLibrary/CS.ClassLibrary-vs2019.vstemplate
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VSTemplate Version="3.0.0" Type="Project" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
   <TemplateData>
-    <Name>Class Library (nanoFramework)</Name>
+    <Name>Class Library (.NET nanoFramework)</Name>
     <Description>A project for a .NET nanoFramework class library (DLL) to be used in other projects.</Description>
     <Icon>CSLibrary.ico</Icon>
     <ProjectType>CSharp</ProjectType>

--- a/CSharp.ClassLibrary/CS.ClassLibrary-vs2022.vstemplate
+++ b/CSharp.ClassLibrary/CS.ClassLibrary-vs2022.vstemplate
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VSTemplate Version="3.0.0" Type="Project" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
   <TemplateData>
-    <Name>Class Library (nanoFramework)</Name>
+    <Name>Class Library (.NET nanoFramework)</Name>
     <Description>A project for a .NET nanoFramework class library (DLL) to be used in other projects.</Description>
     <Icon>CSLibrary.ico</Icon>
     <ProjectType>CSharp</ProjectType>

--- a/CSharp.ClassTemplate/CSharp.ClassTemplate.vstemplate
+++ b/CSharp.ClassTemplate/CSharp.ClassTemplate.vstemplate
@@ -3,7 +3,7 @@
   <TemplateData>
     <!--<Name Package="{FAE04EC1-301F-11d3-BF4B-00C04F79EFBC}" ID="2245" />-->
     <!--<Description Package="{FAE04EC1-301F-11d3-BF4B-00C04F79EFBC}" ID="2262" />-->
-    <Name>Class definition (nanoFramework)</Name>
+    <Name>Class definition (.NET nanoFramework)</Name>
     <Description>An empty .NET nanoFramework class definition.</Description>
     <AppliesTo>CSharp</AppliesTo>
     <TemplateID>2202056b-59a6-4362-b498-df418a940084</TemplateID>

--- a/CSharp.ResourceTemplate/CSharp.ResourceTemplate.vstemplate
+++ b/CSharp.ResourceTemplate/CSharp.ResourceTemplate.vstemplate
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010" Type="Item">
   <TemplateData>
-    <Name>Resource File (nanoFramework)</Name>
+    <Name>Resource File (.NET nanoFramework)</Name>
     <Description>A file for storing nanoFramework resources.</Description>
 	  <AppliesTo>CSharp</AppliesTo>
     <Icon>FileGroup.ico</Icon>


### PR DESCRIPTION
## Description
- Category name was missing .NET.

## Motivation and Context
- Fix lack of consistency on templates storage.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
