### PR TITLE
Improve async package init

### DIFF
--- a/VisualStudio.Extension-2022/NanoFrameworkPackage.cs
+++ b/VisualStudio.Extension-2022/NanoFrameworkPackage.cs
@@ -395,6 +395,9 @@ namespace nanoFramework.Tools.VisualStudio.Extension
         }
 
         private static string s_SettingVirtualDevicePort = null;
+        private static INanoDeviceCommService _nanoDeviceCommService;
+        private static IVirtualDeviceService _virtualDeviceService;
+
         /// <summary>
         /// Setting to store COM port for the virtual device
         /// The value is persisted per user.
@@ -427,13 +430,41 @@ namespace nanoFramework.Tools.VisualStudio.Extension
         /// Provides direct access to <see cref="INanoDeviceCommService"/> service.
         /// To be used by providers and other classes in the package.
         /// </summary>
-        public static INanoDeviceCommService NanoDeviceCommService { get; private set; }
+        public static INanoDeviceCommService NanoDeviceCommService 
+        {
+            get
+            {
+                if (_nanoDeviceCommService is null)
+                {
+                    _nanoDeviceCommService = ThreadHelper.JoinableTaskFactory.Run(async delegate
+                    {
+                        return await s_instance.GetServiceAsync(typeof(NanoDeviceCommService)) as INanoDeviceCommService;
+                    });
+                }
+
+                return _nanoDeviceCommService;
+            }
+        }
 
         /// <summary>
         /// Provides direct access to <see cref="IVirtualDeviceService"/> service.
         /// To be used by providers and other classes in the package.
         /// </summary>
-        internal static IVirtualDeviceService VirtualDeviceService { get; private set; }
+        internal static IVirtualDeviceService VirtualDeviceService 
+        {
+            get
+            {
+                if (_virtualDeviceService is null)
+                {
+                    _virtualDeviceService = ThreadHelper.JoinableTaskFactory.Run(async delegate
+                    {
+                        return await s_instance.GetServiceAsync(typeof(VirtualDeviceService)) as IVirtualDeviceService;
+                    });
+                }
+
+                return _virtualDeviceService;
+            }
+        }
 
         private static NanoFrameworkPackage s_instance { get; set; }
 
@@ -449,12 +480,19 @@ namespace nanoFramework.Tools.VisualStudio.Extension
         /// </summary>
         public NanoFrameworkPackage()
         {
-
             // fill the property holding the extension install directory
             var assembly = GetType().Assembly;
-            if (assembly.Location == null) throw new Exception("Could not get assembly location!");
+            if (assembly.Location == null)
+            {
+                throw new FileNotFoundException("Could not find location of VS extension assembly!");
+            }
+
             var info = new FileInfo(assembly.Location).Directory;
-            if (info == null) throw new Exception("Could not get assembly directory!");
+            if (info == null)
+            {
+                throw new FileNotFoundException("Could not find directory location of VS extension assembly!");
+            }
+
             NanoFrameworkExtensionDirectory = info.FullName;
 
             // fill the property of the DLL version
@@ -474,17 +512,11 @@ namespace nanoFramework.Tools.VisualStudio.Extension
         /// <returns>A task representing the async work of package initialization, or an already completed task if there is none. Do not return null from this method.</returns>
         protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
-            // make sure "our" key exists and it's writeable
+            // make sure "our" key exists and it's writable
             s_instance.UserRegistryRoot.CreateSubKey(EXTENSION_SUBKEY, true);
-
-            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-
+ 
             AddService(typeof(NanoDeviceCommService), CreateNanoDeviceCommServiceAsync);
             AddService(typeof(VirtualDeviceService), CreateVirtualDeviceManagerServiceAsync);
-
-            NanoDeviceCommService = await GetServiceAsync(typeof(NanoDeviceCommService)) as INanoDeviceCommService;
-            VirtualDeviceService = await GetServiceAsync(typeof(VirtualDeviceService)) as IVirtualDeviceService;
-            Assumes.Present(VirtualDeviceService);
 
             ViewModelLocator viewModelLocator = null;
 
@@ -504,16 +536,14 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
             await MessageCentre.InitializeAsync(this, ".NET nanoFramework Extension");
 
-            await DeviceExplorerCommand.InitializeAsync(this, viewModelLocator);
             DeployProvider.Initialize(this, viewModelLocator);
             UpdateManager.Initialize(this, viewModelLocator);
 
             // Enable debugger UI context
             UIContext.FromUIContextGuid(CorDebug.EngineGuid).IsActive = true;
 
-            VirtualDeviceService.InitVirtualDeviceAsync().FireAndForget();
-
-            OutputWelcomeMessage();
+            await DeviceExplorerCommand.InitializeAsync(this, viewModelLocator);
+            await VirtualDeviceService.InitVirtualDeviceAsync();
         }
 
         #endregion
@@ -541,40 +571,6 @@ namespace nanoFramework.Tools.VisualStudio.Extension
             });
 
             return service;
