### PR TITLE
Fix resource not updating when adding or renaming resources

### DIFF
--- a/Tools.BuildTasks-2019/GenerateNanoResourceTask.cs
+++ b/Tools.BuildTasks-2019/GenerateNanoResourceTask.cs
@@ -992,37 +992,36 @@ namespace nanoFramework.Tools
                     }
                 }
 
-                // TODO
-                //// if the .resources is up to date with respect to the .resx file
-                ////  then we need to compare timestamps for each linked file inside
-                ////  the .resx file itself
-                //if (!shouldRebuildOutputFile && resxFileInfo.LinkedFiles != null)
-                //{
-                //    foreach (string linkedFilePath in resxFileInfo.LinkedFiles)
-                //    {
-                //        // If the linked file doesn't exist, then we want to rebuild this
-                //        // .resources file so the user sees an error from ResGen.exe
-                //        shouldRebuildOutputFile = !File.Exists(linkedFilePath);
+                // if the .resources is up to date with respect to the .resx file
+                // then we need to compare timestamps for each linked file inside
+                // the .resx file itself
+                if (!shouldRebuildOutputFile && resxFileInfo.LinkedFiles != null)
+                {
+                    foreach (string linkedFilePath in resxFileInfo.LinkedFiles)
+                    {
+                        // If the linked file doesn't exist, then we want to rebuild this
+                        // .resources file so the user sees an error from ResGen.exe
+                        shouldRebuildOutputFile = !File.Exists(linkedFilePath);
 
-                //        // If the linked file exists, then we need to compare the timestamp
-                //        // for the linked resource to see if it is more recent than the
-                //        // .resources file
-                //        if (!shouldRebuildOutputFile)
-                //        {
-                //            DateTime linkedFileTimeStamp = File.GetLastWriteTime(linkedFilePath);
-                //            shouldRebuildOutputFile = linkedFileTimeStamp > outputFileTimeStamp;
-                //        }
+                        // If the linked file exists, then we need to compare the timestamp
+                        // for the linked resource to see if it is more recent than the
+                        // .resources file
+                        if (!shouldRebuildOutputFile)
+                        {
+                            DateTime linkedFileTimeStamp = File.GetLastWriteTime(linkedFilePath);
+                            shouldRebuildOutputFile = linkedFileTimeStamp > outputFileTimeStamp;
+                        }
 
-                //        // If we found an instance where a linked file is in a state
-                //        // that we should rebuild the .resources file, then we should
-                //        // bail from this loop & just return since the first file that
-                //        // forces a rebuild is enough
-                //        if (shouldRebuildOutputFile)
-                //        {
-                //            break;
-                //        }
-                //    }
-                //}
+                        // If we found an instance where a linked file is in a state
+                        // that we should rebuild the .resources file, then we should
+                        // bail from this loop & just return since the first file that
+                        // forces a rebuild is enough
+                        if (shouldRebuildOutputFile)
+                        {
+                            break;
+                        }
+                    }
+                }
             }
 
             return shouldRebuildOutputFile;

