### PR TITLE
Add message about background task when searching nano devices

### DIFF
--- a/vs-extension.shared/MessageCentre/MessageCentre.cs
+++ b/vs-extension.shared/MessageCentre/MessageCentre.cs
@@ -1,19 +1,17 @@
-//
+﻿//
 // Copyright (c) .NET Foundation and Contributors
 // Portions Copyright (c) Microsoft Corporation.  All rights reserved.
 // See LICENSE file in the project root for full license information.
 //
 
-using Microsoft;
-using Microsoft.VisualStudio;
-using Microsoft.VisualStudio.OLE.Interop;
-using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Interop;
-using nanoFramework.Tools.Debugger;
 using System;
 using System.Diagnostics;
 using System.Text;
-using System.Threading.Tasks;
+using Microsoft;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using nanoFramework.Tools.Debugger;
 
 namespace nanoFramework.Tools.VisualStudio.Extension
 {
@@ -32,6 +30,9 @@ namespace nanoFramework.Tools.VisualStudio.Extension
         private static IVsStatusbar _statusBar;
         private static string _paneName;
         private static uint progressCookie;
+
+        public static string MessageStartSearchingDevices = "[.NET nanoFramework] Start searching for devices in the background...";
+        public static string MessageCompletedDevicesSearch = "[.NET nanoFramework] Devices search completed.";
 
         public static System.Threading.Tasks.Task InitializeAsync(AsyncPackage package, string name)
         {

--- a/vs-extension.shared/NanoDeviceCommService/NanoDeviceCommService.cs
+++ b/vs-extension.shared/NanoDeviceCommService/NanoDeviceCommService.cs
@@ -50,6 +50,12 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                     _debugClient = PortBase.CreateInstanceForComposite(
                         new[] { serialDebug, networkDebug },
                         !NanoFrameworkPackage.OptionDisableDeviceWatchers);
+
+                    if (!NanoFrameworkPackage.OptionDisableDeviceWatchers)
+                    {
+                        // output progress message
+                        MessageCentre.StartProgressMessage(MessageCentre.MessageStartSearchingDevices);
+                    }
                 }
 
                 return _debugClient;

--- a/vs-extension.shared/ToolWindow.DeviceExplorer/DeviceExplorerCommand.cs
+++ b/vs-extension.shared/ToolWindow.DeviceExplorer/DeviceExplorerCommand.cs
@@ -979,6 +979,8 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 {
                     NanoDeviceCommService.DebugClient.ReScanDevices();
 
+                    MessageCentre.StartProgressMessage(MessageCentre.MessageStartSearchingDevices);
+
                     // don't enable the button here to prevent compulsive developers to click it when the operation is still ongoing
                     // it will be enabled back at NanoDevicesCollectionChangedHandlerAsync
                 }
@@ -1020,6 +1022,8 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
                 NanoDeviceCommService.DebugClient.StartDeviceWatchers();
 
+                MessageCentre.StartProgressMessage(MessageCentre.MessageStartSearchingDevices);
+
                 // don't enable the rescan devices button as this will happen on device enumeration completed
             }
             else
@@ -1030,8 +1034,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
                 var deviceExplorer = Ioc.Default.GetService<DeviceExplorerViewModel>();
 
-                // need to remove event handler
-                NanoDeviceCommService.DebugClient.NanoFrameworkDevices.CollectionChanged -= deviceExplorer.NanoFrameworkDevices_CollectionChanged;
+                deviceExplorer.ResetEnumerationFlag();
 
                 MessageCentre.OutputMessage(Environment.NewLine);
                 MessageCentre.OutputMessage("***********************************************************************************");

--- a/vs-extension.shared/ToolWindow.DeviceExplorer/ViewModel/DeviceExplorerViewModel.cs
+++ b/vs-extension.shared/ToolWindow.DeviceExplorer/ViewModel/DeviceExplorerViewModel.cs
@@ -116,6 +116,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension.ToolWindow.ViewModel
 
             WeakReferenceMessenger.Default.Send(new NanoDeviceEnumerationCompletedMessage());
 
+            MessageCentre.StopProgressMessage();
         }
 
         public void NanoFrameworkDevices_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)

--- a/vs-extension.shared/VirtualDeviceService/VirtualDeviceService.cs
+++ b/vs-extension.shared/VirtualDeviceService/VirtualDeviceService.cs
@@ -3,13 +3,6 @@
 // See LICENSE file in the project root for full license information.
 ////
 
-using CliWrap;
-using CliWrap.Buffered;
-using CommunityToolkit.Mvvm.Messaging;
-using Microsoft;
-using Microsoft.VisualStudio.Shell;
-using nanoFramework.Tools.VisualStudio.Extension.ToolWindow.ViewModel;
-using Newtonsoft.Json;
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -17,6 +10,12 @@ using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using CliWrap;
+using CliWrap.Buffered;
+using CommunityToolkit.Mvvm.Messaging;
+using Microsoft;
+using Microsoft.VisualStudio.Shell;
+using Newtonsoft.Json;
 using static nanoFramework.Tools.VisualStudio.Extension.ToolWindow.ViewModel.DeviceExplorerViewModel.Messages;
 using Task = System.Threading.Tasks.Task;
 
@@ -90,6 +89,8 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                     if (!NanoFrameworkPackage.OptionDisableDeviceWatchers)
                     {
                         _nanoDeviceCommService.DebugClient.ReScanDevices();
+
+                        MessageCentre.StartProgressMessage(MessageCentre.MessageStartSearchingDevices);
                     }
 
                     // OK to start/stop virtual device
@@ -340,7 +341,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
                         try
                         {
-                            _nanoClrProcess.EnableRaisingEvents = false; 
+                            _nanoClrProcess.EnableRaisingEvents = false;
                             _nanoClrProcess.OutputDataReceived -= nanoClrProcess_OutputDataReceived;
                             _nanoClrProcess.Exited -= VirtualDeviceProcess_Exited;
 
@@ -364,6 +365,8 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
                             // rescan devices
                             _nanoDeviceCommService.DebugClient.ReScanDevices();
+
+                            MessageCentre.StartProgressMessage(MessageCentre.MessageStartSearchingDevices);
                         }
                         catch
                         {
@@ -458,7 +461,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                 // check if we are to load a local nanoCLR instance
                 string nanoClrInstanceOption = string.Empty;
 
-                if(NanoFrameworkPackage.SettingLoadNanoClrInstance && !string.IsNullOrEmpty(NanoFrameworkPackage.SettingPathOfLocalNanoClrInstance))
+                if (NanoFrameworkPackage.SettingLoadNanoClrInstance && !string.IsNullOrEmpty(NanoFrameworkPackage.SettingPathOfLocalNanoClrInstance))
                 {
                     nanoClrInstanceOption = $"--localinstance \"{NanoFrameworkPackage.SettingPathOfLocalNanoClrInstance}\"";
                 }
@@ -572,6 +575,8 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                     && rescanDevices)
                 {
                     _nanoDeviceCommService.DebugClient.ReScanDevices();
+
+                    MessageCentre.StartProgressMessage(MessageCentre.MessageStartSearchingDevices);
                 }
             }
 


### PR DESCRIPTION
## Description
- Add constants with messages about start and completion of device search.
- Add calls to message centre to give aminated feedback on background task when searching nano devices.

## Motivation and Context
- Improve visual feedback to developers about background message.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
