### PR TITLE
Add support to show (and process) exception and stack trace as option

### DIFF
--- a/VisualStudio.Extension-2019/NanoFrameworkPackage.cs
+++ b/VisualStudio.Extension-2019/NanoFrameworkPackage.cs
@@ -5,7 +5,6 @@
 
 using GalaSoft.MvvmLight.Ioc;
 using Microsoft;
-using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.ProjectSystem.VS;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -71,6 +70,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
     // register code generator for resources
     [ProvideObject(typeof(nFResXFileCodeGenerator))]
     [ProvideCodeGenerator(typeof(nFResXFileCodeGenerator), nFResXFileCodeGenerator.Name, nFResXFileCodeGenerator.Description, true, ProjectSystem = ProvideCodeGeneratorAttribute.CSharpProjectGuid)]
+    [ProvideOptionPage(typeof(NanoOptionsPageDebugging), ".NET nanoFramework", "Debugging", 0, 0, true)]
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1650:ElementDocumentationMustBeSpelledCorrectly", Justification = "pkgdef, VS and vsixmanifest are valid VS terms")]
     public sealed class NanoFrameworkPackage : AsyncPackage, Microsoft.VisualStudio.OLE.Interop.IOleCommandTarget
     {
@@ -523,6 +523,15 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 return _virtualDeviceService;
             }
         }
+
+        /// <summary>
+        /// Gets the debugging options page for the .NET nanoFramework extension.
+        /// </summary>
+        public static NanoOptionsPageDebugging DebuggingOptions => ThreadHelper.JoinableTaskFactory.Run(async delegate
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            return s_instance.GetDialogPage(typeof(NanoOptionsPageDebugging)) as NanoOptionsPageDebugging;
+        });
 
         private static NanoFrameworkPackage s_instance { get; set; }
 

--- a/VisualStudio.Extension-2019/VisualStudio.Extension-vs2019.csproj
+++ b/VisualStudio.Extension-2019/VisualStudio.Extension-vs2019.csproj
@@ -550,7 +550,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="nanoFramework.Tools.Debugger.Net" Version="2.4.25" />
+    <PackageReference Include="nanoFramework.Tools.Debugger.Net" Version="2.4.33" />
     <PackageReference Include="nanoFramework.Tools.MetadataProcessor.MsBuildTask" Version="3.0.36" />
     <PackageReference Include="Nerdbank.GitVersioning">
       <Version>3.5.119</Version>

--- a/VisualStudio.Extension-2019/packages.lock.json
+++ b/VisualStudio.Extension-2019/packages.lock.json
@@ -368,9 +368,9 @@
       },
       "nanoFramework.Tools.Debugger.Net": {
         "type": "Direct",
-        "requested": "[2.4.25, )",
-        "resolved": "2.4.25",
-        "contentHash": "NOHcdxd09Pxn5ifiinSeDhrXkh/R1+hjp9OQ8pkNAaFTbJsNlGR4+M293r11tAVlpQwoeq5AYpFDOgyJIglC4Q==",
+        "requested": "[2.4.33, )",
+        "resolved": "2.4.33",
+        "contentHash": "Y1Sq1xOuFAkLBmxdpWBDq4CBWHOYuEEb70RXUWm5a+o9axj0/p7yGKY13fJGe3x9MStUYIzptcIcHefWOE7yfg==",
         "dependencies": {
           "Polly": "7.2.3",
           "PropertyChanged.Fody": "2.6.1",
@@ -2418,6 +2418,24 @@
           "VSSDK.DTE": "[7.0.4, 8.0.0)",
           "VSSDK.IDE.12": "[12.0.4, 13.0.0)"
         }
+      },
+      "csharp.assemblyinfotemplate": {
+        "type": "Project"
+      },
+      "csharp.blankapplication-vs2019": {
+        "type": "Project"
+      },
+      "csharp.classlibrary-vs2019": {
+        "type": "Project"
+      },
+      "csharp.classtemplate": {
+        "type": "Project"
+      },
+      "csharp.resourcetemplate": {
+        "type": "Project"
+      },
+      "csharp.testapplication-vs2019": {
+        "type": "Project"
       },
       "nanoFramework.Tools.BuildTasks": {
         "type": "Project",

--- a/VisualStudio.Extension-2022/NanoFrameworkPackage.cs
+++ b/VisualStudio.Extension-2022/NanoFrameworkPackage.cs
@@ -71,6 +71,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
     [ProvideService(typeof(NanoDeviceCommService), IsAsyncQueryable = true)]
     [ProvideService(typeof(VirtualDeviceService), IsAsyncQueryable = true)]
     [ProvideCodeGenerator(typeof(nFResXFileCodeGenerator), nFResXFileCodeGenerator.Name, nFResXFileCodeGenerator.Description, true, ProjectSystem = ProvideCodeGeneratorAttribute.CSharpProjectGuid)]
+    [ProvideOptionPage(typeof(NanoOptionsPageDebugging), ".NET nanoFramework", "Debugging", 0, 0, true)]
     public sealed class NanoFrameworkPackage : AsyncPackage, Microsoft.VisualStudio.OLE.Interop.IOleCommandTarget
     {
         /// <summary>
@@ -523,6 +524,15 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 return _virtualDeviceService;
             }
         }
