### PR TITLE
Add support for loading local nanoCLR instance in virtual device

### DIFF
--- a/VisualStudio.Extension-2019/NanoFrameworkPackage.cs
+++ b/VisualStudio.Extension-2019/NanoFrameworkPackage.cs
@@ -112,6 +112,8 @@ namespace nanoFramework.Tools.VisualStudio.Extension
         private const string SETTINGS_ALLOW_PREVIEW_IMAGES_KEY = "IncludePrereleaseUpdates";
         private const string SETTINGS_VIRTUAL_DEVICE_ENABLE_KEY = "VirtualDeviceEnable";
         private const string SETTINGS_VIRTUAL_DEVICE_AUTO_UPDATE_NANOCLR_KEY = "VirtualDeviceAutoUpdateNanoCLR";
+        private const string SETTINGS_VIRTUAL_DEVICE_LOAD_NANOCLR_INSTANCE_KEY = "VirtualDeviceLoadNanoCLRInstance";
+        private const string SETTINGS_VIRTUAL_DEVICE_PATH_OF_NANOCLR_INSTANCE_KEY = "VirtualDevicePathOfNanoCLRInstance";
         private const string SETTINGS_VIRTUAL_DEVICE_PORT = "VirtualDevicePort";
 
         private static bool? s_OptionShowInternalErrors;
@@ -423,6 +425,60 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 s_instance.UserRegistryRoot.OpenSubKey(EXTENSION_SUBKEY, true).Flush();
 
                 s_SettingVirtualDevicePort = value;
+            }
+        }
+
+        private static bool? s_SettingLoadNanoClrInstance = null;
+        /// <summary>
+        /// Setting to enable loading a nanoCLR instance in the virtual device.
+        /// The value is persisted per user
+        /// Default is <see langword="false"/>
+        /// </summary>
+        public static bool SettingLoadNanoClrInstance
+        {
+            get
+            {
+                if (!s_SettingLoadNanoClrInstance.HasValue)
+                {
+                    s_SettingLoadNanoClrInstance = bool.Parse((string)s_instance.UserRegistryRoot.OpenSubKey(EXTENSION_SUBKEY).GetValue(SETTINGS_VIRTUAL_DEVICE_LOAD_NANOCLR_INSTANCE_KEY, "False"));
+                }
+
+                return s_SettingLoadNanoClrInstance.Value;
+
+            }
+            set
+            {
+                s_instance.UserRegistryRoot.OpenSubKey(EXTENSION_SUBKEY, true).SetValue(SETTINGS_VIRTUAL_DEVICE_LOAD_NANOCLR_INSTANCE_KEY, value);
+                s_instance.UserRegistryRoot.OpenSubKey(EXTENSION_SUBKEY, true).Flush();
+
+                s_SettingLoadNanoClrInstance = value;
+            }
+        }
+
+        private static string s_SettingPathOfLocalNanoClrInstance = null;
+        /// <summary>
+        /// Setting to store path where to load nanoCLR instance from.
+        /// The value is persisted per user.
+        /// Default is empty.
+        /// </summary>
+        public static string SettingPathOfLocalNanoClrInstance
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(s_SettingPathOfFlashDumpCache))
+                {
+                    s_SettingPathOfLocalNanoClrInstance = (string)s_instance.UserRegistryRoot.OpenSubKey(EXTENSION_SUBKEY).GetValue(SETTINGS_VIRTUAL_DEVICE_PATH_OF_NANOCLR_INSTANCE_KEY);
+                }
+
+                return s_SettingPathOfLocalNanoClrInstance;
+            }
+
+            set
+            {
+                s_instance.UserRegistryRoot.OpenSubKey(EXTENSION_SUBKEY, true).SetValue(SETTINGS_VIRTUAL_DEVICE_PATH_OF_NANOCLR_INSTANCE_KEY, value);
+                s_instance.UserRegistryRoot.OpenSubKey(EXTENSION_SUBKEY, true).Flush();
+
+                s_SettingPathOfLocalNanoClrInstance = value;
             }
         }
 