--- a/Tools.BuildTasks-2019/GenerateNanoResourceTask.cs
+++ b/Tools.BuildTasks-2019/GenerateNanoResourceTask.cs
@@ -997,8 +997,17 @@ namespace nanoFramework.Tools
                 // the .resx file itself
                 if (!shouldRebuildOutputFile && resxFileInfo.LinkedFiles != null)
                 {
-                    foreach (string linkedFilePath in resxFileInfo.LinkedFiles)
+                    // Linked file paths in the .resx may be relative. Resolve them the same
+                    // way ResXResourceReader does: against BaseLinkedFileDirectory if set,
+                    // otherwise against the directory containing the .resx file.
+                    string linkedFileBaseDir = cache.BaseLinkedFileDirectory ?? Path.GetDirectoryName(sourceFilePath);
+
+                    foreach (string rawLinkedFilePath in resxFileInfo.LinkedFiles)
                     {
+                        string linkedFilePath = Path.IsPathRooted(rawLinkedFilePath)
+                            ? rawLinkedFilePath
+                            : Path.GetFullPath(Path.Combine(linkedFileBaseDir, rawLinkedFilePath));
+
                         // If the linked file doesn't exist, then we want to rebuild this
                         // .resources file so the user sees an error from ResGen.exe
                         shouldRebuildOutputFile = !File.Exists(linkedFilePath);

--- a/Tools.BuildTasks-2019/ProcessResourceFiles.cs
+++ b/Tools.BuildTasks-2019/ProcessResourceFiles.cs
@@ -945,7 +945,7 @@ namespace nanoFramework.Tools
                         // this is a binary resource
                         MemoryStream msOther = (MemoryStream)value;
                         byte[] memoryData = new byte[msOther.Length];
-                        msOther.Read(memoryData, 0, 0);
+                        msOther.Read(memoryData, 0, (int) msOther.Length);
                         entry = new BinaryEntry(name, memoryData);
                         break;
                     default:

--- a/Tools.BuildTasks-2019/ProcessResourceFiles.cs
+++ b/Tools.BuildTasks-2019/ProcessResourceFiles.cs
@@ -1010,9 +1010,7 @@ namespace nanoFramework.Tools
                         // Examples  - .wav
                         // this is a binary resource
                         MemoryStream msOther = (MemoryStream)value;
-                        msOther.Position = 0;
-                        byte[] memoryData = new byte[msOther.Length];
-                        msOther.Read(memoryData, 0, (int)msOther.Length);
+                        byte[] memoryData = msOther.ToArray();
                         entry = new BinaryEntry(name, memoryData);
                         break;
                     default:

--- a/Tools.BuildTasks-2019/ProcessResourceFiles.cs
+++ b/Tools.BuildTasks-2019/ProcessResourceFiles.cs
@@ -955,7 +955,7 @@ namespace nanoFramework.Tools
 
                 if (entry == null)
                 {
-                    throw new Exception();
+                    throw new Exception($"Resource '{name}' has unsupported type '{value.GetType().FullName}'.");
                 }
 
                 if (entry.Namespace.Length == 0)

--- a/Tools.BuildTasks-2019/ProcessResourceFiles.cs
+++ b/Tools.BuildTasks-2019/ProcessResourceFiles.cs
@@ -427,6 +427,54 @@ namespace nanoFramework.Tools
             StronglyTypedResourceSuccessfullyCreated = true;
         }
 
+        /// <summary>
+        /// Generates a strongly typed resource class from in-memory .resx content.
+        /// Used by the VS custom tool so that unsaved designer edits are reflected
+        /// immediately without waiting for the file to be written to disk.
+        /// </summary>
+        public void CreateStronglyTypedResources(string inputFileName, string inputFileContent, CodeDomProvider provider, TextWriter writer, string resourceName)
+        {
+            Init();
+
+            ReadResources(inputFileName, inputFileContent, true);
+
+            string[] errors = null;
+
+            CreateStronglyTypedResources(provider, writer, resourceName, out errors);
+
+            if (errors != null && errors.Length > 0)
+            {
+                throw new ApplicationException(errors[0]);
+            }
+
+            StronglyTypedResourceSuccessfullyCreated = true;
+        }
+
+        /// <summary>
+        /// Reads resources from in-memory .resx content. For ResXFileRef entries the
+        /// linked files are still resolved from disk using the directory of
+        /// <paramref name="filename"/> as the base path.
+        /// </summary>
+        public void ReadResources(String filename, string fileContent, bool shouldUseSourcePath)
+        {
+            Format format = GetFormat(filename);
+            if (format == Format.XML)
+            {
+                ResXResourceReader resXReader = assemblyList != null
+                    ? new ResXResourceReader(new StringReader(fileContent), assemblyList)
+                    : new ResXResourceReader(new StringReader(fileContent));
+                if (shouldUseSourcePath)
+                {
+                    resXReader.BasePath = Path.GetDirectoryName(Path.GetFullPath(filename));
+                }
+                ReadResources(resXReader, filename);
+            }
+            else
+            {
+                ReadResources(filename, shouldUseSourcePath);
+            }
+        }
+
         private CodeNamespace CreateNamespace(CodeCompileUnit ccu, string ns, Hashtable tableNamespaces)
         {
             CodeNamespace codeNamespace = (CodeNamespace)tableNamespaces[ns];

--- a/Tools.BuildTasks-2019/ProcessResourceFiles.cs
+++ b/Tools.BuildTasks-2019/ProcessResourceFiles.cs
@@ -98,7 +98,7 @@ namespace nanoFramework.Tools
         /// <summary>
         /// Whether we successfully created the STR class
         /// </summary>
-        internal bool StronglyTypedResourceSuccessfullyCreated { get; } = false;
+        internal bool StronglyTypedResourceSuccessfullyCreated { get; private set; } = false;
 
         /// <summary>
         /// Indicates whether the resource reader should use the source file's
@@ -423,6 +423,8 @@ namespace nanoFramework.Tools
             {
                 throw new ApplicationException(errors[0]);
             }
+
+            StronglyTypedResourceSuccessfullyCreated = true;
         }
 
         private CodeNamespace CreateNamespace(CodeCompileUnit ccu, string ns, Hashtable tableNamespaces)

--- a/Tools.BuildTasks-2019/ProcessResourceFiles.cs
+++ b/Tools.BuildTasks-2019/ProcessResourceFiles.cs
@@ -837,11 +837,18 @@ namespace nanoFramework.Tools
         /// <param name="linePosition">Column number for messages</param>
         private void AddResource(string name, object value, String inputFileName, int lineNumber, int linePosition)
         {
+            if (resourcesHashTable.ContainsKey(name))
+            {
+                logger?.LogWarning(null, inputFileName, lineNumber, linePosition, 0, 0, "GenerateResource.DuplicateResourceName", name);
+                return;
+            }
+
             Entry entry = Entry.CreateEntry(name, value, StronglyTypedNamespace, GenerateNestedEnums ? StronglyTypedClassName : string.Empty);
 
             Debug.Assert(entry.ClassName.Length > 0);
 
             resources.Add(entry);
+            resourcesHashTable[name] = entry;
         }
 
         private void AddResource(string name, object value, String inputFileName)

--- a/Tools.BuildTasks-2019/ProcessResourceFiles.cs
+++ b/Tools.BuildTasks-2019/ProcessResourceFiles.cs
@@ -944,8 +944,9 @@ namespace nanoFramework.Tools
                         // Examples  - .wav
                         // this is a binary resource
                         MemoryStream msOther = (MemoryStream)value;
+                        msOther.Position = 0;
                         byte[] memoryData = new byte[msOther.Length];
-                        msOther.Read(memoryData, 0, (int) msOther.Length);
+                        msOther.Read(memoryData, 0, (int)msOther.Length);
                         entry = new BinaryEntry(name, memoryData);
                         break;
                     default:

--- a/Tools.BuildTasks-2019/ProcessResourceFiles.cs
+++ b/Tools.BuildTasks-2019/ProcessResourceFiles.cs
@@ -680,13 +680,22 @@ namespace nanoFramework.Tools
                 while (resEnum.MoveNext())
                 {
                     string name = (string)resEnum.Key;
-                    // Replace dot in the name with underscore. 
+                    // Replace dot in the name with underscore.
                     // 1. First reason  - this is what desktop resource generator does.
                     // 2. Second reason - Extra dots causes resource generator to create name space and enumerations.
                     //    This complicates the syntax and finally create invalid code if 2 or more dots are present.
                     //    So we just make longer name.
                     name = name.Replace('.', '_');
-                    object value = resEnum.Value;
+                    object value;
+                    try
+                    {
+                        value = resEnum.Value;
+                    }
+                    catch (Exception ex)
+                    {
+                        logger?.LogWarning(null, fileName, 0, 0, 0, 0, "GenerateResource.CannotLoadResource", (string)resEnum.Key, ex.Message);
+                        continue;
+                    }
                     AddResource(name, value, fileName);
                 }
             }

