### PR TITLE
Allow shared access to .pe files on build

### DIFF
--- a/Tools.BuildTasks-2019/GenerateBinaryOutputTask.cs
+++ b/Tools.BuildTasks-2019/GenerateBinaryOutputTask.cs
@@ -64,7 +64,7 @@ namespace nanoFramework.Tools
                 foreach (string peItem in peCollection)
                 {
                     // append to the deploy blob the assembly
-                    using (FileStream fs = File.Open(peItem, FileMode.Open, FileAccess.Read))
+                    using (FileStream fs = File.Open(peItem, FileMode.Open, FileAccess.Read, FileShare.Read))
                     {
                         long length = (fs.Length + 3) / 4 * 4;
                         byte[] buffer = new byte[length];


### PR DESCRIPTION
## Description
- Added FileSharing.Read to File.Open

## Motivation and Context
I'm dogfooding the MSBuild task that verifies whether the native assemblies required by a nanoFramework project's results are supported by the devices the software is intended to be run on. The MSBuild task analyzes the project's assembly plus referenced assemblies as present in the @(ReferencePath) MSBuild variable. Included in the referenced assemblies are the ones from the NuGet packages, as located in the package's directory that is shared by all projects in a solution. The MSBuild task reads the *.pe versions (via File.Open ("assembly.pe", FileMode.Open, FileAccess.Read, FileShare.Read)) to get the assembly's checksum.

If a solution with a lot of projects is (re-)built, often the MSBuild task accesses the assembly of a NuGet package for one project, while the GenerateBinaryOutputTask tries to open the same assembly for another project. With the current implementation the GenerateBinaryOutputTask then fails:
```
The "GenerateBinaryOutputTask" task failed unexpectedly.
System.IO.IOException: The process cannot access the file 'C:\..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.pe' because it is being used by another process.
   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.FileStream.Init(String path, FileMode mode, FileAccess access, Int32 rights, Boolean useRights, FileShare share, Int32 bufferSize, FileOptions options, SECURITY_ATTRIBUTES secAttrs, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share)
   at nanoFramework.Tools.GenerateBinaryOutputTask.Execute() in D:\a\1\s\Tools.BuildTasks-2019\GenerateBinaryOutputTask.cs:line 64
   at Microsoft.Build.BackEnd.TaskExecutionHost.Execute()
   at Microsoft.Build.BackEnd.TaskBuilder.<ExecuteInstantiatedTask>d__26.MoveNext()
```

By allowing read-sharing with other processes this should be solved.

(I don't understand why the same issue does not occur when GenerateBinaryOutputTasks is executed in parallel for different projects, perhaps because that never happens?)

## How Has This Been Tested?
I don't know how to test this. It compiles :-) I trust it will solve the issue.

## Types of changes
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