--- a/VisualStudio.Extension-2019/ToolWindow.DeviceExplorer/SettingsDialog.xaml
+++ b/VisualStudio.Extension-2019/ToolWindow.DeviceExplorer/SettingsDialog.xaml
@@ -132,6 +132,7 @@
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
 
                             </Grid.RowDefinitions>
                             <Grid.ColumnDefinitions>
@@ -157,6 +158,11 @@
                             </Grid>
                             <Button x:Name="StartStopDevice" Content="Start virtual device" HorizontalAlignment="Left" Click="StartStopDevice_Click" Grid.Row="1" Margin="55,20,0,0" VerticalAlignment="Top" Width="106" Grid.Column="1" />
                             <CheckBox x:Name="AutoUpdateNanoClrImage" Grid.Row="2" Grid.Column="0" HorizontalAlignment="Left"  Margin="4,20,0,0" Content="Auto update nanoCLR image" Grid.ColumnSpan="2" Checked="AutoUpdateNanoClrImage_Checked" Unchecked="AutoUpdateNanoClrImage_Checked" />
+
+                            <!-- setting to allow loading a specific nanoCLR instance  -->
+                            <CheckBox x:Name="LoadNanoClrInstance" Grid.Row="3" Grid.Column="0" HorizontalAlignment="Left"  Margin="4,14,0,0" Content="Load specific nanoCLR instance" Grid.ColumnSpan="2"/>
+                            <TextBox x:Name="PathOfLocalNanoClrInstance" Grid.Row="3" Grid.Column="1" Margin="0,42,64,0" HorizontalAlignment="Stretch" Text="" IsEnabled="False"/>
+                            <Button x:Name="ShowFilePickerLocalNanoClrInstance" Grid.Row="3" Grid.Column="1" HorizontalAlignment="Right" Content=" Browse... " IsEnabled="False" Margin="0,42,0,0" Click="ShowFilePickerForNanoCLRInstance_Click"/>
 
                         </Grid>
                     </GroupBox>

--- a/VisualStudio.Extension-2022/NanoFrameworkPackage.cs
+++ b/VisualStudio.Extension-2022/NanoFrameworkPackage.cs
@@ -112,6 +112,8 @@ namespace nanoFramework.Tools.VisualStudio.Extension
         private const string SETTINGS_ALLOW_PREVIEW_IMAGES_KEY = "IncludePrereleaseUpdates";
         private const string SETTINGS_VIRTUAL_DEVICE_ENABLE_KEY = "VirtualDeviceEnable";
         private const string SETTINGS_VIRTUAL_DEVICE_AUTO_UPDATE_NANOCLR_KEY = "VirtualDeviceAutoUpdateNanoCLR";
+        private const string SETTINGS_VIRTUAL_DEVICE_LOAD_NANOCLR_INSTANCE_KEY = "VirtualDeviceLoadNanoCLRInstance";
+        private const string SETTINGS_VIRTUAL_DEVICE_PATH_OF_NANOCLR_INSTANCE_KEY = "VirtualDevicePathOfNanoCLRInstance";
         private const string SETTINGS_VIRTUAL_DEVICE_PORT = "VirtualDevicePort";
 
         private static bool? s_OptionShowInternalErrors;
@@ -393,6 +395,60 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
                 s_SettingVirtualDeviceEnable = value;
 
