### PR TITLE
Improvements in virtual device management

### DIFF
--- a/VisualStudio.Extension-2019/ToolWindow.DeviceExplorer/SettingsDialog.xaml
+++ b/VisualStudio.Extension-2019/ToolWindow.DeviceExplorer/SettingsDialog.xaml
@@ -161,7 +161,7 @@
                         </Grid>
                     </GroupBox>
 
-                    <CheckBox x:Name="EnableVirtualDevice"  Grid.Row="0" Margin="10,2,-10,0" Content="Enable Virtual Device"  Height="16" VerticalAlignment="Top" Checked="EnableVirtualSerialDevice_Checked" Unchecked="EnableVirtualSerialDevice_Checked"/>
+                    <CheckBox x:Name="EnableVirtualDevice"  Grid.Row="0" Margin="10,2,-10,0" Content="Enable Virtual Device"  Height="16" VerticalAlignment="Top"/>
 
                 </Grid>
             </TabItem>

--- a/VisualStudio.Extension-2022/ToolWindow.DeviceExplorer/SettingsDialog.xaml
+++ b/VisualStudio.Extension-2022/ToolWindow.DeviceExplorer/SettingsDialog.xaml
@@ -161,7 +161,7 @@
                         </Grid>
                     </GroupBox>
 
-                    <CheckBox x:Name="EnableVirtualDevice"  Grid.Row="0" Margin="10,2,-10,0" Content="Enable Virtual Device"  Height="16" VerticalAlignment="Top" Checked="EnableVirtualSerialDevice_Checked" Unchecked="EnableVirtualSerialDevice_Checked"/>
+                    <CheckBox x:Name="EnableVirtualDevice"  Grid.Row="0" Margin="10,2,-10,0" Content="Enable Virtual Device"  Height="16" VerticalAlignment="Top"/>
 
                 </Grid>
             </TabItem>

--- a/vs-extension.shared/NanoDeviceCommService/NanoDeviceCommService.cs
+++ b/vs-extension.shared/NanoDeviceCommService/NanoDeviceCommService.cs
@@ -28,7 +28,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 {
                     // grab and parse COM port list
                     List<string> serialPortList = new List<string>();
-                    
+
                     // need to wrap the processing in a try/catch to deal with bad user input/format
                     try
                     {
@@ -50,10 +50,10 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                     PortBase networkDebug = PortBase.CreateInstanceForNetwork(false);
 
                     // create composite client with all ports
-                    // DO NOT start device watcher as this will happen after the virtual device is created (if required)
+                    // OK to start device watchers, if setting is enabled
                     _debugClient = PortBase.CreateInstanceForComposite(
                         new[] { serialDebug, networkDebug },
-                        false);
+                        !NanoFrameworkPackage.OptionDisableDeviceWatchers);
                 }
 
                 return _debugClient;

--- a/vs-extension.shared/VirtualDeviceService/IVirtualDeviceService.cs
+++ b/vs-extension.shared/VirtualDeviceService/IVirtualDeviceService.cs
@@ -9,9 +9,11 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 {
     internal interface IVirtualDeviceService
     {
-        bool NanoClrInstalled { get; }
+        bool NanoClrIsInstalled { get; }
 
         bool VirtualDeviceIsRunning { get; }
+
+        bool CanStartVirtualDevice { get; }
 
         Task InitVirtualDeviceAsync();
 


### PR DESCRIPTION
## Description
- Improve start/stop.
- Improve message when instance is already running.
- Device watchers are now started independent of virtual device preferences.
- Upon successful install of nanoclr the virtual device manager now performs a device rescan.
- Improve responsiveness of UI when executing long running operations with virtual device service.
- General improvements in code starting virtual instance.
- Fix regex showing CLR version updated.
- Remove duplicated or confusing messages being written to virtual device output pane.

## Motivation and Context
- General improvements in virtual device following community feedback.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
