### PR TITLE
Only check for supported bitmaps, all other images types are entered as byte arrays

### DIFF
--- a/Tools.BuildTasks-2019/ProcessResourceFiles.cs
+++ b/Tools.BuildTasks-2019/ProcessResourceFiles.cs
@@ -906,35 +906,22 @@ namespace nanoFramework.Tools
                         bool imageJPeg = false;
                         bool imageGif = false;
                         bool imageBmp = false;
-                        bool imageIcon = false;
                         try
                         {
                             bitmapImage = Image.FromStream(new MemoryStream(rawValue)) as Bitmap;
                             imageJPeg = bitmapImage.RawFormat.Equals(ImageFormat.Jpeg);
                             imageGif = bitmapImage.RawFormat.Equals(ImageFormat.Gif);
                             imageBmp = bitmapImage.RawFormat.Equals(ImageFormat.Bmp);
-                            imageIcon = bitmapImage.RawFormat.Equals(ImageFormat.Icon);
                         }
                         catch
                         {
-                            // Ignore error if not a bitmap
+                            // Ignore error if not a known supported bitmap
                         }
                         // read raw content so it can be saved as a binary entry resource (byte[])
                         if (imageJPeg || imageGif || imageBmp)
                         {
                             entry = new BitmapEntry(name, bitmapImage);
     
-                        }
-                        else if (imageIcon)
-                        {
-                            // this is an ICO, treat as a binary resource (byte[])
-                            using (MemoryStream stream = new MemoryStream())
-                            {
-                                // save to rawValue as byte[]
-                                bitmapImage.Save(stream, ImageFormat.Icon);
-                                stream.Capacity = (int)stream.Length;
-                                entry = new BinaryEntry(name, stream.GetBuffer());
-                            }
                         }
                         else if (rawValue != null)
                         {
@@ -953,7 +940,6 @@ namespace nanoFramework.Tools
                             }
                         }
                         break;
-
                     case "MemoryStream":
                         // Examples  - .wav
                         // this is a binary resource


### PR DESCRIPTION
## Description
Removed the check of Icon as a bitmap and reverted it to as a binary entry in the resource file/

## Motivation and Context
Fixes a problem with the Icon resources

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
. Added resources of vaious file types and images and checked that an entry in the resource designer 
has the appropriate c# code generated 

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
