### PR TITLE
Add CommandLineArgsForDesignTimeEvaluation property to project system

### DIFF
--- a/VisualStudio.Extension-2022/Rules/general.xaml
+++ b/VisualStudio.Extension-2022/Rules/general.xaml
@@ -43,4 +43,7 @@
 
     <StringProperty Name="SourceDirectory" Subtype="Folder"/>
 
+    <StringProperty Name="CommandLineArgsForDesignTimeEvaluation"
+                  Visible="False" />
+
 </Rule>

--- a/VisualStudio.Extension-2022/Targets/NFProjectSystem.CSharp.targets
+++ b/VisualStudio.Extension-2022/Targets/NFProjectSystem.CSharp.targets
@@ -127,6 +127,11 @@ from generating the TargetFrameworkMonikerAttribute file. All the rest (such as 
     <CompilerResponseFile Condition="'$(IsCoreAssembly)' == 'true'">$(ProjectDir)coreAssembly.rsp</CompilerResponseFile>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <CommandLineArgsForDesignTimeEvaluation>-langversion:$(LangVersion)</CommandLineArgsForDesignTimeEvaluation>
+    <CommandLineArgsForDesignTimeEvaluation Condition="'$(DefineConstants)' != ''">$(CommandLineArgsForDesignTimeEvaluation) -define:$(DefineConstants)</CommandLineArgsForDesignTimeEvaluation>
+  </PropertyGroup>
+
   <!-- Import MetaDataProcessor targets **AFTER** everything else-->
   <Import Project="$(MSBuildThisFileDirectory)\NFProjectSystem.MDP.targets" />
 


### PR DESCRIPTION
## Description
- Add CommandLineArgsForDesignTimeEvaluation property to targets and rule file.

## Motivation and Context
- Fixes nanoframework/Home#1125.
- Required to fix blocking issue loading nfproj after release of VS 17.3.
- Following dotnet/roslyn#60855.
- Fix for reported issue in [Developer Community](https://developercommunity.visualstudio.com/t/NET-nanoFramework-extension-broken-on-1/10116629)

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Locally build in VS experimental issue and mainstream one.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
