### PR TITLE
Remove dependency of Xceed library

### DIFF
--- a/VisualStudio.Extension-2019/ToolWindow.DeviceExplorer/NetworkConfigurationDialog.xaml
+++ b/VisualStudio.Extension-2019/ToolWindow.DeviceExplorer/NetworkConfigurationDialog.xaml
@@ -6,7 +6,6 @@
              xmlns:vsp="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
              xmlns:extension="clr-namespace:nanoFramework.Tools.VisualStudio.Extension"
              xmlns:debuglib="clr-namespace:nanoFramework.Tools.Debugger;assembly=nanoFramework.Tools.DebugLibrary.Net"
-             xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
              xmlns:Converters="clr-namespace:nanoFramework.Tools.VisualStudio.Extension.Converters"
              xmlns:ViewModel="clr-namespace:nanoFramework.Tools.VisualStudio.Extension.ToolWindow.ViewModel"
              x:Class="nanoFramework.Tools.VisualStudio.Extension.NetworkConfigurationDialog"
@@ -118,8 +117,8 @@
 
                     <!--MAC address-->
                     <Label Grid.Row="0" Grid.Column="0" HorizontalAlignment="Left" Content="MAC address:" Margin="-6,0,0,0" />
-                    <xctk:MaskedTextBox Grid.Row="0" Grid.Column="1" HorizontalAlignment="Left" Height="23" Mask="AA\:AA\:AA\:AA\:AA\:AA" VerticalAlignment="Center" VerticalContentAlignment="Center" Width="120" Margin="0,3,0,0" x:Name="MACAddress"
-                                         Text="{Binding DeviceNetworkConfiguration.MacAddress, Converter={StaticResource MacAddressConverter}, ValidatesOnNotifyDataErrors=False}" IsEnabled="{Binding CanChangeMacAddress}"/>
+                    <TextBox Grid.Row="0" Grid.Column="1" HorizontalAlignment="Left" Height="23" VerticalAlignment="Center" VerticalContentAlignment="Center" Width="120" Margin="0,3,0,0" x:Name="MACAddress"
+                                         Text="{Binding DeviceNetworkConfiguration.MacAddress, Converter={StaticResource MacAddressConverter}, ValidatesOnNotifyDataErrors=False}" IsEnabled="{Binding CanChangeMacAddress}" />
 
                     <!--Interface type-->
                     <Label Grid.Row="1" Grid.Column="0" HorizontalAlignment="Left" Content="Interface type:" Margin="-6,6,0,0" />
@@ -128,7 +127,6 @@
                               ItemsSource="{extension:ByteEnumToItemsSource {x:Type debuglib:NetworkInterfaceType}}"
                               SelectedValue="{Binding DeviceNetworkConfiguration.InterfaceType, Converter={StaticResource NetworkInterfaceTypeConverter}, Mode=TwoWay, NotifyOnTargetUpdated=True, NotifyOnSourceUpdated=True, ValidatesOnNotifyDataErrors=False}"
                               SelectedValuePath="Value" />
-                    <!--<xctk:MaskedTextBox Grid.Row="1" Grid.Column="1" HorizontalAlignment="Left" Height="23" Mask="AA\:AA\:AA\:AA\:AA\:AA" VerticalAlignment="Top" Width="120" Margin="0,3,0,0" x:Name="InterfaceType"/>-->
 
                 </Grid>
             </TabItem>
@@ -150,11 +148,11 @@
 
                     <!--SSID-->
                     <Label Grid.Row="0" Grid.Column="0" HorizontalAlignment="Left" Content="SSID:" Margin="-6,0,0,0" />
-                    <xctk:MaskedTextBox Grid.Row="0" Grid.Column="1" HorizontalAlignment="Left" MaxLength="32" Height="23" VerticalContentAlignment="Center" VerticalAlignment="Center" Width="120" Margin="0,3,0,0" Text="{Binding DeviceWireless80211Configuration.Ssid, Mode=TwoWay}" x:Name="SSID"/>
+                    <TextBox Grid.Row="0" Grid.Column="1" HorizontalAlignment="Left" MaxLength="32" Height="23" VerticalContentAlignment="Center" VerticalAlignment="Center" Width="120" Margin="0,3,0,0" Text="{Binding DeviceWireless80211Configuration.Ssid, Mode=TwoWay}" x:Name="SSID"/>
 
                     <!--Pass-->
                     <Label Grid.Row="1" Grid.Column="0" HorizontalAlignment="Left" Content="Password:" Margin="-6,6,0,0" />
-                    <xctk:WatermarkPasswordBox Grid.Row="1" Grid.Column="1" HorizontalAlignment="Left" MaxLength="64" Height="23" VerticalContentAlignment="Center" VerticalAlignment="Center" Width="120" Margin="0,6,0,0" x:Name="WiFiPassword" />
+                    <PasswordBox Grid.Row="1" Grid.Column="1" HorizontalAlignment="Left" MaxLength="64" Height="23" VerticalContentAlignment="Center" VerticalAlignment="Center" Width="120" Margin="0,6,0,0" x:Name="WiFiPassword" PasswordChar="•"/>
 
                     <!--Security type-->
                     <Label Grid.Row="2" Grid.Column="0" HorizontalAlignment="Left" Content="Security type:" Margin="-6,6,0,0" />