-        }
-
-        private void OutputWelcomeMessage()
-        {
-            _ = System.Threading.Tasks.Task.Run(async () =>
-            {
-                // schedule this to wait a few seconds (allowing VS to load) before doing it's thing
-                await System.Threading.Tasks.Task.Delay(5000);
-
-                // loaded 
-                MessageCentre.OutputMessage($"** .NET nanoFramework extension v{NanoFrameworkExtensionVersion.ToString()} loaded **");
-
-                // intro messages
-                MessageCentre.OutputMessage("GitHub repo: https://github.com/nanoframework/Home");
-                MessageCentre.OutputMessage("Report issues: https://github.com/nanoframework/Home/issues");
-                MessageCentre.OutputMessage("Browse samples: https://github.com/nanoframework/samples");
-                MessageCentre.OutputMessage("Join our Discord community: https://discord.gg/gCyBu8T");
-                MessageCentre.OutputMessage("Join our Hackster.io platform: https://www.hackster.io/nanoframework");
-                MessageCentre.OutputMessage("Follow us on Twitter: https://twitter.com/nanoframework");
-                MessageCentre.OutputMessage("Follow our YouTube channel: https://www.youtube.com/c/nanoFramework");
-                MessageCentre.OutputMessage("Star our GitHub repos: https://github.com/nanoframework/Home");
-                MessageCentre.OutputMessage("Add a short review or rate the VS extension: https://marketplace.visualstudio.com/items?itemName=nanoframework.nanoFramework-VS2022-Extension");
-                MessageCentre.OutputMessage(Environment.NewLine);
-
-                // check device watchers option
-                if (OptionDisableDeviceWatchers)
-                {
-                    MessageCentre.OutputMessage(Environment.NewLine);
-                    MessageCentre.OutputMessage("*******************************************************************************");
-                    MessageCentre.OutputMessage("** Device Watchers are DISABLED. Won't be able to connect to any nanoDevice. **");
-                    MessageCentre.OutputMessage("*******************************************************************************");
-                    MessageCentre.OutputMessage(Environment.NewLine);
-                }
-            });
         }
 
         private int LaunchNanoDebug(uint nCmdExecOpt, IntPtr pvaIn, IntPtr pvaOut)

--- a/vs-extension.shared/ToolWindow.DeviceExplorer/DeviceExplorerCommand.cs
+++ b/vs-extension.shared/ToolWindow.DeviceExplorer/DeviceExplorerCommand.cs
@@ -139,7 +139,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
             Instance.ViewModelLocator = vmLocator;
 
-            var commService = await package.GetServiceAsync(typeof(NanoDeviceCommService)) ?? throw new ArgumentNullException(nameof(NanoDeviceCommService));
+            var commService = await package.GetServiceAsync(typeof(NanoDeviceCommService));
 
             Instance.NanoDeviceCommService = commService as INanoDeviceCommService;
 

--- a/vs-extension.shared/VirtualDeviceService/IVirtualDeviceService.cs
+++ b/vs-extension.shared/VirtualDeviceService/IVirtualDeviceService.cs
@@ -12,7 +12,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
         bool NanoClrInstalled { get; }
 
         bool VirtualDeviceIsRunning { get; }
-        
+
         Task InitVirtualDeviceAsync();
 
         void InstallNanoClrTool();

--- a/vs-extension.shared/VirtualDeviceService/VirtualDeviceService.cs
+++ b/vs-extension.shared/VirtualDeviceService/VirtualDeviceService.cs
@@ -22,6 +22,7 @@ using System.Security.Policy;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace nanoFramework.Tools.VisualStudio.Extension
 {
@@ -41,28 +42,32 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
         public async System.Threading.Tasks.Task InitVirtualDeviceAsync()
         {
-            _nanoDeviceCommService = await _serviceProvider.GetServiceAsync(typeof(NanoDeviceCommService)) as INanoDeviceCommService;
-            Assumes.Present(_nanoDeviceCommService);
-
-            if (NanoFrameworkPackage.SettingVirtualDeviceEnable)
+            await System.Threading.Tasks.Task.Run(async () =>
             {
-                // take care of installing/updating nanoclr tool
-                InstallNanoClrTool();
+                _nanoDeviceCommService = await _serviceProvider.GetServiceAsync(typeof(NanoDeviceCommService)) as INanoDeviceCommService;
+                Assumes.Present(_nanoDeviceCommService);
 
-                if (NanoFrameworkPackage.SettingVirtualDeviceAutoUpdateNanoClrImage)
+                if (NanoFrameworkPackage.SettingVirtualDeviceEnable)
                 {
-                    // update nanoCLR image
-                    UpdateNanoClr();
+                    // take care of installing/updating nanoclr tool
+                    InstallNanoClrTool();
+
+                    if (NanoFrameworkPackage.SettingVirtualDeviceAutoUpdateNanoClrImage)
+                    {
+                        // update nanoCLR image
+                        UpdateNanoClr();
+                    }
+
+                    // start virtual device
+                    await StartVirtualDeviceAsync(false);
                 }
 
-                // start virtual device
-                await StartVirtualDeviceAsync(false);
-            }
-
-            if (!NanoFrameworkPackage.OptionDisableDeviceWatchers)
-            {
-                _nanoDeviceCommService.DebugClient.StartDeviceWatchers();
-            }
+                if (!NanoFrameworkPackage.OptionDisableDeviceWatchers)
+                {
+                    _nanoDeviceCommService.DebugClient.StartDeviceWatchers();
+                }
+               
+            });
         }
 
         public void InstallNanoClrTool()


### PR DESCRIPTION
## Description
- Move output message block to message centre.
- Simplified several init methods for services.
- Tidy up calls in async package constructor.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
