### PR TITLE
Improvements in starting virtual device

### DIFF
--- a/vs-extension.shared/DeployProvider/DeployProvider.cs
+++ b/vs-extension.shared/DeployProvider/DeployProvider.cs
@@ -145,7 +145,9 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 needsToCloseMessageOutput = true;
 
                 // if this is a serial virtual device, ping to check if it's responsive
-                if (device.Description.StartsWith("Virtual nanoDevice @ COM")
+                // this will happen in case the virtual device setting is ON
+                if (NanoFrameworkPackage.SettingVirtualDeviceEnable
+                    && device.Description.StartsWith("Virtual nanoDevice @ COM")
                     && device.Ping() != Debugger.WireProtocol.ConnectionSource.nanoCLR)
                 {
                     // doesn't seem to be... better try to launch it

--- a/vs-extension.shared/VirtualDeviceService/VirtualDeviceService.cs
+++ b/vs-extension.shared/VirtualDeviceService/VirtualDeviceService.cs
@@ -122,7 +122,8 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
                         if (regexResult.Success)
                         {
-                            MessageCentre.InternalErrorWriteLine($"VirtualDevice: Install/update successful v{regexResult.Groups["version"].Value}");
+                            MessageCentre.InternalErrorWriteLine($"VirtualDevice: Install/update successful. Running v{regexResult.Groups["version"].Value}");
+                            MessageCentre.OutputVirtualDeviceMessage($"Running nanoclr v{regexResult.Groups["version"].Value}");
                         }
 
                         NanoClrIsInstalled = true;
@@ -375,7 +376,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 _nanoClrProcess = new Process();
 
                 _nanoClrProcess.StartInfo.FileName = "nanoclr";
-                _nanoClrProcess.StartInfo.Arguments = $"run --serialport {NanoFrameworkPackage.SettingVirtualDevicePort} --monitorparentpid {Process.GetCurrentProcess().Id}";
+                _nanoClrProcess.StartInfo.Arguments = $"run --serialport {NanoFrameworkPackage.SettingVirtualDevicePort} --waitfordebugger --monitorparentpid {Process.GetCurrentProcess().Id}";
                 _nanoClrProcess.StartInfo.UseShellExecute = false;
                 _nanoClrProcess.StartInfo.CreateNoWindow = true;
                 _nanoClrProcess.StartInfo.RedirectStandardOutput = true;


### PR DESCRIPTION
## Description
- Add option to wait for debugger to tool parameters.
- Restarting virtual device will be done only if the setting is ON.
- Add message with nanoclr version at start.

## Motivation and Context
- Improves virtual device start/stop.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
