### PR TITLE
Fix debugging VS2022 extension

### DIFF
--- a/VisualStudio.Extension-2022/Properties/AssemblyInfo.cs
+++ b/VisualStudio.Extension-2022/Properties/AssemblyInfo.cs
@@ -15,6 +15,13 @@ using Microsoft.VisualStudio.Shell;
 [assembly: AssemblyCopyright("Copyright © 2019 .NET nanoFramework contributors")]
 [assembly: System.CLSCompliant(false)]
 
+#if DEBUG
+// for debug build need to set these so binding redirects allow loading the correct library
+[assembly: AssemblyVersion("9.99.999.0")]
+[assembly: AssemblyFileVersion("9.99.999.0")]
+[assembly: AssemblyInformationalVersion("9.99.999.0-DEBUG")]
+#endif
+
 [assembly: ProvideCodeBase(
     AssemblyName = @"CommunityToolkit.Mvvm",
     CodeBase = @"$PackageFolder$\CommunityToolkit.Mvvm.dll")]

--- a/VisualStudio.Extension-2022/VisualStudio.Extension-vs2022.csproj
+++ b/VisualStudio.Extension-2022/VisualStudio.Extension-vs2022.csproj
@@ -35,6 +35,8 @@
     <StartProgram Condition="'$(DevEnvDir)' != ''">$(DevEnvDir)devenv.exe</StartProgram>
     <StartArguments>/rootSuffix Exp</StartArguments>
     <NF_Build_VS2022>True</NF_Build_VS2022>
+    <!-- Don't generate version info for local builds -->
+    <GenerateAssemblyVersionInfo Condition="'$(Configuration)' == 'Debug'">false</GenerateAssemblyVersionInfo>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
@@ -143,6 +145,8 @@
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Resource Include="Resources\Reboot.16.16.png" />
+    <!-- Only Include app.config for local debugging -->
+    <None Include="app.config" Condition="'$(Configuration)' == 'Debug'" />
     <None Include="Key.snk" />
     <None Include="packages.lock.json" />
     <None Include="source.extension.vsixmanifest">

--- a/VisualStudio.Extension-2022/app.config
+++ b/VisualStudio.Extension-2022/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="nanoFramework.Tools.VS2022.Extension" publicKeyToken="c07d481e9758c731" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.99.999.0" newVersion="9.99.999.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" /></startup></configuration>


### PR DESCRIPTION
## Description
- Updated `AssemblyInfo.cs` to include versioning for debug builds.
- Added `app.config` for assembly binding redirects to support debugging extension.
- Modified `VisualStudio.Extension-vs2022.csproj` to prevent version info generation for local builds and conditionally include `app.config` for debugging.

## Motivation and Context
- Fix debugging with VS2022 experimental instance. Following the fixes introduced in #854 to load icon images, debugging the extension wasn't possible anymore because VS loaded either the "real" DLL or the debugging version depending on what being called (deployment for example loads the "real" version). This was reported back to the developer community issue, and this is following guidance provided there.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Debugging extension in experimental instance.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