--- a/vs-extension.shared/ResXFileCodeGenerator/NFResXFileCodeGenerator.cs
+++ b/vs-extension.shared/ResXFileCodeGenerator/NFResXFileCodeGenerator.cs
@@ -82,17 +82,29 @@ namespace nanoFramework.Tools.VisualStudio.Extension
             codeFileNameSpace = wszDefaultNamespace;
             codeGeneratorProgress = pGenerateProgress;
 
-            byte[] bytes = GenerateCode(wszInputFilePath, bstrInputFileContents);
-            if (bytes == null)
+            try
             {
+                byte[] bytes = GenerateCode(wszInputFilePath, bstrInputFileContents);
+                if (bytes == null)
+                {
+                    pbstrOutputFileContents[0] = IntPtr.Zero;
+                    pbstrOutputFileContentSize = 0;
+                }
+                else
+                {
+                    pbstrOutputFileContents[0] = Marshal.AllocCoTaskMem(bytes.Length);
+                    Marshal.Copy(bytes, 0, pbstrOutputFileContents[0], bytes.Length);
+                    pbstrOutputFileContentSize = (uint)bytes.Length;
+                }
+            }
+            catch (Exception ex)
+            {
+                Exception reported = ex is TargetInvocationException tie && tie.InnerException != null
+                    ? tie.InnerException
+                    : ex;
+                GeneratorErrorCallback(0, 4, reported.Message, 0, 0);
                 pbstrOutputFileContents[0] = IntPtr.Zero;
                 pbstrOutputFileContentSize = 0;
-            }
-            else
-            {
-                pbstrOutputFileContents[0] = Marshal.AllocCoTaskMem(bytes.Length);
-                Marshal.Copy(bytes, 0, pbstrOutputFileContents[0], bytes.Length);
-                pbstrOutputFileContentSize = (uint)bytes.Length;
             }
             return COM_HResults.S_OK;
         }