+
+        /// <summary>
+        /// Gets the debugging options page for the .NET nanoFramework extension.
+        /// </summary>
+        public static NanoOptionsPageDebugging DebuggingOptions => ThreadHelper.JoinableTaskFactory.Run(async delegate
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            return s_instance.GetDialogPage(typeof(NanoOptionsPageDebugging)) as NanoOptionsPageDebugging;
+        });
 
         private static NanoFrameworkPackage s_instance { get; set; }
 

--- a/VisualStudio.Extension-2022/VisualStudio.Extension-vs2022.csproj
+++ b/VisualStudio.Extension-2022/VisualStudio.Extension-vs2022.csproj
@@ -560,7 +560,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="nanoFramework.Tools.Debugger.Net" Version="2.4.25" />
+    <PackageReference Include="nanoFramework.Tools.Debugger.Net" Version="2.4.33" />
     <PackageReference Include="nanoFramework.Tools.MetadataProcessor.MsBuildTask" Version="3.0.36" />
     <PackageReference Include="Nerdbank.GitVersioning">
       <Version>3.5.119</Version>

--- a/VisualStudio.Extension-2022/packages.lock.json
+++ b/VisualStudio.Extension-2022/packages.lock.json
@@ -360,9 +360,9 @@
       },
       "nanoFramework.Tools.Debugger.Net": {
         "type": "Direct",
-        "requested": "[2.4.25, )",
-        "resolved": "2.4.25",
-        "contentHash": "NOHcdxd09Pxn5ifiinSeDhrXkh/R1+hjp9OQ8pkNAaFTbJsNlGR4+M293r11tAVlpQwoeq5AYpFDOgyJIglC4Q==",
+        "requested": "[2.4.33, )",
+        "resolved": "2.4.33",
+        "contentHash": "Y1Sq1xOuFAkLBmxdpWBDq4CBWHOYuEEb70RXUWm5a+o9axj0/p7yGKY13fJGe3x9MStUYIzptcIcHefWOE7yfg==",
         "dependencies": {
           "Polly": "7.2.3",
           "PropertyChanged.Fody": "2.6.1",
@@ -2065,6 +2065,24 @@
         "dependencies": {
           "Microsoft.VisualStudio.Interop": "17.5.33428.366"
         }
+      },
+      "csharp.assemblyinfotemplate": {
+        "type": "Project"
+      },
+      "csharp.blankapplication-vs2022": {
+        "type": "Project"
+      },
+      "csharp.classlibrary-vs2022": {
+        "type": "Project"
+      },
+      "csharp.classtemplate": {
+        "type": "Project"
+      },
+      "csharp.resourcetemplate": {
+        "type": "Project"
+      },
+      "csharp.testapplication-vs2022": {
+        "type": "Project"
       },
       "nanoFramework.Tools.BuildTasks": {
         "type": "Project",

--- a/vs-extension.shared/CorDebug/CorDebugProcess.cs
+++ b/vs-extension.shared/CorDebug/CorDebugProcess.cs
@@ -6,7 +6,6 @@
 
 using CorDebugInterop;
 using Microsoft.VisualStudio.Debugger.Interop;
-using Microsoft.VisualStudio.Shell;
 using nanoFramework.Tools.Debugger;
 using nanoFramework.Tools.Debugger.Extensions;
 using nanoFramework.Tools.Debugger.WireProtocol;
@@ -493,12 +492,21 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
                             Thread.Sleep(10);
 
-                            if(_engine.SetExecutionMode(Commands.DebuggingExecutionChangeConditions.State.SourceLevelDebugging, 0))
+                            // compose execution mode flags
+                            // always enable source level debugging
+                            var executionMode = Commands.DebuggingExecutionChangeConditions.State.SourceLevelDebugging;
+
+                            // check if we need to disable the stack trace in exceptions
+                            if(_engine.ThrowOnCommunicationFailure)
+                            {
+                                executionMode |= Commands.DebuggingExecutionChangeConditions.State.NoStackTraceInExceptions;
+                            }
+
+                            if (_engine.SetExecutionMode(executionMode, 0))
                             {
                                 // done here
                                 break;
                             }
-
                         }
                     }
 

