### PR TITLE
Improve PrepareImageManifest.targets to support assembly public key

### DIFF
--- a/VisualStudio.Extension-2022/PrepareImageManifest.targets
+++ b/VisualStudio.Extension-2022/PrepareImageManifest.targets
@@ -37,9 +37,16 @@
                Text="Cannot find the Value attribute of the Resources element. imagemanifest cannot be updated."
                Condition="'$(ResourcesValue)' == ''" />
         <PropertyGroup>
-            <LastIndex>$([MSBuild]::Subtract($(ResourcesValue.Split(';').Length), 1))</LastIndex>
-            <LastComponent>$(ResourcesValue.Split(';')[$(LastIndex)])</LastComponent>
-            <ValueToSet>$([System.String]::Concat(/$(AssemblyName);v%(ImageManifests.AssemblyVersion);$(LastComponent)))</ValueToSet>
+            <SegmentsCount>$([System.String]::Copy('$(ResourcesValue)').Split(';').Length)</SegmentsCount>
+            <LastComponent Condition="'$(SegmentsCount)' == '4'">$([System.String]::Copy('$(ResourcesValue)').Split(';')[3])</LastComponent>
+            <LastComponent Condition="'$(SegmentsCount)' == '3'">$([System.String]::Copy('$(ResourcesValue)').Split(';')[2])</LastComponent>
+            <PublicKey Condition="'$(SegmentsCount)' == '4'">$([System.String]::Copy('$(ResourcesValue)').Split(';')[2])</PublicKey>
+            <PublicKey Condition="'$(SegmentsCount)' != '4'"></PublicKey>
+            <SemiPublicKey Condition="'$(PublicKey)' != ''">;$(PublicKey)</SemiPublicKey>
+            <SemiPublicKey Condition="'$(PublicKey)' == ''"></SemiPublicKey>
+            <ValueToSet>
+              $([System.String]::Concat(/$(AssemblyName);v%(ImageManifests.AssemblyVersion)$(SemiPublicKey);$(LastComponent)))
+            </ValueToSet>
         </PropertyGroup>
         <XmlPoke Namespaces="$(Namespace)"
                  XmlInputPath="%(ImageManifests.FullPath)"


### PR DESCRIPTION
Improved handling `Resources` Value generation to respect assembly's public key if present.

## Description
The PrepareImageManifet.targets file automatically replaces the version part of the moniker during build, otherwise every time the version of the assembly changes someone would need to manually update the version in the `.imagemanifest' files, otherwise all the monikers will break hence no icon would be rendered from the VS Extension.

The above logic works fine, but if the assembly has a public key (digitally signed), the public key is now silently removed from the value and consequently break the logic. I improved the logic that if the public key is present, it will be respected, so the following two examples would work:
* /AssemblyName;v1.1.1.1;26be58bdab7122ab;Component/Resources
* /AssemblyName;v1.1.1.1;Component/Resources

## Motivation and Context
It's just an improvement and will be necessary if you need to sign your extension (e.g. before publishing to VS Marketplace). 

## How Has This Been Tested?
I have used a similar logic in my extension, and it has been tested there.

## Screenshots
N/A

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [X] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [X] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