--- a/vs-extension.shared/ResXFileCodeGenerator/NFResXFileCodeGenerator.cs
+++ b/vs-extension.shared/ResXFileCodeGenerator/NFResXFileCodeGenerator.cs
@@ -60,17 +60,19 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
         protected virtual void GeneratorErrorCallback(int warning, uint level, string message, uint line, uint column)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
             IVsGeneratorProgress progress = CodeGeneratorProgress;
             if (progress != null)
             {
-                //Utility.ThrowOnFailure(progress.GeneratorError(warning, level, message, line, column));
-
+                progress.GeneratorError(warning, level, message, line, column);
             }
         }
 
         public int Generate(string wszInputFilePath, string bstrInputFileContents, string wszDefaultNamespace,
                              IntPtr[] pbstrOutputFileContents, out uint pbstrOutputFileContentSize, IVsGeneratorProgress pGenerateProgress)
         {
+            // wait for debugger on var
+            DebuggerHelper.WaitForDebuggerIfEnabled("NFRESXCODEGEN_DEBUG");
 
             if (bstrInputFileContents == null)
             {
@@ -149,6 +151,7 @@ namespace nanoFramework.Tools.VisualStudio.Extension
         {
             get
             {
+                ThreadHelper.ThrowIfNotOnUIThread();
                 if (serviceProvider == null)
                 {
                     IOleServiceProvider oleServiceProvider = site as IOleServiceProvider;
@@ -162,11 +165,13 @@ namespace nanoFramework.Tools.VisualStudio.Extension
 
         protected Object GetService(Guid serviceGuid)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
             return SiteServiceProvider.GetService(serviceGuid);
         }
 
         protected object GetService(Type serviceType)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
             return SiteServiceProvider.GetService(serviceType);
         }
 
@@ -373,228 +378,5 @@ namespace nanoFramework.Tools.VisualStudio.Extension
             return base.StreamToBytes(outputStream);
         }
 
-        internal abstract class BaseCodeGenerator : IVsSingleFileGenerator
-        {
-            private string codeFileNameSpace = string.Empty;
-            private string codeFilePath = string.Empty;
-
-            private IVsGeneratorProgress codeGeneratorProgress;
-
-            // **************************** PROPERTIES ****************************
-            protected string FileNameSpace
-            {
-                get
-                {
-                    return codeFileNameSpace;
-                }
-            }
-
-            protected string InputFilePath
-            {
-                get
-                {
-                    return codeFilePath;
-                }
-            }
-
-            internal IVsGeneratorProgress CodeGeneratorProgress
-            {
-                get
-                {
-                    return codeGeneratorProgress;
-                }
-            }
-
-            // **************************** METHODS **************************
-            public abstract int DefaultExtension(out string ext);
-
-            // MUST implement this abstract method.
-            protected abstract byte[] GenerateCode(string inputFileName, string inputFileContent);
-
-
-            protected virtual void GeneratorErrorCallback(int warning, uint level, string message, uint line, uint column)
-            {
-                ThreadHelper.ThrowIfNotOnUIThread();
-                IVsGeneratorProgress progress = CodeGeneratorProgress;
-                if (progress != null)
-                {
-                    progress.GeneratorError(warning, level, message, line, column);
-                }
-            }
-
-            public int Generate(string wszInputFilePath, string bstrInputFileContents, string wszDefaultNamespace,
-                                 IntPtr[] pbstrOutputFileContents, out uint pbstrOutputFileContentSize, IVsGeneratorProgress pGenerateProgress)
-            {
-                // wait for debugger on var
-                DebuggerHelper.WaitForDebuggerIfEnabled("NFRESXCODEGEN_DEBUG");
-
-                if (bstrInputFileContents == null)
-                {
-                    throw new ArgumentNullException(bstrInputFileContents);
-                }
-                codeFilePath = wszInputFilePath;
-                codeFileNameSpace = wszDefaultNamespace;
-                codeGeneratorProgress = pGenerateProgress;
-
-                byte[] bytes = GenerateCode(wszInputFilePath, bstrInputFileContents);
-                if (bytes == null)
-                {
-                    pbstrOutputFileContents[0] = IntPtr.Zero;
-                    pbstrOutputFileContentSize = 0;
-                }
-                else
-                {
-                    pbstrOutputFileContents[0] = Marshal.AllocCoTaskMem(bytes.Length);
-                    Marshal.Copy(bytes, 0, pbstrOutputFileContents[0], bytes.Length);
-                    pbstrOutputFileContentSize = (uint)bytes.Length;
-                }
-                return COM_HResults.S_OK;
-            }
-
-            protected byte[] StreamToBytes(Stream stream)
-            {
-                if (stream.Length == 0)
-                    return new byte[] { };
-
-                long position = stream.Position;
-                stream.Position = 0;
-                byte[] bytes = new byte[(int)stream.Length];
-                stream.Read(bytes, 0, bytes.Length);
-                stream.Position = position;
-
-                return bytes;
-            }
-        }
-
-        internal abstract class BaseCodeGeneratorWithSite : BaseCodeGenerator, IObjectWithSite
-        {
-            private Object site = null;
-            private CodeDomProvider codeDomProvider = null;
-            private static Guid CodeDomInterfaceGuid = new Guid("{73E59688-C7C4-4a85-AF64-A538754784C5}");
-            private static Guid CodeDomServiceGuid = CodeDomInterfaceGuid;
-            private ServiceProvider serviceProvider = null;
-
-            protected virtual CodeDomProvider CodeProvider
-            {
-                get
-                {
-                    if (codeDomProvider == null)
-                    {
-                        IVSMDCodeDomProvider vsmdCodeDomProvider = (IVSMDCodeDomProvider)GetService(CodeDomServiceGuid);
-                        if (vsmdCodeDomProvider != null)
-                        {
-                            codeDomProvider = (CodeDomProvider)vsmdCodeDomProvider.CodeDomProvider;
-                        }
-                        Debug.Assert(codeDomProvider != null, "Get CodeDomProvider Interface failed.  GetService(QueryService(CodeDomProvider) returned Null.");
-                    }
-                    return codeDomProvider;
-                }
-                set
-                {
-                    if (value == null)
-                    {
-                        throw new ArgumentNullException();
-                    }
-
-                    codeDomProvider = value;
-                }
-            }
-
-            private ServiceProvider SiteServiceProvider
-            {
-                get
-                {
-                    ThreadHelper.ThrowIfNotOnUIThread();
-                    if (serviceProvider == null)
-                    {
-                        IOleServiceProvider oleServiceProvider = site as IOleServiceProvider;
-                        Debug.Assert(oleServiceProvider != null, "Unable to get IOleServiceProvider from site object.");
-
-                        serviceProvider = new ServiceProvider(oleServiceProvider);
-                    }
-                    return serviceProvider;
-                }
-            }
-
-            protected Object GetService(Guid serviceGuid)
-            {
-                ThreadHelper.ThrowIfNotOnUIThread();
-                return SiteServiceProvider.GetService(serviceGuid);
-            }
-
-            protected object GetService(Type serviceType)
-            {
-                ThreadHelper.ThrowIfNotOnUIThread();
-                return SiteServiceProvider.GetService(serviceType);
-            }
-
-
-            public override int DefaultExtension(out string ext)
-            {
-                CodeDomProvider codeDom = CodeProvider;
-                Debug.Assert(codeDom != null, "CodeDomProvider is NULL.");
-                string extension = codeDom.FileExtension;
-                if (extension != null && extension.Length > 0)
-                {
-                    if (extension[0] != '.')
-                    {
-                        extension = "." + extension;
-                    }
-                }
-
-                ext = extension;
-                return COM_HResults.S_OK;
-            }
-
-            protected virtual ICodeGenerator GetCodeWriter()
-            {
-                CodeDomProvider codeDom = CodeProvider;
-                if (codeDom != null)
-                {
-#pragma warning disable 618 //backwards compat
-                    return codeDom.CreateGenerator();
-#pragma warning restore 618
-                }
-
-                return null;
-            }
-
-            // ******************* Implement IObjectWithSite *****************
-            //
-            public virtual void SetSite(object pUnkSite)
-            {
-                site = pUnkSite;
-                codeDomProvider = null;
-                serviceProvider = null;
-            }
-
-            // Does anyone rely on this method?
-            public virtual void GetSite(ref Guid riid, out IntPtr ppvSite)
-            {
-                if (site == null)
-                {
-                    // COM_HResults.Throw(COM_HResults.E_FAIL);
-                }
-
-                IntPtr pUnknownPointer = Marshal.GetIUnknownForObject(site);
-                try
-                {
-                    Marshal.QueryInterface(pUnknownPointer, ref riid, out ppvSite);
-
-                    if (ppvSite == IntPtr.Zero)
-                    {
-                        //COM_HResults.Throw(COM_HResults.E_NOINTERFACE);
-                    }
-                }
-                finally
-                {
-                    if (pUnknownPointer != IntPtr.Zero)
-                    {
-                        Marshal.Release(pUnknownPointer);
-                        pUnknownPointer = IntPtr.Zero;
-                    }
-                }
-            }
-        }
     }
 }