+            }
+        }
+
+        private static bool? s_SettingLoadNanoClrInstance = null;
+        /// <summary>
+        /// Setting to enable loading a nanoCLR instance in the virtual device.
+        /// The value is persisted per user
+        /// Default is <see langword="false"/>
+        /// </summary>
+        public static bool SettingLoadNanoClrInstance
+        {
+            get
+            {
+                if (!s_SettingLoadNanoClrInstance.HasValue)
+                {
+                    s_SettingLoadNanoClrInstance = bool.Parse((string)s_instance.UserRegistryRoot.OpenSubKey(EXTENSION_SUBKEY).GetValue(SETTINGS_VIRTUAL_DEVICE_LOAD_NANOCLR_INSTANCE_KEY, "False"));
+                }
+
+                return s_SettingLoadNanoClrInstance.Value;
+
+            }
+            set
+            {
+                s_instance.UserRegistryRoot.OpenSubKey(EXTENSION_SUBKEY, true).SetValue(SETTINGS_VIRTUAL_DEVICE_LOAD_NANOCLR_INSTANCE_KEY, value);
+                s_instance.UserRegistryRoot.OpenSubKey(EXTENSION_SUBKEY, true).Flush();
+
+                s_SettingLoadNanoClrInstance = value;
+            }
+        }
+
+        private static string s_SettingPathOfLocalNanoClrInstance = null;
+        /// <summary>
+        /// Setting to store path where to load nanoCLR instance from.
+        /// The value is persisted per user.
+        /// Default is empty.
+        /// </summary>
+        public static string SettingPathOfLocalNanoClrInstance
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(s_SettingPathOfFlashDumpCache))
+                {
+                    s_SettingPathOfLocalNanoClrInstance = (string)s_instance.UserRegistryRoot.OpenSubKey(EXTENSION_SUBKEY).GetValue(SETTINGS_VIRTUAL_DEVICE_PATH_OF_NANOCLR_INSTANCE_KEY);
+                }
+
+                return s_SettingPathOfLocalNanoClrInstance;
+            }
+
+            set
+            {
+                s_instance.UserRegistryRoot.OpenSubKey(EXTENSION_SUBKEY, true).SetValue(SETTINGS_VIRTUAL_DEVICE_PATH_OF_NANOCLR_INSTANCE_KEY, value);
+                s_instance.UserRegistryRoot.OpenSubKey(EXTENSION_SUBKEY, true).Flush();
+
+                s_SettingPathOfLocalNanoClrInstance = value;
             }
         }
 

--- a/VisualStudio.Extension-2022/ToolWindow.DeviceExplorer/SettingsDialog.xaml
+++ b/VisualStudio.Extension-2022/ToolWindow.DeviceExplorer/SettingsDialog.xaml
@@ -132,6 +132,7 @@
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
 
                             </Grid.RowDefinitions>
                             <Grid.ColumnDefinitions>
@@ -157,6 +158,11 @@
                             </Grid>
                             <Button x:Name="StartStopDevice" Content="Start virtual device" HorizontalAlignment="Left" Click="StartStopDevice_Click" Grid.Row="1" Margin="55,20,0,0" VerticalAlignment="Top" Width="106" Grid.Column="1" />
                             <CheckBox x:Name="AutoUpdateNanoClrImage" Grid.Row="2" Grid.Column="0" HorizontalAlignment="Left"  Margin="4,20,0,0" Content="Auto update nanoCLR image" Grid.ColumnSpan="2" Checked="AutoUpdateNanoClrImage_Checked" Unchecked="AutoUpdateNanoClrImage_Checked" />
+
+                            <!-- setting to allow loading a specific nanoCLR instance  -->
+                            <CheckBox x:Name="LoadNanoClrInstance" Grid.Row="3" Grid.Column="0" HorizontalAlignment="Left"  Margin="4,14,0,0" Content="Load specific nanoCLR instance" Grid.ColumnSpan="2"/>
+                            <TextBox x:Name="PathOfLocalNanoClrInstance" Grid.Row="3" Grid.Column="1" Margin="0,42,64,0" HorizontalAlignment="Stretch" Text="" IsEnabled="False"/>
+                            <Button x:Name="ShowFilePickerLocalNanoClrInstance" Grid.Row="3" Grid.Column="1" HorizontalAlignment="Right" Content=" Browse... " IsEnabled="False" Margin="0,42,0,0" Click="ShowFilePickerForNanoCLRInstance_Click"/>
 
                         </Grid>
                     </GroupBox>

--- a/VisualStudio.Extension-2022/ToolWindow.DeviceExplorer/SettingsDialog.xaml.cs
+++ b/VisualStudio.Extension-2022/ToolWindow.DeviceExplorer/SettingsDialog.xaml.cs
@@ -8,7 +8,6 @@ namespace nanoFramework.Tools.VisualStudio.Extension
     using GalaSoft.MvvmLight.Messaging;
     using Microsoft.VisualStudio.PlatformUI;
     using Microsoft.VisualStudio.Shell;
