### PR TITLE
Improvements in UI responsiveness with virtual device operation

### DIFF
--- a/VisualStudio.Extension-2019/NanoFrameworkPackage.cs
+++ b/VisualStudio.Extension-2019/NanoFrameworkPackage.cs
@@ -544,7 +544,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
             UIContext.FromUIContextGuid(CorDebug.EngineGuid).IsActive = true;
 
             await DeviceExplorerCommand.InitializeAsync(this, viewModelLocator);
-            await VirtualDeviceService.InitVirtualDeviceAsync();
+            VirtualDeviceService.InitVirtualDeviceAsync().FireAndForget();
         }
 
         #endregion

--- a/VisualStudio.Extension-2022/NanoFrameworkPackage.cs
+++ b/VisualStudio.Extension-2022/NanoFrameworkPackage.cs
@@ -543,7 +543,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
             UIContext.FromUIContextGuid(CorDebug.EngineGuid).IsActive = true;
 
             await DeviceExplorerCommand.InitializeAsync(this, viewModelLocator);
-            await VirtualDeviceService.InitVirtualDeviceAsync();
+            VirtualDeviceService.InitVirtualDeviceAsync().FireAndForget(); ;
         }
 
         #endregion

--- a/vs-extension.shared/VirtualDeviceService/VirtualDeviceService.cs
+++ b/vs-extension.shared/VirtualDeviceService/VirtualDeviceService.cs
@@ -72,17 +72,17 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
                 if (NanoFrameworkPackage.SettingVirtualDeviceEnable)
                 {
+                    // wait a little bit to allow other services to load
+                    await System.Threading.Tasks.Task.Delay(5_000);
+
                     // take care of installing/updating nanoclr tool
                     InstallNanoClrTool();
 
-                    if (NanoClrIsInstalled)
+                    if (NanoClrIsInstalled
+                        && NanoFrameworkPackage.SettingVirtualDeviceAutoUpdateNanoClrImage)
                     {
-
-                        if (NanoFrameworkPackage.SettingVirtualDeviceAutoUpdateNanoClrImage)
-                        {
-                            // update nanoCLR image
-                            UpdateNanoClr();
-                        }
+                        // update nanoCLR image
+                        UpdateNanoClr();
                     }
 
                     // start virtual device
@@ -93,7 +93,6 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 {
                     _nanoDeviceCommService.DebugClient.ReScanDevices();
                 }
-
             });
         }
 


### PR DESCRIPTION
## Description
- Fix wrapping of async operations.
- Virtual device init now uses fire and forget on package load.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