--- a/vs-extension.shared/ResXFileCodeGenerator/NFResXFileCodeGenerator.cs
+++ b/vs-extension.shared/ResXFileCodeGenerator/NFResXFileCodeGenerator.cs
@@ -379,7 +379,8 @@ namespace nanoFramework.Tools.VisualStudio.Extension
                     resourceName = string.Format("{0}.{1}", resourceName, inputFileNameWithoutExtension);
                 }
 
-                typ.GetMethod("CreateStronglyTypedResources").Invoke(processResourceFiles, new object[] { inputFileName, CodeProvider, streamWriter, resourceName });
+                typ.GetMethod("CreateStronglyTypedResources", new Type[] { typeof(string), typeof(string), typeof(CodeDomProvider), typeof(TextWriter), typeof(string) })
+                    .Invoke(processResourceFiles, new object[] { inputFileName, inputFileContent, CodeProvider, streamWriter, resourceName });
             }
             else
             {


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
### Problem

Adding or renaming a resource in the Visual Studio resource designer did not reliably update the generated `Resources.Designer.cs` file. The only reliable workaround was to right-click the `.resx` file and choose **Run Custom Tool** after an explicit save. This caused the generated code to silently fall out of sync with the designer — resource IDs in the code would reflect old names, and newly added resources would not appear at all.

### Root Cause

The nanoFramework custom tool (`nFResXFileCodeGenerator`) was ignoring the `bstrInputFileContents` parameter that VS passes to every custom tool invocation. This parameter carries the editor's **current in-memory state**, which VS provides precisely because the file buffer may not have been flushed to disk yet.

Instead, the generator was re-reading the `.resx` from disk. When VS triggered the custom tool during a live designer edit — before writing the changes to disk — the generator read stale content and produced a stale Designer.cs.

### Fix

Added a `CreateStronglyTypedResources` overload in `ProcessResourceFiles` that accepts the `.resx` XML as a string and feeds it to `ResXResourceReader` via a `StringReader`. `BasePath` is set from the file path so that `ResXFileRef` linked files (images, fonts, HTML, etc.) still resolve correctly from disk. The custom tool generator now passes `inputFileContent` to this overload instead of the file path.

### Additional Fixes

Several related correctness issues found during investigation:

- **Silent failures** — exceptions during code generation were unhandled, leaving the Designer.cs frozen at its last good state with no error shown. Errors are now reported to VS via `GeneratorErrorCallback`.
- **One bad resource blocks all others** — a single `ResXFileRef` entry with a missing file caused `ResXResourceReader` to throw mid-enumeration, aborting processing of all resources. Bad entries are now skipped with a warning so the rest generate correctly.
- **MemoryStream binary resources** — stream position was not reset before reading, causing `.wav` and similar resources to be written as all-zeroes even after a prior fix to the read count.
- **Dead duplicate detection** — `resourcesHashTable` was never populated, making the duplicate-name check inert. Duplicates are now detected and warned on add.
- **Linked file timestamps** — changes to externally linked files (images, etc.) referenced from a `.resx` were not checked during incremental build, causing the `.nanoresources` binary to go stale.


## Motivation and Context
Reduce frustration related to using Resource files
- Fixes nanoframework/Home#1217.
- Fixes nanoframework/Home#1604.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
On device

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
