### PR TITLE
Revert update on VS2019 refs

### DIFF
--- a/VisualStudio.Extension-2019/VisualStudio.Extension-vs2019.csproj
+++ b/VisualStudio.Extension-2019/VisualStudio.Extension-vs2019.csproj
@@ -573,7 +573,7 @@
       <Version>16.10.31320.204</Version>
     </PackageReference>
     <PackageReference Include="StreamJsonRpc">
-      <Version>2.9.85</Version>
+      <Version>2.8.28</Version>
     </PackageReference>
     <PackageReference Include="System.Collections">
       <Version>4.3.0</Version>

--- a/VisualStudio.Extension-2019/packages.lock.json
+++ b/VisualStudio.Extension-2019/packages.lock.json
@@ -431,15 +431,15 @@
       },
       "StreamJsonRpc": {
         "type": "Direct",
-        "requested": "[2.9.85, )",
-        "resolved": "2.9.85",
-        "contentHash": "ZLW1Y/I9NO8PRkCbqAvJvHqsNDfAw4/DpD8EFhAXgnct7pFKFs6y+LFokFoI2rB1jGaYYxW7aX6DNrxO1e+vKg==",
+        "requested": "[2.8.28, )",
+        "resolved": "2.8.28",
+        "contentHash": "i2hKUXJSLEoWpPqQNyISqLDqmFHMiyasjTC/PrrHNWhQyauFeVoebSct3E4OTUzRC1DYjVJ9AMiVbp/uVYLnjQ==",
         "dependencies": {
-          "MessagePack": "2.3.75",
+          "MessagePack": "2.2.85",
           "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
-          "Microsoft.VisualStudio.Threading": "16.10.56",
-          "Nerdbank.Streams": "2.8.46",
-          "Newtonsoft.Json": "13.0.1",
+          "Microsoft.VisualStudio.Threading": "16.9.60",
+          "Nerdbank.Streams": "2.6.81",
+          "Newtonsoft.Json": "12.0.2",
           "System.Collections.Immutable": "5.0.0",
           "System.Diagnostics.DiagnosticSource": "5.0.1",
           "System.IO.Pipelines": "5.0.1",
@@ -1972,8 +1972,8 @@
       },
       "Microsoft.VisualStudio.Validation": {
         "type": "Transitive",
-        "resolved": "16.10.26",
-        "contentHash": "5KXcBcBjvuCZvRrudAEGN64a6OtbRxqLxecKpTSm4p9GCavYtclZYA01csTtmTEkveiAX1k9bpx/4H0ohk2d5g=="
+        "resolved": "16.9.32",
+        "contentHash": "4Ozqy5OjtU4k9aKT76or3y8tVq6ju8+ba4YZHIe5wTb28jeCg11zkK6bdI4kj8s+k5OSekyO+FkUyoOkvPkgVg=="
       },
       "Microsoft.VisualStudio.VSHelp": {
         "type": "Transitive",
@@ -2008,15 +2008,15 @@
       },
       "Nerdbank.Streams": {
         "type": "Transitive",
-        "resolved": "2.8.46",
-        "contentHash": "/d18ruvWphgn15w9kXQCD77TTvtbPLqnTAzXlMK+HpxDY8WJrBhnJmuUsJbOZ1HtbTRmRbiIqcNmcSLERBLj+w==",
+        "resolved": "2.6.81",
+        "contentHash": "htBHFE359qyyFwrvAGvFxrbBAoldZdl0XjtQdDWTJ8t5sWWs7QVXID5y1ZGJE61UgpV5CqWsj/NT0LOAn5GdZw==",
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
-          "Microsoft.VisualStudio.Threading": "16.10.56",
-          "Microsoft.VisualStudio.Validation": "16.10.26",
-          "System.IO.Pipelines": "5.0.1",
+          "Microsoft.Bcl.AsyncInterfaces": "1.1.1",
+          "Microsoft.VisualStudio.Threading": "16.7.56",
+          "Microsoft.VisualStudio.Validation": "15.5.31",
+          "System.IO.Pipelines": "4.7.2",
           "System.Net.WebSockets": "4.3.0",
-          "System.Runtime.CompilerServices.Unsafe": "5.0.0"
+          "System.Runtime.CompilerServices.Unsafe": "4.7.1"
         }
       },
       "Polly": {


### PR DESCRIPTION
## Description
- Revert update on VS2019 refs.

## Motivation and Context
- Issues with VS2019 loading assemblies.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [x] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
