### PR TITLE
Remove ExcludeClassByName parameter from MDP targets

### DIFF
--- a/VisualStudio.Extension-2019/Targets/NFProjectSystem.MDP.targets
+++ b/VisualStudio.Extension-2019/Targets/NFProjectSystem.MDP.targets
@@ -235,7 +235,6 @@
         DumpMetadata="$(NFMDP_DUMP_METADATA)"
         DumpExports="$(NFMDP_STUB_DumpExports)"
         GenerateDependency="$(NFMDP_STUB_GenerateDependency)"
-        ExcludeClassByName="@(NFMDP_PE_ExcludeClassByName)"
         LoadHints="@(ReferencePath);@(ReferenceDependencyPaths);@(ReferenceSatellitePaths)"
         Compile="$(NanoFramework_IntermediateAssembly).pe"
         GenerateStubs="$(NFMDP_GENERATE_STUBS)"
@@ -452,7 +451,6 @@
         CreateDatabaseFile="$(NFMDP_PE_CreateDatabaseFile)"
         LoadHints="@(ReferencePath);@(ReferenceDependencyPaths);@(ReferenceSatellitePaths)"
         IgnoreAssembly="@(NFMDP_PE_IgnoreAssembly)"
-        ExcludeClassByName="@(NFMDP_PE_ExcludeClassByName)"
         Condition="'$(NFMDP_GENERATE_STUBS)' == 'false'">
       <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
       <Output TaskParameter="NativeChecksum" PropertyName="NativeChecksum" />
@@ -489,7 +487,6 @@
         CreateDatabaseFile="$(NFMDP_STUB_CreateDatabaseFile)"
         LoadHints="@(ReferencePath);@(ReferenceDependencyPaths);@(ReferenceSatellitePaths)"
         IgnoreAssembly="@(NFMDP_STUB_IgnoreAssembly)"
-        ExcludeClassByName="@(NFMDP_PE_ExcludeClassByName)"
         Condition="'$(NFMDP_GENERATE_STUBS)' == 'true'">
       <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
       <Output TaskParameter="NativeChecksum" PropertyName="NativeChecksum" />
@@ -567,7 +564,6 @@
         IgnoreAssembly="@(NFMDP_DAT_IgnoreAssembly)"
         Load="@(NFMDP_DAT_Load)"
         LoadDatabase="@(NFMDP_DAT_LoadDatabase)"
-        ExcludeClassByName="@(NFMDP_DAT_ExcludeClassByName)">
       <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
       <Output TaskParameter="NativeChecksum" PropertyName="NativeChecksum" />
     </MetaDataProcessorTask>

--- a/VisualStudio.Extension-2022/Targets/NFProjectSystem.MDP.targets
+++ b/VisualStudio.Extension-2022/Targets/NFProjectSystem.MDP.targets
@@ -235,7 +235,6 @@
         DumpMetadata="$(NFMDP_DUMP_METADATA)"
         DumpExports="$(NFMDP_STUB_DumpExports)"
         GenerateDependency="$(NFMDP_STUB_GenerateDependency)"
-        ExcludeClassByName="@(NFMDP_PE_ExcludeClassByName)"
         LoadHints="@(ReferencePath);@(ReferenceDependencyPaths);@(ReferenceSatellitePaths)"
         Compile="$(NanoFramework_IntermediateAssembly).pe"
         GenerateStubs="$(NFMDP_GENERATE_STUBS)"
@@ -453,7 +452,6 @@
         CreateDatabaseFile="$(NFMDP_PE_CreateDatabaseFile)"
         LoadHints="@(NFMDP_PE_LoadHints)"
         IgnoreAssembly="@(NFMDP_PE_IgnoreAssembly)"
-        ExcludeClassByName="@(NFMDP_PE_ExcludeClassByName)"
         Condition="'$(NFMDP_GENERATE_STUBS)' == 'false'">
       <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
       <Output TaskParameter="NativeChecksum" PropertyName="NativeChecksum" />
@@ -490,7 +488,6 @@
         CreateDatabaseFile="$(NFMDP_STUB_CreateDatabaseFile)"
         LoadHints="@(ReferencePath);@(ReferenceDependencyPaths);@(ReferenceSatellitePaths)"
         IgnoreAssembly="@(NFMDP_STUB_IgnoreAssembly)"
-        ExcludeClassByName="@(NFMDP_PE_ExcludeClassByName)"
         Condition="'$(NFMDP_GENERATE_STUBS)' == 'true'">
       <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
       <Output TaskParameter="NativeChecksum" PropertyName="NativeChecksum" />
@@ -567,8 +564,7 @@
         LoadHints="@(ReferencePath);@(ReferenceDependencyPaths);@(ReferenceSatellitePaths)"
         IgnoreAssembly="@(NFMDP_DAT_IgnoreAssembly)"
         Load="@(NFMDP_DAT_Load)"
-        LoadDatabase="@(NFMDP_DAT_LoadDatabase)"
-        ExcludeClassByName="@(NFMDP_DAT_ExcludeClassByName)">
+        LoadDatabase="@(NFMDP_DAT_LoadDatabase)">
       <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
       <Output TaskParameter="NativeChecksum" PropertyName="NativeChecksum" />
     </MetaDataProcessorTask>


### PR DESCRIPTION

## Description
- Remove ExcludeClassByName parameter from MDP targets.

## Motivation and Context
- This parameter has been marked as obsolete for quite some time. Now feels like a good time to make this breaking change.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
