### PR TITLE
Add ARM64 support for VS2022/VS2026 VSIX

### DIFF
--- a/Tools.BuildTasks-2022/Tools.BuildTasks-2022.csproj
+++ b/Tools.BuildTasks-2022/Tools.BuildTasks-2022.csproj
@@ -43,7 +43,7 @@
     <OutputPath>bin\x64\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
@@ -52,7 +52,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>

--- a/VisualStudio.Extension-2022/VisualStudio.Extension-vs2022.csproj
+++ b/VisualStudio.Extension-2022/VisualStudio.Extension-vs2022.csproj
@@ -44,7 +44,7 @@
     <DefineConstants>TRACE;DEBUG;DEV17;</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugType>full</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <DeployExtension>True</DeployExtension>
   </PropertyGroup>
@@ -54,7 +54,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <DeployExtension>False</DeployExtension>
   </PropertyGroup>
@@ -70,7 +70,7 @@
     <CodeAnalysisRuleSet>
     </CodeAnalysisRuleSet>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -82,7 +82,7 @@
     <CodeAnalysisRuleSet>
     </CodeAnalysisRuleSet>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <PlatformTarget>x86</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <DeployExtension>False</DeployExtension>
     <DeployExtension>False</DeployExtension>
   </PropertyGroup>

--- a/VisualStudio.Extension-2022/source.extension.vsixmanifest
+++ b/VisualStudio.Extension-2022/source.extension.vsixmanifest
@@ -16,6 +16,9 @@
         <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.14,19.0)">
             <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.14,19.0)">
+            <ProductArchitecture>arm64</ProductArchitecture>
+        </InstallationTarget>
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.7.2,)" />


### PR DESCRIPTION
<!--- In the TITLE (above, not here) provide a general, short summary of your changes. -->
<!--- Suggested title: Add ARM64 support for VS2022/VS2026 VSIX -->
<!--- Please DO NOT use references to other PRs or issues in the title. -->

## Description

- Added an `arm64` installation target to the VS2022/VS2026 VSIX manifest while preserving the existing `amd64` target.
- Changed the VSIX package assembly `PlatformTarget` values to `AnyCPU`.
- Changed the managed build task `PlatformTarget` values to `AnyCPU`.
- Kept the existing `VisualStudio.Extension-2022` project structure because it already targets the VS2022/VS2026 compatibility range.

## Motivation and Context

The current VS2022/VS2026 extension package declares only an `amd64` installation target in the VSIX manifest. Because of that, native ARM64 Visual Studio rejects the extension during installation.

This change enables the same managed VSIX payload to install and load in native ARM64 Visual Studio while preserving existing AMD64 support.

No separate `VisualStudio.Extension-2026` project was added because this is an architecture enablement change, not a VS2026-specific fork.

## How Has This Been Tested?

Tested locally on Windows ARM64 with native Visual Studio 2026.

Build command used:

```powershell
MSBuild.exe VisualStudio.Extension-2022\VisualStudio.Extension-vs2022.csproj /restore /m /p:Configuration=Release /p:Platform=x64 /p:PublicRelease=true /v:minimal
```

Generated VSIX:

```text
VisualStudio.Extension-2022\bin\x64\Release\nanoFramework.Tools.VS2022.Extension.vsix
```

Verified the generated managed assemblies with `CorFlags`:

```text
PE32
ILONLY=1
32BITREQ=0
32BITPREF=0
```

Smoke-tested the locally built VSIX on native ARM64 Visual Studio 2026:

- The VSIX installs successfully.
- The .NET nanoFramework extension loads successfully.
- A new nanoFramework project can be created.
- The generated project builds successfully to `.pe`.

Existing NuGet vulnerability/downgrade warnings were not addressed in this PR to keep the ARM64 support change minimal and reviewable.

## Screenshots

Current Marketplace package cannot be installed into native ARM64 Visual Studio 2026 because the VSIX declares only amd64 support.
<img width="436" height="291" alt="Screenshot 2026-05-02 204142" src="https://github.com/user-attachments/assets/c8feeedf-0739-46ad-b90a-5998de3371fe" />

Locally built VSIX with amd64 + arm64 installation targets installs successfully into native ARM64 Visual Studio 2026.
<img width="436" height="332" alt="Screenshot 2026-05-02 204445" src="https://github.com/user-attachments/assets/48991130-9a78-44d4-af2c-78dc481b6689" />

Extension loaded in native ARM64 Visual Studio 2026.
<img width="1223" height="771" alt="Screenshot 2026-05-02 204912" src="https://github.com/user-attachments/assets/8fa89221-e5ba-4c8e-9ebb-061e5f6cb0b9" />

Smoke test on ARM64 VS2026: nanoFramework project template works and project builds successfully to .pe.
<img width="812" height="489" alt="Screenshot 2026-05-02 204628" src="https://github.com/user-attachments/assets/2585fa5e-9d4b-4f7b-a3d4-1a09b594f203" />

## Types of changes

- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:

- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