-    using Microsoft.VisualStudio.Threading;
     using nanoFramework.Tools.VisualStudio.Extension.ToolWindow.ViewModel;
     using System.Collections.Generic;
     using System.Net;
@@ -52,6 +51,8 @@ namespace nanoFramework.Tools.VisualStudio.Extension
             IncludePrereleaseUpdates.IsChecked = NanoFrameworkPackage.SettingIncludePrereleaseUpdates;
             EnableVirtualDevice.IsChecked = NanoFrameworkPackage.SettingVirtualDeviceEnable;
             VirtualDeviceSerialPort.Text = NanoFrameworkPackage.SettingVirtualDevicePort;
+            LoadNanoClrInstance.IsChecked = NanoFrameworkPackage.SettingLoadNanoClrInstance;
+            PathOfLocalNanoClrInstance.Text = NanoFrameworkPackage.SettingPathOfLocalNanoClrInstance;
             AutoUpdateNanoClrImage.IsChecked = NanoFrameworkPackage.SettingVirtualDeviceAutoUpdateNanoClrImage;
 
             if (string.IsNullOrEmpty(NanoFrameworkPackage.SettingPathOfFlashDumpCache))
@@ -69,21 +70,25 @@ namespace nanoFramework.Tools.VisualStudio.Extension
             PortBlackList.Text = NanoFrameworkPackage.SettingPortBlackList;
 
             // update button content for start/stop device depending if it's running or not
+            bool canStartStopVirtualDevice = NanoFrameworkPackage.VirtualDeviceService.CanStartStopVirtualDevice;
+            bool virtualDeviceIsRunning = NanoFrameworkPackage.VirtualDeviceService.VirtualDeviceIsRunning;
+
             if (EnableVirtualDevice.IsChecked.Value
-               && NanoFrameworkPackage.VirtualDeviceService.CanStartVirtualDevice
-               && NanoFrameworkPackage.VirtualDeviceService.VirtualDeviceIsRunning)
+               && virtualDeviceIsRunning)
             {
                 StartStopDevice.Content = _stopVirtualDeviceLabel;
             }
 
             // enable start/stop button if possible
-            StartStopDevice.IsEnabled = NanoFrameworkPackage.VirtualDeviceService.NanoClrIsInstalled
-                                        && NanoFrameworkPackage.VirtualDeviceService.CanStartVirtualDevice;
+            StartStopDevice.IsEnabled = canStartStopVirtualDevice;
+
+            LoadNanoClrInstance.IsEnabled = EnableVirtualDevice.IsChecked.Value;
+            ShowFilePickerLocalNanoClrInstance.IsEnabled = LoadNanoClrInstance.IsEnabled;
 
             if (!string.IsNullOrEmpty(VirtualDeviceSerialPort.Text))
             {
                 // if there is a COM port set, enable the text box only if it's not running
-                VirtualDeviceSerialPort.IsEnabled = !NanoFrameworkPackage.VirtualDeviceService.VirtualDeviceIsRunning;
+                VirtualDeviceSerialPort.IsEnabled = !virtualDeviceIsRunning;
             }
 
             // OK to add event handlers to controls now
@@ -92,6 +97,8 @@ namespace nanoFramework.Tools.VisualStudio.Extension
             VirtualDeviceSerialPort.LostFocus += VirtualDeviceSerialPort_LostFocus;
             EnableVirtualDevice.Checked += EnableVirtualSerialDevice_Checked;
             EnableVirtualDevice.Unchecked += EnableVirtualSerialDevice_Checked;
+            LoadNanoClrInstance.Checked += LoadNanoClrInstance_Checked;
+            LoadNanoClrInstance.Unchecked += LoadNanoClrInstance_Checked;
 
             // set focus on close button
             CloseButton.Focus();
@@ -103,7 +110,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
             StartStopDevice.IsEnabled = !bool.Parse(installCompleted)
                                         && NanoFrameworkPackage.VirtualDeviceService.NanoClrIsInstalled
