### PR TITLE
Improve virtual device shutdown and restart

### DIFF
--- a/VisualStudio.Extension-2019/NanoFrameworkPackage.cs
+++ b/VisualStudio.Extension-2019/NanoFrameworkPackage.cs
@@ -5,6 +5,7 @@
 
 using GalaSoft.MvvmLight.Ioc;
 using Microsoft;
+using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.ProjectSystem.VS;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -603,6 +604,18 @@ namespace nanoFramework.Tools.VisualStudio.Extension
             VsDebugTargetProcessInfo[] processInfo = new VsDebugTargetProcessInfo[debugTargets.Length];
 
             debugger.LaunchDebugTargets4(1, debugTargets, processInfo);
+        }
+
+        protected override int QueryClose(out bool canClose)
+        {
+            var res = base.QueryClose(out canClose);
+
+            if (canClose)
+            {
+                VirtualDeviceService?.StopVirtualDevice(true);
+            }
+
+            return res;
         }
 
         #region IOleCommandTarget Members

--- a/VisualStudio.Extension-2022/NanoFrameworkPackage.cs
+++ b/VisualStudio.Extension-2022/NanoFrameworkPackage.cs
@@ -604,6 +604,18 @@ namespace nanoFramework.Tools.VisualStudio.Extension
             debugger.LaunchDebugTargets4(1, debugTargets, processInfo);
         }
 
+        protected override int QueryClose(out bool canClose)
+        {
+            var res = base.QueryClose(out canClose);
+
+            if (canClose)
+            {
+                VirtualDeviceService?.StopVirtualDevice(true);
+            }
+
+            return res;
+        }
+
         #region IOleCommandTarget Members
 
         int Microsoft.VisualStudio.OLE.Interop.IOleCommandTarget.Exec(ref Guid cmdGroup, uint nCmdID, uint nCmdExecOpt, IntPtr pvaIn, IntPtr pvaOut)

--- a/vs-extension.shared/DeployProvider/DeployProvider.cs
+++ b/vs-extension.shared/DeployProvider/DeployProvider.cs
@@ -144,6 +144,14 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 MessageCentre.InternalErrorWrite("Connecting to debugger engine...");
                 needsToCloseMessageOutput = true;
 
+                // if this is a serial virtual device, ping to check if it's responsive
+                if (device.Description.StartsWith("Virtual nanoDevice @ COM")
+                    && device.Ping() != Debugger.WireProtocol.ConnectionSource.nanoCLR)
+                {
+                    // doesn't seem to be... better try to launch it
+                    await NanoFrameworkPackage.VirtualDeviceService.StartVirtualDeviceAsync(false);
+                }
+
                 // connect to the device
                 if (device.DebugEngine.Connect(false, true))
                 {

--- a/vs-extension.shared/VirtualDeviceService/IVirtualDeviceService.cs
+++ b/vs-extension.shared/VirtualDeviceService/IVirtualDeviceService.cs
@@ -25,7 +25,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
         bool CreateVirtualSerialPort(string portName, out string executionLog);
 
-        void StopVirtualDevice();
+        void StopVirtualDevice(bool shutdownProcessing = false);
 
         Task<bool> StartVirtualDeviceAsync(bool rescanDevices);
     }


### PR DESCRIPTION
## Description
- On shutdown event handlers are removed before killing the process.
- Process is not nulled anymore on VS shutdown.
- Add handlers for VS shutdown.
- Add code to check and restart virtual device on deployment.
- Other minor improvements in stop virtual device.

## Motivation and Context
- Need more robust start & stop of virtual device.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