--- a/vs-extension.shared/DebugLauncher/NanoDebuggerLaunchProvider.cs
+++ b/vs-extension.shared/DebugLauncher/NanoDebuggerLaunchProvider.cs
@@ -8,7 +8,6 @@ using Microsoft.VisualStudio.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.Debug;
 using Microsoft.VisualStudio.ProjectSystem.VS.Debug;
 using Microsoft.VisualStudio.Threading;
-using nanoFramework.Tools.Debugger;
 using nanoFramework.Tools.VisualStudio.Extension.ToolWindow.ViewModel;
 using System;
 using System.Collections.Generic;
@@ -16,7 +15,6 @@ using System.ComponentModel.Composition;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
-using System.Windows;
 
 namespace nanoFramework.Tools.VisualStudio.Extension
 {
@@ -58,10 +56,13 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                     device.CreateDebugEngine();
                 }
 
+                // update stack trace processing option
+                device.DebugEngine.NoStackTraceInExceptions = !NanoFrameworkPackage.DebuggingOptions.ProcessStackTraceOption;
+
                 // make sure that the device is connected
                 if (device.DebugEngine.Connect(
-                    false,
-                    true))
+                            false,
+                            true))
                 {
                     string commandLine = await GetCommandLineForLaunchAsync();
                     commandLine = string.Format("{0} \"{1}{2}\"", commandLine, CorDebugProcess.DeployDeviceName, deployDeviceName);

--- a/vs-extension.shared/NanoOptions/NanoOptionsPageDebugging.cs
+++ b/vs-extension.shared/NanoOptions/NanoOptionsPageDebugging.cs
@@ -1,0 +1,52 @@
+﻿////
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+////
+
+using GalaSoft.MvvmLight.Ioc;
+using Microsoft.VisualStudio.Shell;
+using nanoFramework.Tools.VisualStudio.Extension.ToolWindow.ViewModel;
+using System.ComponentModel;
+using Commands = nanoFramework.Tools.Debugger.WireProtocol.Commands;
+
+namespace nanoFramework.Tools.VisualStudio.Extension
+{
+    public class NanoOptionsPageDebugging : DialogPage
+    {
+        [Category("General Output Settings")]
+        [DisplayName("Process Stack Trace")]
+        [Description("Determines if stack trace will be processed by the nano device. This is used to save processing time with crawling the stack and gatthering the details. It will also prevent detailed stack trace information to be sent to the debugger. The StackTrace property in the Exception will be empty.")]
+        [DefaultValue(true)]
+        public bool ProcessStackTraceOption { get; set; } = true;
+
+        public override void SaveSettingsToStorage()
+        {
+            base.SaveSettingsToStorage();
+
+            try
+            {
+                // update execution conditions in nano device if there is a debug session active
+                var device = SimpleIoc.Default.GetInstance<DeviceExplorerViewModel>().SelectedDevice;
+
+                if (device?.DebugEngine != null
+                    && device.DebugEngine.IsRunning)
+                {
+                    // update execution mode according to option
+                    if (ProcessStackTraceOption)
+                    {
+                        _ = device.DebugEngine.SetExecutionMode(0, Commands.DebuggingExecutionChangeConditions.State.NoStackTraceInExceptions);
+                    }
+                    else
+                    {
+                        _ = device.DebugEngine.SetExecutionMode(Commands.DebuggingExecutionChangeConditions.State.NoStackTraceInExceptions, 0);
+                    }
+                }
+            }
+            catch
+            {
+                // don't care about any exception here
+                // it's OK to fail silently as we need to make sure that the settings are saved
+            }
+        }
+    }
+}

--- a/vs-extension.shared/vs-extension.shared.projitems
+++ b/vs-extension.shared/vs-extension.shared.projitems
@@ -67,6 +67,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)NanoDeviceCommService\INanoDeviceCommService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NanoDeviceCommService\NanoDeviceCommService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NanoDeviceCommService\SNanoDeviceCommService.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)NanoOptions\NanoOptionsPageDebugging.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ProjectSystem\GlobalPropertiesProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ProjectSystem\NanoCSharpProjectConfigured.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ProjectSystem\NanoCSharpProjectUnconfigured.cs" />


### PR DESCRIPTION
## Description
- Add nanoFramework options.
- Expose these on VS package.
- Add code to debugger launch provider and CorDebug process to set execution condition including this flag.
- Update nanoFramework.Tools.Debugger.Net to v2.4.33.
- Update debugger sub-module @2a53448.

## Motivation and Context
- Exposes and implements this new execution option.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