-                                        && NanoFrameworkPackage.VirtualDeviceService.CanStartVirtualDevice;
+                                        && NanoFrameworkPackage.VirtualDeviceService.CanStartStopVirtualDevice;
         }
 
         private void CloseButton_Click(object sender, System.Windows.RoutedEventArgs e)
@@ -210,6 +217,9 @@ namespace nanoFramework.Tools.VisualStudio.Extension
             // save new state
             NanoFrameworkPackage.SettingVirtualDeviceEnable = (sender as ToggleButton).IsChecked ?? false;
 
+            LoadNanoClrInstance.IsEnabled = (sender as ToggleButton).IsChecked ?? false;
+            ShowFilePickerLocalNanoClrInstance.IsEnabled = LoadNanoClrInstance.IsEnabled;
+
             // install/update nanoclr tool
             if (NanoFrameworkPackage.SettingVirtualDeviceEnable && !NanoFrameworkPackage.VirtualDeviceService.NanoClrIsInstalled)
             {
@@ -267,6 +277,51 @@ namespace nanoFramework.Tools.VisualStudio.Extension
         {
             // save new state
             NanoFrameworkPackage.SettingVirtualDeviceAutoUpdateNanoClrImage = (sender as ToggleButton).IsChecked ?? false;
+        }
+
+        private void LoadNanoClrInstance_Checked(object sender, System.Windows.RoutedEventArgs e)
+        {
+            // save new state
+            NanoFrameworkPackage.SettingLoadNanoClrInstance = (sender as ToggleButton).IsChecked ?? false;
+
+            // enable/disable file picker button
+            ShowFilePickerLocalNanoClrInstance.IsEnabled = (sender as ToggleButton).IsChecked ?? false;
+        }
+
+        private void ShowFilePickerForNanoCLRInstance_Click(object sender, System.Windows.RoutedEventArgs e)
+        {
+            var filePickerDialog = new OpenFileDialog
+            {
+                Title = "Select nanoCLR instance",
+                DefaultExt = ".dll",
+                Filter = "nanoCLR instance (*.dll)|*.dll",
+                CheckFileExists = true,
+                CheckPathExists = true,
+                Multiselect = false,
+            };
+
+            // let's try make things easier:
+            // if the current path is set, open folder browser dialog with it
+            if (!string.IsNullOrEmpty(PathOfLocalNanoClrInstance.Text))
+            {
+                filePickerDialog.FileName = PathOfLocalNanoClrInstance.Text;
+            }
+
+            // show dialog
+            DialogResult result = filePickerDialog.ShowDialog();
+
+            if (result == System.Windows.Forms.DialogResult.OK && !string.IsNullOrWhiteSpace(filePickerDialog.FileName))
+            {
+                // looks like we have a valid path
+                // save setting
+                NanoFrameworkPackage.SettingPathOfLocalNanoClrInstance = filePickerDialog.FileName;
+                // update UI control too
+                PathOfLocalNanoClrInstance.Text = filePickerDialog.FileName;
+            }
+            else
+            {
+                // any other outcome from folder browser dialog doesn't require processing
+            }
         }
     }
 }

--- a/VisualStudio.Extension-2022/VisualStudio.Extension-vs2022.csproj
+++ b/VisualStudio.Extension-2022/VisualStudio.Extension-vs2022.csproj
@@ -648,10 +648,11 @@
     <PackageReference Include="System.Xml.ReaderWriter">
       <Version>4.3.1</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.5.4072" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.3.2094" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers" />
   </ItemGroup>
   <Import Project="..\vs-extension.shared\vs-extension.shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != '' AND Exists('$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/vs-extension.shared/VirtualDeviceService/IVirtualDeviceService.cs
+++ b/vs-extension.shared/VirtualDeviceService/IVirtualDeviceService.cs
@@ -13,7 +13,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
         bool VirtualDeviceIsRunning { get; }
 
-        bool CanStartVirtualDevice { get; }
+        bool CanStartStopVirtualDevice { get; }
 
         Task InitVirtualDeviceAsync();
 

