### PR TITLE
Fix Settings dialog

### DIFF
--- a/VisualStudio.Extension-2022/ToolWindow.DeviceExplorer/SettingsDialog.xaml.cs
+++ b/VisualStudio.Extension-2022/ToolWindow.DeviceExplorer/SettingsDialog.xaml.cs
@@ -7,11 +7,13 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 {
     using System.Collections.Generic;
     using System.Net;
-    using System.Threading.Tasks;
     using System.Windows.Controls.Primitives;
     using System.Windows.Forms;
+    using CommunityToolkit.Mvvm.Messaging;
     using Microsoft.VisualStudio.PlatformUI;
     using Microsoft.VisualStudio.Shell;
+    using static nanoFramework.Tools.VisualStudio.Extension.ToolWindow.ViewModel.DeviceExplorerViewModel.Messages;
+    using Task = System.Threading.Tasks.Task;
 
     /// <summary>
     /// Interaction logic for DeviceExplorerControl.
@@ -40,7 +42,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
         // init controls
         private void InitControls()
         {
-            //WeakReferenceMessenger.Default.Register<NotificationMessage>(this, DeviceExplorerViewModel.MessagingTokens.VirtualDeviceOperationExecuting, (message) => this.UpdateStartStopAvailabilityAsync(message.Notification).ConfigureAwait(false));
+            WeakReferenceMessenger.Default.Register<VirtualDeviceOperationExecutingMessage>(this, (r, message) => this.UpdateStartStopAvailabilityAsync(message.Value).ConfigureAwait(false));
 
             // set controls according to stored preferences
             GenerateDeploymentImage.IsChecked = NanoFrameworkPackage.SettingGenerateDeploymentImage;
@@ -102,11 +104,11 @@ namespace nanoFramework.Tools.VisualStudio.Extension
             CloseButton.Focus();
         }
 
-        private async Task UpdateStartStopAvailabilityAsync(string installCompleted)
+        private async Task UpdateStartStopAvailabilityAsync(bool installCompleted)
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            StartStopDevice.IsEnabled = !bool.Parse(installCompleted)
+            StartStopDevice.IsEnabled = !installCompleted
                                         && NanoFrameworkPackage.VirtualDeviceService.NanoClrIsInstalled
                                         && NanoFrameworkPackage.VirtualDeviceService.CanStartStopVirtualDevice;
         }


### PR DESCRIPTION
## Description
- Add missing registration of MVVM message.
- Fix declaration of message handler.

## Motivation and Context
- Missed rework on MVVM migration.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
