### PR TITLE
Fix CA root certificate upload

### DIFF
--- a/VisualStudio.Extension-2022/ToolWindow.DeviceExplorer/NetworkConfigurationDialog.xaml.cs
+++ b/VisualStudio.Extension-2022/ToolWindow.DeviceExplorer/NetworkConfigurationDialog.xaml.cs
@@ -5,6 +5,7 @@
 
 namespace nanoFramework.Tools.VisualStudio.Extension
 {
+    using Microsoft.VisualStudio.Package;
     using Microsoft.VisualStudio.PlatformUI;
     using nanoFramework.Tools.Debugger;
     using nanoFramework.Tools.VisualStudio.Extension.ToolWindow.ViewModel;
@@ -343,11 +344,29 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 {
                     MessageCentre.InternalErrorWriteLine($"Opening device certificate file: {openFileDialog.FileName}");
 
+                    /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+                    // Requirement from Mbed TLS parser: if the file is a PEM file, need to make sure it ends with a terminator (0x00) //
+                    /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+                    var fileIsPem = FilePathUtilities.GetFileExtension(openFileDialog.FileName) == ".pem";
+
                     using (FileStream binFile = new FileStream(openFileDialog.FileName, FileMode.Open))
                     {
-                        deviceCertificateFile.Certificate = new byte[binFile.Length];
-                        binFile.Read(deviceCertificateFile.Certificate, 0, (int)binFile.Length);
-                        deviceCertificateFile.CertificateSize = (uint)binFile.Length;
+                        var certificateContent = new byte[binFile.Length];
+                        binFile.Read(certificateContent, 0, (int)binFile.Length);
+
+                        if (fileIsPem)
+                        {
+                            // check if last position it's a terminator
+                            if (certificateContent[certificateContent.Length - 1] != 0x00)
+                            {
+                                // nope, add terminator
+                                Array.Resize(ref certificateContent, certificateContent.Length + 1);
+                                certificateContent[certificateContent.Length - 1] = 0x00;
+                            }
+                        }
+
+                        deviceCertificateFile.Certificate = certificateContent;
+                        deviceCertificateFile.CertificateSize = (uint)certificateContent.Length;
                     }
 
                     // store device certificate


### PR DESCRIPTION
## Description
- Now adding terminator to PEM files, if it's not present.

## Motivation and Context
- Fixes uploading CA root certificates in PEM format.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