--- a/vs-extension.shared/VirtualDeviceService/VirtualDeviceService.cs
+++ b/vs-extension.shared/VirtualDeviceService/VirtualDeviceService.cs
@@ -16,6 +16,8 @@ using System.Diagnostics;
 using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading;
+using System.Threading.Tasks;
+using Task = System.Threading.Tasks.Task;
 
 namespace nanoFramework.Tools.VisualStudio.Extension
 {
@@ -44,12 +46,12 @@ namespace nanoFramework.Tools.VisualStudio.Extension
         public bool VirtualDeviceIsRunning => _nanoClrProcess != null && !_nanoClrProcess.HasExited;
 
         /// <summary>
-        /// Gets a value indicating if the virtual device can be started.
+        /// Gets a value indicating if the virtual device can be started or stopped.
         /// </summary>
         /// <remarks>
         /// The virtual device can't be started if it's already running when this instance of Visual Studio was started.
         /// </remarks>
-        public bool CanStartVirtualDevice { get; private set; } = true;
+        public bool CanStartStopVirtualDevice { get; private set; } = true;
 
         public VirtualDeviceService(IAsyncServiceProvider provider)
         {
@@ -66,7 +68,10 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 if (NanoFrameworkPackage.SettingVirtualDeviceEnable)
                 {
                     // wait a little bit to allow other services to load
-                    await System.Threading.Tasks.Task.Delay(5_000);
+                    await Task.Delay(5_000);
+
+                    // can't start/stop virtual device during install
+                    CanStartStopVirtualDevice = false;
 
                     // take care of installing/updating nanoclr tool
                     InstallNanoClrTool();
@@ -85,6 +90,9 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                     {
                         _nanoDeviceCommService.DebugClient.ReScanDevices();
                     }
+
+                    // OK to start/stop virtual device
+                    CanStartStopVirtualDevice = true;
                 }
 
             });
@@ -110,6 +118,9 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
             ThreadHelper.JoinableTaskFactory.Run(async delegate
             {
+                // can't start/stop virtual device during update
+                CanStartStopVirtualDevice = false;
+
                 try
                 {
                     var cliResult = await cmd.ExecuteBufferedAsync(cts.Token);
@@ -156,6 +167,11 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                     performInstallUpdate = true;
                     NanoClrIsInstalled = false;
                 }
+                finally
+                {
+                    // OK to start/stop virtual device
+                    CanStartStopVirtualDevice = true;
+                }
             });
 
             if (performInstallUpdate)
@@ -169,6 +185,9 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
                 ThreadHelper.JoinableTaskFactory.Run(async delegate
                 {
+                    // can't start/stop virtual device during install
+                    CanStartStopVirtualDevice = false;
+
                     var cliResult = await cmd.ExecuteBufferedAsync(cts1.Token);
 
                     if (cliResult.ExitCode == 0)
@@ -190,6 +209,9 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
                         NanoClrIsInstalled = false;
                     }
+
+                    // OK to start/stop virtual device
+                    CanStartStopVirtualDevice = true;
                 });
             }
 
@@ -208,6 +230,9 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
             ThreadHelper.JoinableTaskFactory.Run(async delegate
             {
+                // can't start/stop virtual device during install
+                CanStartStopVirtualDevice = false;
+
                 var cliResult = await cmd.ExecuteBufferedAsync(cts.Token);
 
                 if (cliResult.ExitCode == 0)
@@ -225,6 +250,9 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                     MessageCentre.InternalErrorWriteLine($"VirtualDevice: failed to update the nanoCLR image");
                     MessageCentre.OutputVirtualDeviceMessage("ERROR: failed to update the nanoCLR image");
                 }
+
+                // OK to start/stop virtual device
+                CanStartStopVirtualDevice = true;
             });
         }
         public string ListVirtualSerialPorts()