--- a/VisualStudio.Extension-2019/VisualStudio.Extension-vs2019.csproj
+++ b/VisualStudio.Extension-2019/VisualStudio.Extension-vs2019.csproj
@@ -482,9 +482,6 @@
     <PackageReference Include="CommunityToolkit.Mvvm">
       <Version>8.2.2</Version>
     </PackageReference>
-    <PackageReference Include="Extended.Wpf.Toolkit">
-      <Version>4.3.0</Version>
-    </PackageReference>
     <PackageReference Include="ICSharpCode.Decompiler">
       <Version>7.2.1.6856</Version>
     </PackageReference>

--- a/VisualStudio.Extension-2019/packages.lock.json
+++ b/VisualStudio.Extension-2019/packages.lock.json
@@ -28,12 +28,6 @@
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
-      "Extended.Wpf.Toolkit": {
-        "type": "Direct",
-        "requested": "[4.3.0, )",
-        "resolved": "4.3.0",
-        "contentHash": "leG4va9wdAk0R92UoycOwacWGPvgdWpNkfezAojkfjg+zxJlvRXUS4hR/urPVzX2dRZh8c7UxmdBIOW7O6N+OA=="
-      },
       "ICSharpCode.Decompiler": {
         "type": "Direct",
         "requested": "[7.2.1.6856, )",

--- a/VisualStudio.Extension-2022/NanoFrameworkMoniker.imagemanifest
+++ b/VisualStudio.Extension-2022/NanoFrameworkMoniker.imagemanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ImageManifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://schemas.microsoft.com/VisualStudio/ImageManifestSchema/2014">
   <Symbols>
-    <String Name="Resources" Value="/nanoFramework.Tools.VS2022.Extension;v2022.12.1.0;Component/Resources" />
+    <String Name="Resources" Value="/nanoFramework.Tools.VS2022.Extension;v2022.12.1.3;Component/Resources" />
     <Guid Name="NanoFrameworkCatalog" Value="{23cf437f-5e0e-4b0c-8aa4-ceec5b5f8679}" />
     <ID Name="DeviceConnected" Value="20" />
     <ID Name="DeviceDisconnected" Value="30" />

--- a/VisualStudio.Extension-2022/ToolWindow.DeviceExplorer/NetworkConfigurationDialog.xaml
+++ b/VisualStudio.Extension-2022/ToolWindow.DeviceExplorer/NetworkConfigurationDialog.xaml
@@ -6,7 +6,6 @@
              xmlns:vsp="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
              xmlns:extension="clr-namespace:nanoFramework.Tools.VisualStudio.Extension"
              xmlns:debuglib="clr-namespace:nanoFramework.Tools.Debugger;assembly=nanoFramework.Tools.DebugLibrary.Net"
-             xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
              xmlns:Converters="clr-namespace:nanoFramework.Tools.VisualStudio.Extension.Converters"
              xmlns:ViewModel="clr-namespace:nanoFramework.Tools.VisualStudio.Extension.ToolWindow.ViewModel"
              x:Class="nanoFramework.Tools.VisualStudio.Extension.NetworkConfigurationDialog"
@@ -118,8 +117,9 @@
 
                     <!--MAC address-->
                     <Label Grid.Row="0" Grid.Column="0" HorizontalAlignment="Left" Content="MAC address:" Margin="-6,0,0,0" />
-                    <xctk:MaskedTextBox Grid.Row="0" Grid.Column="1" HorizontalAlignment="Left" Height="23" Mask="AA\:AA\:AA\:AA\:AA\:AA" VerticalAlignment="Center" VerticalContentAlignment="Center" Width="120" Margin="0,3,0,0" x:Name="MACAddress"
-                                         Text="{Binding DeviceNetworkConfiguration.MacAddress, Converter={StaticResource MacAddressConverter}, ValidatesOnNotifyDataErrors=False}" IsEnabled="{Binding CanChangeMacAddress}"/>
+                    <TextBox Grid.Row="0" Grid.Column="1" HorizontalAlignment="Left" Height="23" VerticalAlignment="Center" VerticalContentAlignment="Center" Width="120" Margin="0,3,0,0" x:Name="MACAddress"
+                                         Text="{Binding DeviceNetworkConfiguration.MacAddress, Converter={StaticResource MacAddressConverter}, ValidatesOnNotifyDataErrors=False}" IsEnabled="{Binding CanChangeMacAddress}" />
+                    
 
                     <!--Interface type-->
                     <Label Grid.Row="1" Grid.Column="0" HorizontalAlignment="Left" Content="Interface type:" Margin="-6,6,0,0" />
@@ -128,7 +128,6 @@
                               ItemsSource="{extension:ByteEnumToItemsSource {x:Type debuglib:NetworkInterfaceType}}"
                               SelectedValue="{Binding DeviceNetworkConfiguration.InterfaceType, Converter={StaticResource NetworkInterfaceTypeConverter}, Mode=TwoWay, NotifyOnTargetUpdated=True, NotifyOnSourceUpdated=True, ValidatesOnNotifyDataErrors=False}"
                               SelectedValuePath="Value" />
-                    <!--<xctk:MaskedTextBox Grid.Row="1" Grid.Column="1" HorizontalAlignment="Left" Height="23" Mask="AA\:AA\:AA\:AA\:AA\:AA" VerticalAlignment="Top" Width="120" Margin="0,3,0,0" x:Name="InterfaceType"/>-->
 
                 </Grid>
             </TabItem>
@@ -150,11 +149,11 @@
 
                     <!--SSID-->
                     <Label Grid.Row="0" Grid.Column="0" HorizontalAlignment="Left" Content="SSID:" Margin="-6,0,0,0" />
-                    <xctk:MaskedTextBox Grid.Row="0" Grid.Column="1" HorizontalAlignment="Left" MaxLength="32" Height="23" VerticalContentAlignment="Center" VerticalAlignment="Center" Width="120" Margin="0,3,0,0" Text="{Binding DeviceWireless80211Configuration.Ssid, Mode=TwoWay}" x:Name="SSID"/>
+                    <TextBox Grid.Row="0" Grid.Column="1" HorizontalAlignment="Left" MaxLength="32" Height="23" VerticalContentAlignment="Center" VerticalAlignment="Center" Width="120" Margin="0,3,0,0" Text="{Binding DeviceWireless80211Configuration.Ssid, Mode=TwoWay}" x:Name="SSID"/>
 
                     <!--Pass-->
                     <Label Grid.Row="1" Grid.Column="0" HorizontalAlignment="Left" Content="Password:" Margin="-6,6,0,0" />
-                    <xctk:WatermarkPasswordBox Grid.Row="1" Grid.Column="1" HorizontalAlignment="Left" MaxLength="64" Height="23" VerticalContentAlignment="Center" VerticalAlignment="Center" Width="120" Margin="0,6,0,0" x:Name="WiFiPassword" />
+                    <PasswordBox Grid.Row="1" Grid.Column="1" HorizontalAlignment="Left" MaxLength="64" Height="23" VerticalContentAlignment="Center" VerticalAlignment="Center" Width="120" Margin="0,6,0,0" x:Name="WiFiPassword" PasswordChar="•"/>
 
                     <!--Security type-->
                     <Label Grid.Row="2" Grid.Column="0" HorizontalAlignment="Left" Content="Security type:" Margin="-6,6,0,0" />

--- a/VisualStudio.Extension-2022/VisualStudio.Extension-vs2022.csproj
+++ b/VisualStudio.Extension-2022/VisualStudio.Extension-vs2022.csproj
@@ -502,9 +502,6 @@
     <PackageReference Include="EnvDTE80">
       <Version>17.12.40391</Version>
     </PackageReference>
-    <PackageReference Include="Extended.Wpf.Toolkit">
-      <Version>4.6.1</Version>
-    </PackageReference>
     <PackageReference Include="ICSharpCode.Decompiler">
       <Version>7.2.1.6856</Version>
     </PackageReference>

--- a/VisualStudio.Extension-2022/packages.lock.json
+++ b/VisualStudio.Extension-2022/packages.lock.json
@@ -35,12 +35,6 @@
           "Microsoft.VisualStudio.Interop": "17.12.40391"
         }
       },
-      "Extended.Wpf.Toolkit": {
-        "type": "Direct",
-        "requested": "[4.6.1, )",
-        "resolved": "4.6.1",
-        "contentHash": "LZlLLGZP08mJufT/rjCiURP0owr34ZuAvcyzk5xgsvSMiKJRQvK7oaWUP7IXONE4BwCXREwKhtl34nUS8+RGQg=="
-      },
       "ICSharpCode.Decompiler": {
         "type": "Direct",
         "requested": "[7.2.1.6856, )",

--- a/vs-extension.shared/Converters/MacAddressConverter.cs
+++ b/vs-extension.shared/Converters/MacAddressConverter.cs
@@ -19,7 +19,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension.Converters
             {
                 byte[] macAddress = (byte[])value;
 
-                return String.Join("", macAddress.Select(a => a.ToString("X2")));
+                return String.Join(":", macAddress.Select(a => a.ToString("X2")));
             }
 
             return value;


### PR DESCRIPTION
## Description
- Replace controls with PasswordBox and regular text box.

## Motivation and Context
- Need to fix issue with loading 3rd party libraries in VS2022 following workaround to load icon images. This seems to have broken loading other assemblies, so trying to keep those at the minimum.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [x] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
