### PR TITLE
Improve showing Network Configuration dialog

### DIFF
--- a/vs-extension.shared/ToolWindow.DeviceExplorer/DeviceExplorerCommand.cs
+++ b/vs-extension.shared/ToolWindow.DeviceExplorer/DeviceExplorerCommand.cs
@@ -714,6 +714,21 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                             // need to switch to UI main thread
                             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
+                            if (networkConfigurations.Count == 0
+                               && wirellesConfigurations.Count == 0)
+                            {
+                                // no network configuration available: device doesn't have network capabilities
+
+                                _ = MessageBox.Show(
+                                   "Connected nanoDevice doesn't have network capabilities. Can't open Network Configuration dialog.",
+                                   ".NET nanoFramework Device Explorer",
+                                   MessageBoxButton.OK,
+                                   MessageBoxImage.Error);
+
+                                // done here
+                                return;
+                            }
+
                             // show network configuration dialogue
                             var networkConfigDialog = new NetworkConfigurationDialog
                             {


### PR DESCRIPTION
## Description
- Now checks for existing network configurations.
- Shows message box with information about this and doesn't show it anymore.

## Motivation and Context
- Prevents errors and unwanted behaviors when trying to open and update network configuration for devices that don't support it.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