@@ -278,6 +306,8 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 {
                     await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(CancellationToken.None);
 
+                    byte[] ctrlC = new byte[] { 0x03 };
+
                     if (shutdownProcessing)
                     {
                         // call from VS shutdown handler
@@ -290,7 +320,10 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                             _nanoClrProcess.OutputDataReceived -= nanoClrProcess_OutputDataReceived;
 
                             // send Ctrl+C escape
-                            _nanoClrProcess.StandardInput.Write("\x3");
+                            _nanoClrProcess.StandardInput.Write(ctrlC);
+
+                            // pause for a moment 
+                            await Task.Delay(250);
 
                             // kill process
                             _nanoClrProcess.Kill();
@@ -306,8 +339,15 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
                         try
                         {
+                            _nanoClrProcess.EnableRaisingEvents = false; 
                             _nanoClrProcess.OutputDataReceived -= nanoClrProcess_OutputDataReceived;
                             _nanoClrProcess.Exited -= VirtualDeviceProcess_Exited;
+
+                            // send Ctrl+C escape
+                            _nanoClrProcess.StandardInput.Write(ctrlC);
+
+                            // pause for a moment 
+                            await Task.Delay(250);
 
                             // kill process
                             _nanoClrProcess.Kill();
@@ -341,7 +381,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
             }
         }
 
-        public async System.Threading.Tasks.Task<bool> StartVirtualDeviceAsync(bool rescanDevices)
+        public async Task<bool> StartVirtualDeviceAsync(bool rescanDevices)
         {
             bool firstPassRunning = true;
 
@@ -414,13 +454,21 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                     NanoFrameworkPackage.SettingVirtualDevicePort = regexResult.Groups["comport"].Value;
                 }
 
+                // check if we are to load a local nanoCLR instance
+                string nanoClrInstanceOption = string.Empty;
+
+                if(NanoFrameworkPackage.SettingLoadNanoClrInstance && !string.IsNullOrEmpty(NanoFrameworkPackage.SettingPathOfLocalNanoClrInstance))
+                {
+                    nanoClrInstanceOption = $"--localinstance \"{NanoFrameworkPackage.SettingPathOfLocalNanoClrInstance}\"";
+                }
+
                 MessageCentre.InternalErrorWriteLine($"VirtualDevice: Setting up process to run virtual device");
 
                 // OK to launch process with nanoclr
                 _nanoClrProcess = new Process();
 
                 _nanoClrProcess.StartInfo.FileName = "nanoclr";
-                _nanoClrProcess.StartInfo.Arguments = $"run --serialport {NanoFrameworkPackage.SettingVirtualDevicePort} --waitfordebugger --loopafterexit --monitorparentpid {Process.GetCurrentProcess().Id}";
+                _nanoClrProcess.StartInfo.Arguments = $"run --serialport {NanoFrameworkPackage.SettingVirtualDevicePort} {nanoClrInstanceOption} --waitfordebugger --loopafterexit --monitorparentpid {Process.GetCurrentProcess().Id}";
                 _nanoClrProcess.StartInfo.UseShellExecute = false;
                 _nanoClrProcess.StartInfo.CreateNoWindow = true;
                 _nanoClrProcess.StartInfo.RedirectStandardOutput = true;
@@ -469,8 +517,6 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                         // set handler for process exited
                         _nanoClrProcess.Exited += VirtualDeviceProcess_Exited;
 
-                        CanStartVirtualDevice = true;
-
                         // done here
                         return true;
                     }
@@ -488,8 +534,6 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 if (_nanoClrProcess.ExitCode == NanoClrErrorInstanceAlreadyRunning
                     || _nanoClrProcess.ExitCode == NanoClrErrorUnknowErrorStartingInstance)
                 {
-                    CanStartVirtualDevice = false;
-
                     MessageCentre.OutputVirtualDeviceMessage("");
                     MessageCentre.OutputVirtualDeviceMessage("***********************************************************************************");
                     MessageCentre.OutputVirtualDeviceMessage("Failed to start virtual device. Possibly there is another instance already running.");


### PR DESCRIPTION
## Description
- Add interface in settings dialog box in device explorer.
- Rework start/stop of nanoclr process.

## Motivation and Context
- Add support for loading a local nanoCLR instance. Usefull for debugging and other developement scenarios.
- Improve virtual device start and stop.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- VS experimental instance.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
